### PR TITLE
fix statement of ZHat.multiples

### DIFF
--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -69,7 +69,30 @@ lemma e_not_in_Int : ∀ a : ℤ, e ≠ a := sorry
 lemma torsionfree (N : ℕ+) : Function.Injective (fun z : ZHat ↦ N * z) := sorry
 
 -- LaTeX proof in the notes.
-lemma multiples (N : ℕ+) (z : ZHat) : N * z = 0 ↔ z N = 0 := sorry
+lemma multiples (N : ℕ+) (z : ZHat) : (∃ (y : ZHat), N * y = z) ↔ z N = 0 := by
+  constructor
+  · intro ⟨y, hy⟩
+    rw [← hy]
+    change N * (y N) = 0
+    simp [ZMod.natCast_self]
+  · intro h
+    let y : ZHat := {
+      val := fun j ↦ (by
+        let yj_preimage := z (N * j)
+        have hh := z.2 N (N * j) (by simp only [PNat.mul_coe, dvd_mul_right])
+        have : z.val N = 0 := h
+        rw [this] at hh
+        -- use `hh` to conclude that `yj_preimage/N` makes sense as an element of `ZMod j`.
+        -- This is the `y j` we want.
+        sorry)
+      property := sorry
+        -- `y` is compatible
+    }
+    refine ⟨y, ?_⟩
+    ext j
+    have hh := z.2 j (N * j) (by simp only [PNat.mul_coe, dvd_mul_left])
+    rw [← hh]
+    sorry -- This should be easy once `y` is defined.
 
 end ZHat
 

--- a/blueprint/src/chapter/ch05automorphicformexample.tex
+++ b/blueprint/src/chapter/ch05automorphicformexample.tex
@@ -199,7 +199,7 @@ are multiples of~$N$.
 \end{lemma}
 \begin{proof}
     Clearly $z_N=0$ is a necessary condition to be a multiple of~$N$. To see it is sufficient, 
-    take a general $(z_i)\in\Zhat$ which is a multiple of~$N$, note that $z_N=0$, 
+    take a general $(z_i)\in\Zhat$ such that $z_N=0$, 
     and now define a new element $(y_j)_j$ of $\Zhat$
     by $y_j=z_{Nj}/N$. Just to clarify what this means: $z_{Nj}\in\Z/Nj\Z$ reduces mod~$N$ 
     to $z_N=0$ by the compatibility assumption, so it is in the subgroup $N\Z/Nj\Z$ of $\Z/Nj\Z$, 


### PR DESCRIPTION
The old statement didn't make sense, also fixes a typo in the blueprint.