### PR TITLE
Build both PDF and web in texlive-action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,34 +65,20 @@ jobs:
           python-version: '3.9'
           cache: 'pip' # caching pip dependencies
 
-      - name: Install blueprint apt deps with cache
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          # texlive-binaries is for kpsewhich, which is a dependency of plastex/blueprint
-          packages: graphviz libgraphviz-dev pdf2svg dvisvgm texlive-binaries
-          version: 1.0
-
-      - name: Install blueprint dependencies
-        run: |
-          pip install -r blueprint/requirements.txt
-
-      - name: Build blueprint PDF
+      - name: Build blueprint
         uses: xu-cheng/texlive-action@v2
         with:
           scheme: full
           run: |
             apk update
-            apk add --update make py3-pip git
+            apk add --update make py3-pip git pkgconfig graphviz graphviz-dev gcc musl-dev
             git config --global --add safe.directory $GITHUB_WORKSPACE
             git config --global --add safe.directory `pwd`
             python3 -m pip install --upgrade pip requests wheel
+            python3 -m pip install pygraphviz --global-option=build_ext --global-option="-L/usr/lib/graphviz/" --global-option="-R/usr/lib/graphviz/"
+            pip install -r blueprint/requirements.txt
             python3 -m pip install invoke
-            inv bp
-
-      - name: Build blueprint website and copy blueprint to `docs/blueprint`
-        run: |
-          inv web
-          inv copy
+            inv all
 
       - name: Copy Lean documentation to `docs/docs`
         run: |

--- a/blueprint/requirements.txt
+++ b/blueprint/requirements.txt
@@ -1,4 +1,5 @@
-invoke==1.7.1
+# https://github.com/pyinvoke/invoke/issues/891
+invoke==2.2.0
 plasTeX @ git+https://github.com/plastex/plastex.git
 leanblueprint @ git+https://github.com/utensil/leanblueprint.git@lean4-only-dev
 watchfiles==0.16.1

--- a/tasks.py
+++ b/tasks.py
@@ -9,15 +9,11 @@ from blueprint.tasks import web, bp, print_bp, serve
 ROOT = Path(__file__).parent
 BP_DIR = ROOT/'blueprint'
 
-@task
-def copy(ctx):
+@task(bp, web)
+def all(ctx):
     shutil.rmtree(ROOT/'docs'/'blueprint', ignore_errors=True)
     shutil.copytree(ROOT/'blueprint'/'web', ROOT/'docs'/'blueprint')
     shutil.copy2(ROOT/'blueprint'/'print'/'print.pdf', ROOT/'docs'/'blueprint.pdf')
-
-@task(bp, web, copy)
-def all(ctx):
-    pass
 
 @task(web)
 def html(ctx):


### PR DESCRIPTION
This PR fixes the inconsistency issue in #5 which was trying to accelerate LaTeX building but it only moved the PDF building into texlive-action (which is the key to the acceleration) but blueprint website is left out as I wasn't sure it will work well inside texlive-action .

Soon I realized that plastex (leanblueprint relies on it to generate the web version) will need a full texlive installation for more adavanced features, e.g. the support for adding commutative diagram to both the PDF and the web page requires rendering tikz-cd to PDF then SVG images for the web page , the inconsistency breaks functionalities like this.

After fixing an issue related to Python 3.11 compatibility, both PDF and web can be built in texlive-action, hence the PR. This will also be ~1 minute faster due to less duplicated installation.