### PR TITLE
Fix typos in the blueprint

### DIFF
--- a/blueprint/src/chapter/ch02reductions.tex
+++ b/blueprint/src/chapter/ch02reductions.tex
@@ -85,7 +85,7 @@ This construction is functorial (it sends the identity to the identity, and comp
 \begin{proof} Another easy calculation.
 \end{proof}
 
- Thus if $f K\to L$ is an isomorphism of fields, the induced map $E(K)\to E(L)$ is an isomorphism of groups, with the inverse isomorphism being the map $E(L)\to E(K)$ induced by $f^{-1}$. This construction thus gives us an action of the multiplicative group $\Aut_k(K)$ of automorphisms of the field $K$ on the additive abelian group $E(K)$. 
+ Thus if $f:K\to L$ is an isomorphism of fields, the induced map $E(K)\to E(L)$ is an isomorphism of groups, with the inverse isomorphism being the map $E(L)\to E(K)$ induced by $f^{-1}$. This construction thus gives us an action of the multiplicative group $\Aut_k(K)$ of automorphisms of the field $K$ on the additive abelian group $E(K)$. 
  
 \begin{definition}\label{EllipticCurve.galoisRepresentation}\lean{EllipticCurve.galoisRepresentation}\uses{EllipticCurve.Points.map_id,EllipticCurve.Points.map_comp}
   If $E$ is an elliptic curve over a field $k$ and $K$ is a field and a $k$-algebra,
@@ -97,7 +97,7 @@ We need a variant of this construction where we only consider the $n$-torsion of
 
 \begin{definition}\label{EllipticCurve.torsionGaloisRepresentation}\lean{EllipticCurve.torsionGaloisRepresentation}\uses{EllipticCurve.galoisRepresentation}
   If $E$ is an elliptic curve over a field $k$ and $K$ is a field and a $k$-algebra,
-  and if $n$ is a natural number, hen the group of $k$-automorphisms of $K$ acts on the additive abelian group $E(K)[n]$ of $n$-torsion points on the curve.
+  and if $n$ is a natural number, then the group of $k$-automorphisms of $K$ acts on the additive abelian group $E(K)[n]$ of $n$-torsion points on the curve.
 \end{definition}
 
 If furthermore $n=p$ is prime, then $A[p]$ is naturally a vector space over the field $\Z/p\Z$, and thus it inherits the structure of a mod $p$ representation of $G$. Applying this to the above situation, we deduce that if $E$ is an elliptic curve over $\Q$ then $\GQ$ acts on $E(\Qbar)[p]$ and this is the \emph{mod $p$ Galois representation} attached to the curve $E$.

--- a/blueprint/src/chapter/ch03frey.tex
+++ b/blueprint/src/chapter/ch03frey.tex
@@ -2,7 +2,7 @@
 
 \section{Overview}
 
-In the last chapter we explained how, given a counterexample to Fermat's Last Theorem we could construct a Frey package and thus a Frey curve, which is an elliptic curve with some interesting properties. In this chapter we start with an overview of parts of the theory of the arithmetic of elliptic curves. Following
+In the last chapter we explained how, given a counterexample to Fermat's Last Theorem, we could construct a Frey package and thus a Frey curve, which is an elliptic curve with some interesting properties. In this chapter we start with an overview of parts of the theory of the arithmetic of elliptic curves. Following
 this we sketch proofs of the two main results of this chapter: firstly that the $p$-torsion $\rho$ in the Frey curve is ``hardly ramified'', and secondly that Mazur's result on the possible torsion of elliptic curves implies that $\rho$ must be irreducible. Everything here follows from standard results about elliptic curves, however almost none of these results are in {\tt mathlib} as I am writing this, so there is plenty to be done here.
 
 \section{The arithmetic of elliptic curves}

--- a/blueprint/src/chapter/ch04overview.tex
+++ b/blueprint/src/chapter/ch04overview.tex
@@ -92,7 +92,7 @@ the modularity of the $\ell$-torsion.
 \section{Compatible families, and reduction at 3}
 
 We now use Khare--Wintenberger to lift $\rho$ to a potentially modular $\ell$-adic
-Galois representation of conductor 2, and put it into an $\ell$-adic famiily using
+Galois representation of conductor 2, and put it into an $\ell$-adic family using
 the Brauer's theorem trick in \cite{blggt}. Finally we look at the 3-adic specialisation
 of this family. Reducing mod 3 we get a representation which is flat at 3 and tame at 2,
 so must be reducible because

--- a/blueprint/src/chapter/chtopbestiary.tex
+++ b/blueprint/src/chapter/chtopbestiary.tex
@@ -47,7 +47,7 @@ Continuous group cohomology $H^i(G_K,M)$ in this setting can be defined using co
 \begin{proof}\notready This is Theorem 2 in section 5.2 in \cite{serre-galcoh}. Note again the dubious (as far as Lean is concerned) use of the equality symbol.
 \end{proof}
 
-\begin{theorem} ["Euler-Poincar\'e characteristic]\label{local_galois_coh_euler_poincare}\notready If $h^i(M)$ denotes the order of $H^i(G_K,M)$ then $h^0(M)-h^1(M)+h^2(M)=0$.
+\begin{theorem} ["Euler-Poincar\'e characteristic"]\label{local_galois_coh_euler_poincare}\notready If $h^i(M)$ denotes the order of $H^i(G_K,M)$ then $h^0(M)-h^1(M)+h^2(M)=0$.
 \end{theorem}
 
     If $\mu_\infty$ denotes the Galois module of all roots of unity in our fixed $\overline{K}$, then one can define the dual Galois module $M'$ as $\Hom(M,\mu)$ with its obvious Galois action.
@@ -140,13 +140,13 @@ For some reason, in the literature people seem to fix a choice of maximal compac
 Example: if $G=\GL_2$ and $N=\Q$ then $N_\infty=\R$ and $G(N_\infty)$ is just $\GL_2(\R)$ with its usual Lie group structure and we can take $U_\infty$ to be $O_2(\R)$; $G(\A_N^f)$ is the restricted product of $\GL_2(\Q_p)$ over $\GL_2(\Z_p)$, for all primes $p$.
 
 By assumption, $G(N_\infty)$ admits a finite-dimensional (algebraic) representation $\rho$ with finite kernel. Consider $\rho$ as taking values in $GL_N(\C)=\Aut_\C(V)$. Fix a hermitian sesquilinear form on $V$ which 
-is $U_\infty$ invariant, and now define a norm $||g||_\rho$ on $G(N_\infty)$ by $$||g||_\rho=(\tr \rho(g)^*\rho(g))^{1/2}$$, where the asterisk denote adjoint with respect to the sesquilinear form. According to the article by Borel--Jacquet in \cite{corvallis1} (p189), if $\rho'$ is another such choice then there exists a positive real $C$ and a positive integer $n$ such that $||g||_{\rho'}\leq C||g||_\rho^n$ for all $g\in G(N_\infty)$.
+is $U_\infty$ invariant, and now define a norm $||g||_\rho$ on $G(N_\infty)$ by $$||g||_\rho=(\tr \rho(g)^*\rho(g))^{1/2},$$ where the asterisk denote adjoint with respect to the sesquilinear form. According to the article by Borel--Jacquet in \cite{corvallis1} (p189), if $\rho'$ is another such choice then there exists a positive real $C$ and a positive integer $n$ such that $||g||_{\rho'}\leq C||g||_\rho^n$ for all $g\in G(N_\infty)$.
 
 \begin{definition}\label{slowly_increasing}\notready A function $f : G(N_\infty)\to\C$ is \emph{slowly-increasing} if there exists some $C>0$
     and $n\geq1$ such that $|f(x)\leq C||x||_\rho^n$.
 \end{definition}
 
-\begin{theorem}\label{slowly_increasing_well_defined}\uses{slowly_increasing}\notready This is independent of the choice of $\rho$ as above
+\begin{theorem}\label{slowly_increasing_well_defined}\uses{slowly_increasing}\notready This is independent of the choice of $\rho$ as above.
 \end{theorem}
 \begin{proof} Follows from the above.
 \end{proof}


### PR DESCRIPTION
Fixes a few typos in the blueprint. I have also noticed that there is a broken link at the beginning of section 5.6, but I don't know where exactly that one is supposed to go so I haven't changed it.