### PR TITLE
Update to the newer lakefile format

### DIFF
--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -46,8 +46,8 @@ lemma ext (x y : ZHat) (h : ∀ n : ℕ+, x n = y n) : x = y := by
   ext n
   apply h
 
-@[simp] lemma zero_val : (0 : ZHat) n = 0 := rfl
-@[simp] lemma one_val : (1 : ZHat) n = 1 := rfl
+@[simp] lemma zero_val (n : ℕ+) : (0 : ZHat) n = 0 := rfl
+@[simp] lemma one_val (n : ℕ+) : (1 : ZHat) n = 1 := rfl
 
 instance commRing : CommRing ZHat := inferInstance
 
@@ -154,7 +154,7 @@ noncomputable abbrev zsub : AddSubgroup QHat :=
 
 lemma rat_meet_zHat : ratsub ⊓ zHatsub = zsub := sorry
 
-lemma rat_join_zHat : ratsub ⊔ Zhatsub = ⊤ := sorry
+lemma rat_join_zHat : ratsub ⊔ zHatsub = ⊤ := sorry
 
 end additive_structure_of_QHat
 

--- a/FLT/EllipticCurve/Torsion.lean
+++ b/FLT/EllipticCurve/Torsion.lean
@@ -45,6 +45,7 @@ theorem EllipticCurve.n_torsion_finite {n : ℕ} (hn : 0 < n) : Finite (E.n_tors
 theorem EllipticCurve.n_torsion_card [IsSepClosed k] {n : ℕ} (hn : (n : k) ≠ 0) :
     Nat.card (E.n_torsion n) = n^2 := sorry
 
+set_option autoImplicit true in -- TODO: fix statement
 theorem group_theory_lemma {A : Type*} [AddCommGroup A] {n : ℕ} (hn : 0 < n) (r : ℕ)
     (h : ∀ d : ℕ, d ∣ n → Nat.card (Submodule.torsionBy ℤ A d) = d ^ r) :
     ∃ φ :(Submodule.torsionBy ℤ A n) ≃+ Fin d → (ZMod n), True := sorry

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,27 +1,12 @@
 import Lake
 open Lake DSL
 
-def moreServerArgs := #[
-  "-Dpp.unicode.fun=true", -- pretty-prints `fun a ↦ b`
-  "-Dpp.proofs.withType=false", -- no idea what this does
-  "-DautoImplicit=false", -- attempt to switch off auto-implicit
-  "-DrelaxedAutoImplicit=false" -- attempt to switch off relaxed auto-implicit
-]
-
--- These settings only apply during `lake build`, but not in VSCode editor.
-def moreLeanArgs := moreServerArgs
-
--- These are additional settings which do not affect the lake hash,
--- so they can be enabled in CI and disabled locally or vice versa.
--- Warning: Do not put any options here that actually change the olean files,
--- or inconsistent behavior may result
-def weakLeanArgs : Array String :=
-  if get_config? CI |>.isSome then
-    #["-DwarningAsError=true"]
-  else
-    #[]
-
 package FLT where
+  leanOptions := #[
+    ⟨`pp.unicode.fun, true⟩, -- pretty-prints `fun a ↦ b`
+    ⟨`autoImplicit, false⟩, -- switch off auto-implicit
+    ⟨`relaxedAutoImplicit, false⟩ -- switch off relaxed auto-implicit
+  ]
 
 require mathlib from git "https://github.com/leanprover-community/mathlib4.git"
 
@@ -36,6 +21,4 @@ require «doc-gen4» from git
 lean_lib FLT where
   globs := #[
     .andSubmodules `FLT
-    ]
---  moreLeanArgs := moreLeanArgs
---  weakLeanArgs := weakLeanArgs
+  ]


### PR DESCRIPTION
The `autoImplicit` setting was not actually being applied, as the lines were commented out.

Uncommenting the lines would have resulted in breaking Std files in VSCode.
`leanOptions` is now (4.6.0?) the preferred spelling of `moreServerArgs`, which does not have this issue.

`autoImplicit` flags that one statement appears to be garbage.