### PR TITLE
Add missing `leanok` to lemma 5.13

### DIFF
--- a/blueprint/src/chapter/ch05automorphicformexample.tex
+++ b/blueprint/src/chapter/ch05automorphicformexample.tex
@@ -332,9 +332,10 @@ let's prove this now.
 \begin{lemma}
     \label{QHat.canonicalForm}
     \lean{QHat.canonicalForm}
-    \uses{QHat,ZHat.commRing} Every element of $\Qhat:=\Q\otimes\Zhat$
-can be written as $q\otimes_t z$ with $q\in\Q$ and $z\in\Zhat$.
-Furthermore one can even assume that $q=\frac{1}{N}$ for some positive integer $N$.
+    \uses{QHat,ZHat.commRing}
+    \leanok
+    Every element of $\Qhat:=\Q\otimes\Zhat$ can be written as $q\otimes_t z$ with $q\in\Q$ and $z\in\Zhat$.
+    Furthermore one can even assume that $q=\frac{1}{N}$ for some positive integer $N$.
 \end{lemma}
 \begin{proof} \leanok
     A proof I would write on the board would look like the following. Take a general


### PR DESCRIPTION
[Lemma 5.13](https://imperialcollegelondon.github.io/FLT/blueprint/sect0004.html#QHat.canonicalForm) is done [here](https://github.com/ImperialCollegeLondon/FLT/blob/1ae6d6c0b3895b2260852cb93a7ac150f3ab9138/FLT/AutomorphicRepresentation/Example.lean#L270-L294) but the check mark is not showing.