### PR TITLE
Add missing `leanok` to lemma 6.2

### DIFF
--- a/blueprint/src/chapter/ch06automorphicrepresentations.tex
+++ b/blueprint/src/chapter/ch06automorphicrepresentations.tex
@@ -32,6 +32,7 @@ to do with~$K$.
     \label{MatrixRing.isCentralSimple}
     \lean{MatrixRing.isCentralSimple}
     \uses{IsCentralSimple}
+    \leanok
     \discussion{47}
     If $n\geq1$ then the $n\times n$ matrices $M_n(K)$ are a central simple algebra over~$K$.
 \end{lemma}


### PR DESCRIPTION
[Lemma 6.2](https://imperialcollegelondon.github.io/FLT/blueprint/sect0005.html#MatrixRing.isCentralSimple) is done [here](https://github.com/ImperialCollegeLondon/FLT/blob/3acd39171d3c6b60a09bf7730eb8d08a5bbf120b/FLT/for_mathlib/IsCentralSimple.lean#L52-L102) but the check mark is missing.  This is another case where the `\leanok` was added to the proof but not to the statement.