### PR TITLE
Fix \cite and local pdf compilation

### DIFF
--- a/FLT/Basic/Reductions.lean
+++ b/FLT/Basic/Reductions.lean
@@ -452,7 +452,7 @@ end FreyPackage
 /-!
 
 Given an elliptic curve over `ℚ`, the p-torsion points defined over an algebraic
-closure of `ℚ` are a 2-dimensional Galois reprentation. What can we say about the Galois
+closure of `ℚ` are a 2-dimensional Galois representation. What can we say about the Galois
 representation attached to the p-torsion of the Frey curve attached to a Frey package?
 
 It follows (after a little work!) from a profound theorem of Mazur that this representation

--- a/blueprint/src/chapter/ch03frey.tex
+++ b/blueprint/src/chapter/ch03frey.tex
@@ -408,7 +408,7 @@ theorem without developing all of this machinery and much more.
 \end{corollary}
 \begin{proof}\uses{Elliptic_curve_quotient_by_finite_subgroup, mazur} $\rho$ has a Galois-stable submodule $C$. The quotient curve $E/C$ now has
   a trivial 1-dimensional submodule, and also three points of order~2 (the images of the three
-  2-torsion points in $E$). Hence the torsion subgroup of $E/C$ has order at least 4\ell\geq20, 
+  2-torsion points in $E$). Hence the torsion subgroup of $E/C$ has order at least $4\ell\geq 20$, 
   again contradicting Mazur's theorem.
 \end{proof}
 

--- a/blueprint/src/chapter/chtopbestiary.tex
+++ b/blueprint/src/chapter/chtopbestiary.tex
@@ -216,7 +216,7 @@ The big theorem, which again we are far from even \emph{stating} right now, is
 
 \section{Algebraic geometry}
 
-We have already mentioned Mazur's Theorem on torsion subgroups of elliptic curves (theorem~\cite{mazur}).
+We have already mentioned Mazur's Theorem on torsion subgroups of elliptic curves (theorem~\ref{mazur}).
 The proof of this is 100 pages of a subtle analysis of the bad reduction of modular curves and the consequences of this on their Jacobians.
 
 Talking of modular curves, we also need the existence of Shimura curves and surfaces over totally real fields~$F$ (of degree greater than~2, so always compact). The curves are "modeles \'etranges" in the sense of Deligne, so we also need moduli spaces of unitary Shimura varieties over CM extensions. We need to decompose the first and second etale cohomology groups of these varieties into Galois representations, by understanding them

--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -15,11 +15,11 @@
 
 \usepackage[warnings-off={mathtools-colon,mathtools-overbracket}]{unicode-math}
 \usepackage{fontspec}
-\setmathfont{Latin Modern Math}
-\setmathfont[range=\varnothing]{Asana-Math.otf}
-\setmathfont[range=\pitchfork]{Asana-Math.otf}
-\setmathfont[range=\intprod]{Asana-Math.otf}
-\setmathfont[range=\int]{Latin Modern Math}
+% \setmathfont{Latin Modern Math}
+% \setmathfont[range=\varnothing]{Asana-Math.otf}
+% \setmathfont[range=\pitchfork]{Asana-Math.otf}
+% \setmathfont[range=\intprod]{Asana-Math.otf}
+% \setmathfont[range=\int]{Latin Modern Math}
 
 \usepackage[nameinlink, capitalize]{cleveref}
 

--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -15,11 +15,11 @@
 
 \usepackage[warnings-off={mathtools-colon,mathtools-overbracket}]{unicode-math}
 \usepackage{fontspec}
-% \setmathfont{Latin Modern Math}
-% \setmathfont[range=\varnothing]{Asana-Math.otf}
-% \setmathfont[range=\pitchfork]{Asana-Math.otf}
-% \setmathfont[range=\intprod]{Asana-Math.otf}
-% \setmathfont[range=\int]{Latin Modern Math}
+\setmathfont{latinmodern-math.otf}
+\setmathfont[range=\varnothing]{Asana-Math.otf}
+\setmathfont[range=\pitchfork]{Asana-Math.otf}
+\setmathfont[range=\intprod]{Asana-Math.otf}
+\setmathfont[range=\int]{latinmodern-math.otf}
 
 \usepackage[nameinlink, capitalize]{cleveref}
 


### PR DESCRIPTION
- [x] Fix an incorrect `\cite` turning into the appropriate `\ref`.
- [x] Fix `! Package fontspec Error: The font "Latin Modern Math" cannot be found.`
- [x] Add missing $ for inline math
- [x] Fix a typo in `Reductions.lean`