### PR TITLE
Add comment about FLT3 and fix other typos

### DIFF
--- a/FLT/Basic/Reductions.lean
+++ b/FLT/Basic/Reductions.lean
@@ -51,9 +51,9 @@ theorem PNat.pow_add_pow_ne_pow_of_FermatLastTheorem :
 
 /-- Fermat's Last Theorem is true when n = 3. -/
 lemma fermatLastTheoremThree : FermatLastTheoremFor 3 := sorry
--- This is proved in the FLT-regular project: see
--- https://github.com/leanprover-community/flt-regular/blob/861b7df057140b45b8bb7d30d33426ffbbdda52b/FltRegular/FltThree/FltThree.lean#L698
--- The way to turn this node green is to port that work to mathlib so we can use it here.
+-- This is proved in the FLT-regular project (https://github.com/leanprover-community/flt-regular/blob/861b7df057140b45b8bb7d30d33426ffbbdda52b/FltRegular/FltThree/FltThree.lean#L698)
+-- and the FLT3 project (https://github.com/riccardobrasca/flt3).
+-- The way to turn this node green is to port this latter one to mathlib so we can use it here.
 
 namespace FLT
 

--- a/blueprint/src/chapter/ch02reductions.tex
+++ b/blueprint/src/chapter/ch02reductions.tex
@@ -29,7 +29,8 @@ Euler proved Fermat's Last Theorem for $p=3$; at the time of writing this is not
 \end{lemma}
 \begin{proof}
   A proof has been formalised in Lean in the FLT-regular project \href{https://github.com/leanprover-community/flt-regular/blob/861b7df057140b45b8bb7d30d33426ffbbdda52b/FltRegular/FltThree/FltThree.lean#L698}{\underline{here}}. 
-  Another proof has been formalised in the FLT3 project \href{https://github.com/riccardobrasca/flt3}{\underline{here}} (its dependency graph can be visualised \href{https://pitmonticone.github.io/FLT3/blueprint/dep_graph_document.html}{\underline{here}}) by a team from the Lean For the Curious Mathematician conference held in Luminy in March 2024. 
+  Another proof has been formalised in the FLT3 project \href{https://github.com/riccardobrasca/flt3}{\underline{here}} by a team from the Lean For the Curious Mathematician conference held in Luminy in March 2024 
+  (its dependency graph can be visualised \href{https://pitmonticone.github.io/FLT3/blueprint/dep_graph_document.html}{\underline{here}}). 
   To get this node green, this latter proof needs to be upstreamed to mathlib. This is currently work in progress by the same team.
 \end{proof}
 

--- a/blueprint/src/chapter/ch02reductions.tex
+++ b/blueprint/src/chapter/ch02reductions.tex
@@ -29,7 +29,7 @@ Euler proved Fermat's Last Theorem for $p=3$; at the time of writing this is not
 \end{lemma}
 \begin{proof}
   A proof has been formalised in Lean in the FLT-regular project \href{https://github.com/leanprover-community/flt-regular/blob/861b7df057140b45b8bb7d30d33426ffbbdda52b/FltRegular/FltThree/FltThree.lean#L698}{\underline{here}}. 
-  Another proof has been formalised in the FLT3 project \href{https://github.com/riccardobrasca/flt3}{\underline{here}} by a team from the Lean For the Curious Mathematician conference held in Luminy in March 2024 
+  Another proof has been formalised in Lean in the FLT3 project \href{https://github.com/riccardobrasca/flt3}{\underline{here}} by a team from the Lean For the Curious Mathematician conference held in Luminy in March 2024 
   (its dependency graph can be visualised \href{https://pitmonticone.github.io/FLT3/blueprint/dep_graph_document.html}{\underline{here}}). 
   To get this node green, this latter proof needs to be upstreamed to mathlib. This is currently work in progress by the same team.
 \end{proof}

--- a/blueprint/src/chapter/ch02reductions.tex
+++ b/blueprint/src/chapter/ch02reductions.tex
@@ -1,4 +1,4 @@
-\chapter{First reductions of the problem.}
+\chapter{First reductions of the problem}
 
 \section{Overview}
 The proof of Fermat's Last Theorem is by contradiction. We assume that we have a counterexample $a^n+b^n=c^n$, and manipulate it until it satisfies the axioms of a ``Frey package''. From the Frey package we build a Frey curve -- an elliptic curve defined over the rationals. We then look at a certain representation of a Galois group coming from this elliptic curve, and finally using two very deep and independent theorems (one due to Mazur, the other due to Wiles) we show that this representation is neither reducible or irreducible, a contradiction.

--- a/blueprint/src/chapter/ch02reductions.tex
+++ b/blueprint/src/chapter/ch02reductions.tex
@@ -28,7 +28,9 @@ Euler proved Fermat's Last Theorem for $p=3$; at the time of writing this is not
   There are no solutions in positive integers to $a^3+b^3=c^3$.
 \end{lemma}
 \begin{proof}
-  The proof has been formalised in Lean in the FLT-regular project \href{https://github.com/leanprover-community/flt-regular/blob/861b7df057140b45b8bb7d30d33426ffbbdda52b/FltRegular/FltThree/FltThree.lean#L698}{\underline{here}}. To get this node green, the proof (or another proof) needs to be upstreamed to mathlib. This is currently work in progress by a team from the Lean For the Curious Mathematician conference held in Luminy in March 2024.
+  A proof has been formalised in Lean in the FLT-regular project \href{https://github.com/leanprover-community/flt-regular/blob/861b7df057140b45b8bb7d30d33426ffbbdda52b/FltRegular/FltThree/FltThree.lean#L698}{\underline{here}}. 
+  Another proof has been formalised in the FLT3 project \href{https://github.com/riccardobrasca/flt3}{\underline{here}} (its dependency graph can be visualised \href{https://pitmonticone.github.io/FLT3/blueprint/dep_graph_document.html}{\underline{here}}) by a team from the Lean For the Curious Mathematician conference held in Luminy in March 2024. 
+  To get this node green, this latter proof needs to be upstreamed to mathlib. This is currently work in progress by the same team.
 \end{proof}
 
 \begin{corollary}\label{FLT.p_ge_5_counterexample_of_not_FermatLastTheorem}\lean{FLT.p_ge_5_counterexample_of_not_FermatLastTheorem}\leanok If there is a counterexample to Fermat's Last Theorem, then there is a counterexample $a^p+b^p=c^p$ with $p$ prime and $p\geq 5$.

--- a/blueprint/src/chapter/chtopbestiary.tex
+++ b/blueprint/src/chapter/chtopbestiary.tex
@@ -158,7 +158,7 @@ We can now give the definition of an automorphic form. For FLT we only need the 
         \item $\phi$ is locally constant on $G(\A_N^f)$ and $C^\infty$ on $G(N_\infty)$. In other words, for every $g_\infty$, $\phi(-,g_\infty)$ is locally constant, and for every $g_f$, $\phi(g_f,-)$ is smooth.
         \item $\phi$ is left-invariant under $G(N)$;
         \item $\phi$ is right-$U_\infty$-finite (that is, the space spanned by $x\mapsto \phi(xu)$ as $u$ varies over $U_\infty$ is finite-dimensional);
-        \item $\phi$ is right $K_f$-finite, where $K_f$ is one (or equivalentally all) compact open subgroups of $G(\A_N^f)$;
+        \item $\phi$ is right $K_f$-finite, where $K_f$ is one (or equivalently all) compact open subgroups of $G(\A_N^f)$;
         \item $\phi$ is $\mathcal{z}$-finite, where $\mathcal{z}$ is the centre of the universal enveloping algebra of the Lie algebra of $G(N_\infty)$, acting via differential operators. Equivalently $\phi$ is annihiliated by a finite index ideal of this centre, so morally $\phi$ satisfies lots of differential equations of a certain type;
         \item For all $g_f$, the function $g_\infty\mapsto \phi(g_f g\infty)$ is slowly-increasing in the sense above.
     \end{itemize}
@@ -217,7 +217,7 @@ The big theorem, which again we are far from even \emph{stating} right now, is
 \section{Algebraic geometry}
 
 We have already mentioned Mazur's Theorem on torsion subgroups of elliptic curves (theorem~\cite{mazur}).
-The proof of this is 100 pages of a subtle analysis of the bad reduction of modular curves and the consquences of this on their Jacobians.
+The proof of this is 100 pages of a subtle analysis of the bad reduction of modular curves and the consequences of this on their Jacobians.
 
 Talking of modular curves, we also need the existence of Shimura curves and surfaces over totally real fields~$F$ (of degree greater than~2, so always compact). The curves are "modeles \'etranges" in the sense of Deligne, so we also need moduli spaces of unitary Shimura varieties over CM extensions. We need to decompose the first and second etale cohomology groups of these varieties into Galois representations, by understanding them
 in terms of automorphic representations.


### PR DESCRIPTION
- [x] Add comment about FLT3 in `Reductions.lean` with link to repository. 
- [x] Add comment about FLT3 in `ch02reductions.tex` with link to repository and dependency graph.
- [x] Fix other typos 