### PR TITLE
Remove `.venv` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,3 @@ blueprint/lean_decls
 *.fls
 *.fdb_latexmk
 *.synctex.gz
-# Python virtual environment 
-/.venv


### PR DESCRIPTION
This PR remove `/.venv` from the `.gitignore` since it's unique to my setup and not generalisable. 

Sorry for the previous commit. 