### PR TITLE
A matrix ring is a central simple algebra

### DIFF
--- a/FLT/for_mathlib/IsCentralSimple.lean
+++ b/FLT/for_mathlib/IsCentralSimple.lean
@@ -23,12 +23,30 @@ algebras in this case according to our definition.
 
 universe u v w
 
+open Classical
+open scoped BigOperators
+
 structure IsCentralSimple
     (K : Type u) [Field K] (D : Type v) [Ring D] [Algebra K D] : Prop where
   is_central : ∀ d : D, d ∈ Subring.center D → ∃ k : K, d = algebraMap K D k
   is_simple : IsSimpleOrder (RingCon D)
 
 variable (K : Type u) [Field K]
+
+theorem RingCon.sum {R : Type u} [AddCommMonoid R] [Mul R] {ι : Type v} {s : Finset ι} {a b : ι → R}
+    {r : RingCon R} (h : ∀ i ∈ s, r (a i) (b i)) : r (∑ i in s, a i) (∑ i in s, b i) := by
+  induction s using Finset.induction_on with
+  | empty =>
+    simp only [Finset.sum_empty]
+    exact r.refl 0
+  | insert hj ih =>
+    next h' j s' =>
+      simp_rw [Finset.sum_insert hj]
+      apply RingCon.add
+      · exact h j (Finset.mem_insert_self j s')
+      · apply ih
+        intro i hi
+        exact h i (Finset.mem_insert_of_mem hi)
 
 open Matrix in
 theorem MatrixRing.isCentralSimple (ι : Type v) (hι : Fintype ι) (hnonempty : Nonempty ι) [DecidableEq ι] :
@@ -38,7 +56,51 @@ theorem MatrixRing.isCentralSimple (ι : Type v) (hι : Fintype ι) (hnonempty :
     convert mem_range_scalar_of_commute_stdBasisMatrix (M := d) fun i j hij => hd _
     simp_rw [Set.mem_range, eq_comm, algebraMap_eq_diagonal, Pi.algebraMap_def,
       Algebra.id.map_eq_self, scalar_apply]
-  is_simple := sorry
+  is_simple.exists_pair_ne := by
+    use ⊥, ⊤
+    apply_fun (· 0 1)
+    convert false_ne_true
+    exact iff_false_iff.mpr zero_ne_one
+  is_simple.eq_bot_or_eq_top := by
+    intro r
+    obtain h | h := _root_.forall_or_exists_not (fun x ↦ r 0 x ↔ x = 0)
+    · left
+      apply RingCon.ext
+      intro x y
+      have : r x y ↔ r 0 (y - x) := by
+        constructor
+        · convert RingCon.add r (r.refl (-x)) using 1
+          rw [neg_add_self, sub_eq_add_neg, add_comm]
+        · convert RingCon.add r (r.refl x) using 1
+          rw [add_sub_cancel, add_zero]
+      rw [this, h, sub_eq_zero, eq_comm]
+      rfl
+    · right
+      obtain ⟨x, hx⟩ := h
+      have x_ne_zero : x ≠ 0 := by
+        rintro rfl
+        rw [eq_true (r.refl 0)] at hx
+        simp at hx
+      have r_zero_x : r 0 x := by tauto
+      have : ∃ i j, x i j ≠ 0 := by simpa using x_ne_zero ∘ Matrix.ext
+      obtain ⟨i, j, hij⟩ := this
+      have (k : ι) (_ : k ∈ Finset.univ) :
+          r 0 ((stdBasisMatrix k i 1) * x * (stdBasisMatrix j k 1)) := by
+        simpa using
+          r.mul (r.mul (r.refl (stdBasisMatrix k i 1)) r_zero_x) (r.refl (stdBasisMatrix j k 1))
+      have r_zero_sum := RingCon.sum this
+      have sum_eq_scalar :
+          ∑ k, (stdBasisMatrix k i 1) * x * (stdBasisMatrix j k 1) = scalar ι (x i j) := by
+        ext i' j'
+        simp [diagonal, sum_apply, mul_apply, stdBasisMatrix, ite_and, eq_comm]
+      have r_zero_one : r 0 1 := by
+        simpa [hij, Finset.sum_const_zero, sum_eq_scalar] using
+          r.mul r_zero_sum (r.refl (scalar ι (x i j)⁻¹))
+      have forall_r_zero a : r 0 a := by simpa using r.mul r_zero_one (r.refl a)
+      have forall_forall_r a b : r a b := by simpa using r.add (forall_r_zero (b - a)) (r.refl a)
+      apply RingCon.ext
+      simp [forall_forall_r]
+      trivial
 
 namespace IsCentralSimple
 

--- a/FLT/for_mathlib/IsCentralSimple.lean
+++ b/FLT/for_mathlib/IsCentralSimple.lean
@@ -60,6 +60,7 @@ theorem MatrixRing.isCentralSimple (ι : Type v) (hι : Fintype ι) (hnonempty :
     use ⊥, ⊤
     apply_fun (· 0 1)
     convert false_ne_true
+    -- Change after https://github.com/leanprover-community/mathlib4/pull/12860
     exact iff_false_iff.mpr zero_ne_one
   is_simple.eq_bot_or_eq_top := by
     intro r
@@ -79,8 +80,7 @@ theorem MatrixRing.isCentralSimple (ι : Type v) (hι : Fintype ι) (hnonempty :
       obtain ⟨x, hx⟩ := h
       have x_ne_zero : x ≠ 0 := by
         rintro rfl
-        rw [eq_true (r.refl 0)] at hx
-        simp at hx
+        simp [eq_true (r.refl 0)] at hx
       have r_zero_x : r 0 x := by tauto
       have : ∃ i j, x i j ≠ 0 := by simpa using x_ne_zero ∘ Matrix.ext
       obtain ⟨i, j, hij⟩ := this
@@ -99,8 +99,7 @@ theorem MatrixRing.isCentralSimple (ι : Type v) (hι : Fintype ι) (hnonempty :
       have forall_r_zero a : r 0 a := by simpa using r.mul r_zero_one (r.refl a)
       have forall_forall_r a b : r a b := by simpa using r.add (forall_r_zero (b - a)) (r.refl a)
       apply RingCon.ext
-      simp [forall_forall_r]
-      trivial
+      simp [forall_forall_r, Prop.top_eq_true]
 
 namespace IsCentralSimple
 

--- a/blueprint/src/chapter/ch06automorphicrepresentations.tex
+++ b/blueprint/src/chapter/ch06automorphicrepresentations.tex
@@ -4,9 +4,9 @@ I think that a nice and accessible goal (which will maybe take a month or two) w
 
 \section{Automorphic forms and analysis}
 
-Modular forms were historically the first nontrivial examples of automorphic forms, but by the 1950s or so it was realised that they were special cases of a very general notion of an automorphic form, as were Dirichlet characters! Modular forms are holomorphic automorphic forms for the group $\GL_2/\Q$, and Dirichlet characters are automorphic forms for the group $\GL_1/\Q$. It's possible to make sense of the notion of an automorphic form for the group $G/k$. Here $k$ is a ``global field'' -- that is, a field which is either a finite extension of $\Q$ (a number field) or a finite extension of $(\Z/p\Z)(T)$ (a function field), and $G$ is a connected reductive group variety over $k$. 
+Modular forms were historically the first nontrivial examples of automorphic forms, but by the 1950s or so it was realised that they were special cases of a very general notion of an automorphic form, as were Dirichlet characters! Modular forms are holomorphic automorphic forms for the group $\GL_2/\Q$, and Dirichlet characters are automorphic forms for the group $\GL_1/\Q$. It's possible to make sense of the notion of an automorphic form for the group $G/k$. Here $k$ is a ``global field'' -- that is, a field which is either a finite extension of $\Q$ (a number field) or a finite extension of $(\Z/p\Z)(T)$ (a function field), and $G$ is a connected reductive group variety over $k$.
 
-The reason that the definition of a modular form involves some analysis (they are holomorphic functions) is that if you quotient out the group $\GL_2(\R)$ by its centre and the maximal compact subgroup $O_2(\R)$, you get something which can be naturally identified with the upper half plane, a symmetric space with lots of interesting differential operators associated to it (for example a Casimir operator). However if you do the same thing with $\GL_1(\R)$ then you get a one point set, which is why a Dirichlet character is just a combinatorial object; it's a group homomorphism $(\Z/N\Z)^\times\to\bbC^\times$ where $N$ is some positive integer. It turns out that there are many other connected reductive groups where the associated symmetric space is 0-dimensional, and in these cases the definition of an automorphic form is again combinatorial. An example would be the group variety associated to the units of a totally definite quaternion algebra over a totally real field. In this case, the analogue of $\GL_2(\R)$ would be the units $\bbH^\times$ in the Hamilton quaternions, a maximal compact subgroup would be the quaternions of norm 1 (homeomorphic to the 3-sphere $S^3$) and quotienting out $\bbH^\times$ by its centre $\R^\times$ and $S^3$ again just gives you 1 point. 
+The reason that the definition of a modular form involves some analysis (they are holomorphic functions) is that if you quotient out the group $\GL_2(\R)$ by its centre and the maximal compact subgroup $O_2(\R)$, you get something which can be naturally identified with the upper half plane, a symmetric space with lots of interesting differential operators associated to it (for example a Casimir operator). However if you do the same thing with $\GL_1(\R)$ then you get a one point set, which is why a Dirichlet character is just a combinatorial object; it's a group homomorphism $(\Z/N\Z)^\times\to\bbC^\times$ where $N$ is some positive integer. It turns out that there are many other connected reductive groups where the associated symmetric space is 0-dimensional, and in these cases the definition of an automorphic form is again combinatorial. An example would be the group variety associated to the units of a totally definite quaternion algebra over a totally real field. In this case, the analogue of $\GL_2(\R)$ would be the units $\bbH^\times$ in the Hamilton quaternions, a maximal compact subgroup would be the quaternions of norm 1 (homeomorphic to the 3-sphere $S^3$) and quotienting out $\bbH^\times$ by its centre $\R^\times$ and $S^3$ again just gives you 1 point.
 
 Before we talk about quaternion algebras, let's talk about central simple algebras.
 
@@ -32,31 +32,33 @@ to do with~$K$.
     \label{MatrixRing.isCentralSimple}
     \lean{MatrixRing.isCentralSimple}
     \uses{IsCentralSimple}
+    \leanok
     \discussion{47}
     If $n\geq1$ then the $n\times n$ matrices $M_n(K)$ are a central simple algebra over~$K$.
 \end{lemma}
 \begin{proof}
-We prove more generally that matrices with coefficients in~$K$ and indexed by an arbitrary nonempty 
+We prove more generally that matrices with coefficients in~$K$ and indexed by an arbitrary nonempty
 finite type are a central simple algebra over~$K$.
 
 They are clearly an algebra over $K$, with $K$ embedded via scalar matrices as usual
-(the injectivity of the map from~$K$ comes from nonemptiness of the finite index type). 
+(the injectivity of the map from~$K$ comes from nonemptiness of the finite index type).
 The centre clearly contains $K$; to show that it
 equals~$K$, we argue as follows. Let $e(i,j)$ be the matrix with a 1 in the $i$th row and $j$th
-column, and zeros everywhere else. An element $Z=(Z_{s,t})_{s,t}$ of the centre commutes with 
+column, and zeros everywhere else. An element $Z=(Z_{s,t})_{s,t}$ of the centre commutes with
 all matrices $e(i,j)$ for $i\not=j$ and these equations immediately imply that $Z_{i,j}=0$ if $i\not=j$
 and that $Z_{i,i}=Z_{j,j}$.
 
 It suffices to prove that any nonzero two-sided ideal~$I$ is all of $M_n(K)$. So say $0\not=M\in I$
-and let's fix $(i,j)$ such that $M_{i,j}\not=0$. If now $N$ is any matrix, one easily checks
-that $N=M_{i,j}^{-1}\sum_{k,l}e(k,i)\times M\times e(j,l)\in I$.
+and let's fix $(i,j)$ such that $M_{i,j}\not=0$. One easily checks that
+$M_{i,j} \mathrm{id} = \sum_{k}e(k,i)\times M\times e(j,k)\in I$ (where $\mathrm{id} \in M_n(K)$
+is the identity matrix). Therefore, $\mathrm{id} \in I$, so $I = M_n(K)$.
 
 The definition also requires that the ring be non-zero, but this follows from the index type being nonempty.
 \end{proof}
 
 \begin{lemma}
     \label{IsCentralSimple.baseChange} % no Lean yet because Lean didn't seem to know L \otimes_K D was a ring
-    If $D$ is a central simple algebra over~$K$ and $L/K$ is a field extension, then $L\otimes_KD$ 
+    If $D$ is a central simple algebra over~$K$ and $L/K$ is a field extension, then $L\otimes_KD$
     is a central simple algebra over~$L$.
 \end{lemma}
 \begin{proof}
@@ -74,6 +76,5 @@ Next: define trace and norm.
 %  Any such quaternion algebra has a basis $1,i,j,k$ with $i^2=a$, $j^2=b$ and $ij=-ji=k$.
 %\end{lemma}
 %\begin{proof}
-%  Choose $d\in D\backslash K$. Then 
+%  Choose $d\in D\backslash K$. Then
 %\end{proof}
-

--- a/blueprint/src/chapter/ch06automorphicrepresentations.tex
+++ b/blueprint/src/chapter/ch06automorphicrepresentations.tex
@@ -20,7 +20,7 @@ of what we are considering below would be Hamilton's quaternions $\R\oplus\R i\o
     \label{IsCentralSimple}
     \lean{IsCentralSimple}
     \leanok
-A \emph{central simple algebra} over a field $K$ is a $K$-algebra $D$ such that $K$ is the centre of $D$
+A \emph{central simple algebra} over a field $K$ is a nonzero $K$-algebra $D$ such that $K$ is the centre of $D$
 and that $D$ has no nontrivial two-sided ideals.
 \end{definition}
 
@@ -32,11 +32,10 @@ to do with~$K$.
     \label{MatrixRing.isCentralSimple}
     \lean{MatrixRing.isCentralSimple}
     \uses{IsCentralSimple}
-    \leanok
     \discussion{47}
     If $n\geq1$ then the $n\times n$ matrices $M_n(K)$ are a central simple algebra over~$K$.
 \end{lemma}
-\begin{proof}
+\begin{proof}\leanok
 We prove more generally that matrices with coefficients in~$K$ and indexed by an arbitrary nonempty
 finite type are a central simple algebra over~$K$.
 


### PR DESCRIPTION
This was a pain because the API for `RingCon` is missing some things, like the ability to simplify `⊥ x y` and the fact that `r x y ↔ r 0 (y - x)`.

Once two-sided ideals are added to mathlib, I can revisit this.