### PR TITLE
Fix PDF bookmark string in section title

### DIFF
--- a/blueprint/src/chapter/reductions.tex
+++ b/blueprint/src/chapter/reductions.tex
@@ -3,7 +3,7 @@
 \section{Overview}
 The proof of Fermat's Last Theorem is by contradiction. We assume that we have a counterexample $a^n+b^n=c^n$, and manipulate it until it satsfies the axioms of a ``Frey package''. From the Frey package we build a Frey curve -- an elliptic curve defined over the rationals. We then look at a certain representation of a Galois group coming from this elliptic curve, and finally using two very deep and independent theorems (one due to Mazur, the other due to Wiles) we show that this representation cannot be irreducible or reducible, a contradiction.
 
-\section{Reduction to $n\geq5$ and prime}
+\section{Reduction to \texorpdfstring{$n\geq5$}{ngeq5} and prime}
 
 \begin{lemma}\label{WLOG_n_prime}\lean{FermatLastTheorem.of_odd_primes}\leanok
   If there is a counterexample to Fermat's Last Theorem, then there is a counterexample $a^p+b^p=c^p$


### PR DESCRIPTION
This should make CI green again and test the new look of dep graph. 