### PR TITLE
Fix LaTeX error and warning

### DIFF
--- a/blueprint/src/chapter/ch05automorphicformexample.tex
+++ b/blueprint/src/chapter/ch05automorphicformexample.tex
@@ -650,6 +650,7 @@ is the usual Hamilton quaternions.
 \begin{proof}
     \leanok
     It's a sum of rational squares.
+\end{proof}
 
 \begin{lemma}
     \label{Hurwitz.exists_near}
@@ -675,7 +676,7 @@ is the usual Hamilton quaternions.
     $q$ and $r$ such that $a=qb+r$ and $N(r)<N(b)$.
 \end{lemma}
 \begin{proof}
-  Let $q$ be the Hurwitz quaternion obtained by applying Lemma~\cite{Hurwitz.exists_near}
+  Let $q$ be the Hurwitz quaternion obtained by applying \Cref{Hurwitz.exists_near}
   to $a/b := ab^{-1}$; then $N(a/b-q)<1$ and now everything follows after multiplying up.
 \end{proof}
 


### PR DESCRIPTION
- [x] Fix LaTeX error (missing `\end{proof}`).
- [x] Fix LaTeX warning (substitute `\cite` with `\Cref` in order to correctly refer to the relevant lemma).