### PR TITLE
Fix `hyperref` warning

### DIFF
--- a/blueprint/src/chapter/ch05automorphicformexample.tex
+++ b/blueprint/src/chapter/ch05automorphicformexample.tex
@@ -58,7 +58,7 @@ the `sorry`s in this chapter are completed
 before mathlib gets the necessary complex analysis, then the first nonzero space of modular forms
 to be proved finite-dimensional in Lean will be a space of quaternionic modular forms.
 
-\section{$\Zhat$}
+\section{\texorpdfstring{$\Zhat$}{Zhat}}
 
 Classically automorphic forms were defined as functions on symmetric spaces (like the upper half
 plane) which transformed well under the action of certain discrete groups (for example $\SL_2(\Z)$).
@@ -207,7 +207,7 @@ are multiples of~$N$.
     $y_j$. It is easily checked that the $y_j$ are compatible and that $Ny=z$.
 \end{proof}
 
-\section{More advanced remarks on $\Zhat$ versus $\Q$}
+\section{More advanced remarks on \texorpdfstring{$\Zhat$}{Zhat} versus \texorpdfstring{$\Q$}{Q}}
 
 This section can be skipped on first reading.
 
@@ -227,7 +227,7 @@ ring of infinite adeles of $F$, which is $F\otimes_{\Q}\R$: some kind of univers
 archimedean completion of $F$. I don't know a reference which develops the theory of adeles
 in this way, so this is what we shall do here.
 
-\section{$\Qhat$ and tensor products.}
+\section{\texorpdfstring{$\Qhat$}{Qhat} and tensor products.}
 
 The definition of $\Qhat$ is easy if you know about tensor products
 of additive abelian groups.
@@ -416,7 +416,7 @@ Note that, being commutative rings, $\Q$ and $\Zhat$ both contain a copy of $\Z$
 the corresponding copies of $\Z$ in $\Qhat$ are equal; this is because $1\otimes a=a\otimes 1$
 for all $a\in\Z$.
 
-\section{Additive structure of $\Qhat$.}
+\section{Additive structure of \texorpdfstring{$\Qhat$}{Qhat}.}
 
 Here we forget the ring structure on everything, and analyse $\Qhat$ as an additive
 abelian group, and in particular how the subgroups $\Z$, $\Q$ and $\Zhat$ sit within it.
@@ -454,7 +454,7 @@ these results as $\Q\sqcap\Zhat=\Z$ and $\Q\sqcup\Zhat=\Qhat$.
     that $(z-t)_N=0$, hence $z-t=Ny$ for some $y\in\Zhat$. Now $x=t/N+y\in\Q+\Zhat$.
 \end{proof}
 
-\section{Multiplicative structure of the units of $\Qhat$.}
+\section{Multiplicative structure of the units of \texorpdfstring{$\Qhat$}{Qhat}.}
 
 We now forget the additive structure on the commutative ring $\Qhat$ and consider
 the multiplicative structure of its group of units $\Qhat^\times$ (which I couldn't


### PR DESCRIPTION
Fix `hyperref` warnings such as:

```console
Package hyperref Warning: Token not allowed in a PDF string (Unicode):
(hyperref)                removing `math shift' on input line 419.
```

This warning is generated `hyperref` package when it encounters a math symbol in a section heading or caption, which is not allowed in a PDF string. It automatically removes the math symbol, but it still generates a warning.

Using `\texorpdfstring{$X$}{X}` prevents the warning.