### PR TITLE
Proof of continuous_bilinear 

### DIFF
--- a/FLT/HIMExperiments/module_topology.lean
+++ b/FLT/HIMExperiments/module_topology.lean
@@ -1,6 +1,5 @@
 import Mathlib.RingTheory.TensorProduct.Basic -- we need tensor products of rings at some point
 import Mathlib.Topology.Algebra.Module.Basic -- and we need topological rings and modules
-
 /-
 
 # The "module topology" for a module over a topological ring.
@@ -51,7 +50,7 @@ and target.
 --   refine Continuous.mul (Continuous.comp (continuous_apply _) (continuous_fst)) ?_
 --   exact (Continuous.comp (continuous_apply _) (continuous_snd))
 
-variable (A : Type*) [CommRing A] [TopologicalSpace A] [TopologicalRing A]
+variable (A : Type*) [CommRing A] [hA : TopologicalSpace A] [TopologicalRing A]
 
 -- let M be an A-module
 variable {M : Type*} [AddCommGroup M] [Module A M]
@@ -107,10 +106,10 @@ def Module.homeomorphism_equiv (e : M ≃ₗ[A] N) :
   -- all the sorries should be formal.
   { toFun := e
     invFun := e.symm
-    left_inv := sorry
-    right_inv := sorry
-    continuous_toFun := sorry
-    continuous_invFun := sorry
+    left_inv := e.left_inv
+    right_inv := e.right_inv
+    continuous_toFun := Module.continuous_linear A e
+    continuous_invFun := Module.continuous_linear A e.symm
   }
 
 -- sanity check: the topology on A^n is the product topology
@@ -137,13 +136,81 @@ example (ι : Type*) [Finite ι] :
     -- it's linear, because Lean has the projections as linear maps.
     exact ⟨LinearMap.proj i, rfl⟩
 
+--maybe I should conclude this from the example above but don't know how
+--otherwise this should be very easy to do by hand
+lemma Module.topology_self : (hA : TopologicalSpace A) = Module.topology A := by
+  apply le_antisymm
+  · unfold topology
+    apply le_iInf
+    intro i
+    rw [← continuous_iff_le_induced]
+    have hi : i = LinearMap.lsmul A A (i 1) := by
+      ext
+      simp only [LinearMap.lsmul_apply, smul_eq_mul, mul_one]
+    rw [hi]
+    apply continuous_const.mul continuous_id
+    -- a linear map should always be continuous in this setting right?
+  · apply sInf_le
+    rw [Set.mem_range]
+    use LinearMap.id
+    exact induced_id
+
 -- We need that the module topology on a product is the product topology
 lemma Module.prod_canonical :
     @instTopologicalSpaceProd M N (Module.topology A) (Module.topology A) =
     (Module.topology A : TopologicalSpace (M × N)) := by
   -- the goal is to prove that an iInf equals an inf (of two topologies).
-  unfold instTopologicalSpaceProd -- you can probably delete this later
-  sorry
+  apply le_antisymm
+  · apply le_iInf
+    intro f
+    rw [← continuous_iff_le_induced]
+    have : ⇑f = fun ⟨m, n⟩ ↦ f (⟨m, 0⟩) + f (⟨0, n⟩) := by
+      ext x
+      simp only
+      have : x = (x.1, 0) + (0, x.2) := by simp
+      nth_rewrite 1 [this]
+      apply LinearMap.map_add
+    rw [this]
+    simp only
+    have h1 : @Continuous _ _ (@instTopologicalSpaceProd M N (Module.topology A) (Module.topology A))
+      _ (fun (x : M × N) ↦ f (x.1, 0)) := by
+        have : (fun (x : M × N) ↦ f (x.1, 0)) = fun x ↦ (fun m ↦ f (m, 0)) x.1 := by
+          ext x
+          simp only [Function.comp_apply]
+        rw [this]
+        apply @Continuous.fst' _ _ _ (Module.topology A) (Module.topology A) _ (fun m ↦ f (m, 0))
+        let h :  M →ₗ[A] A := {
+          toFun := fun m ↦ f (m, 0)
+          map_add' := by
+            intro x y
+            rw [← LinearMap.map_add, Prod.mk_add_mk, add_zero]
+          map_smul' := by
+            intro m x
+            rw [← LinearMap.map_smul, RingHom.id_apply, Prod.smul_mk, smul_zero]
+        }
+        have : (fun m ↦ f (m, 0)) = h := by rfl
+        rw [this, continuous_iff_le_induced]
+        nth_rewrite 2 [Module.topology_self A]
+        rw [← continuous_iff_le_induced]
+        exact Module.continuous_linear A h
+    have h2 : @Continuous _ _ (@instTopologicalSpaceProd M N (Module.topology A) (Module.topology A))
+      _ (fun (x : M × N) ↦ f (0, x.2))
+      := by sorry -- this will be exactly the same as above so better do the cleanup first
+    apply @Continuous.add _ _
+      (@instTopologicalSpaceProd M N (Module.topology A) (Module.topology A)) _ _ _ _ _ h1 h2
+  · apply le_inf
+    · rw [induced_iInf]
+      apply le_iInf
+      intro f
+      rw [induced_compose]
+      exact iInf_le (fun (f :  M × N →ₗ[A] A) ↦ TopologicalSpace.induced (⇑f) inferInstance)
+        (LinearMap.lcomp A A (LinearMap.fst A M N) f)
+    · rw [induced_iInf]
+      apply le_iInf
+      intro f
+      rw [induced_compose]
+      exact iInf_le (fun (f :  M × N →ₗ[A] A) ↦ TopologicalSpace.induced (⇑f) inferInstance)
+        (LinearMap.lcomp A A (LinearMap.snd A M N) f)
 
 -- I assume this is true! Lots of things like this seem to be true.
 lemma Module.continuous_bilinear {P : Type*} [AddCommGroup P] [Module A P]
@@ -171,7 +238,7 @@ noncomputable def LinearMap.add (M : Type*) [AddCommGroup M] [Module A M] :
 
 -- Now say we have a non-commutative `A`-algebra `D` which is free of finite type.
 
-variable (D : Type*) [Ring D] [Algebra A D] [Module.Finite A D] [Module.Free A D]
+variable (D : Type*) [Ring D] [Algebra A D]
 
 -- Let's put the module topology on `D`
 def D_topology : TopologicalSpace D := Module.topology A

--- a/FLT/HIMExperiments/module_topology.lean
+++ b/FLT/HIMExperiments/module_topology.lean
@@ -167,7 +167,7 @@ lemma LinearMap.continuous_on_prod (f : (M × N) →ₗ[A] A) :
     convert this
     simp_rw [← LinearMap.map_add, Prod.mk_add_mk, add_zero, zero_add]
   apply Continuous.add
-  . apply @Continuous.fst' _ _ _ _ _ _ (fun m ↦ f (m, 0))
+  . refine Continuous.fst' (?_ : Continuous fun m ↦ f (m, 0))
     exact Module.continuous_linear_to_ring A
       ({toFun := fun m ↦ f (m, 0),
         map_add' := by {intro x y; rw [← LinearMap.map_add, Prod.mk_add_mk, zero_add]},
@@ -218,7 +218,7 @@ noncomputable def LinearMap.add (M : Type*) [AddCommGroup M] [Module A M] :
 
 /-- Basis.repr in the first variable as a linear map. -/
 noncomputable def LinearMap.basis₁ (M : Type*) (ι : Type*) [Finite ι] [AddCommGroup M] [Module A M]
-  (b : Basis ι A M) (i : ι): M →ₗ[A] A where
+    (b : Basis ι A M) (i : ι) : M →ₗ[A] A where
   toFun m := b.repr m i
   map_add' := by simp only [map_add, Finsupp.coe_add, Pi.add_apply, implies_true]
   map_smul' _ _  := by simp only [LinearMapClass.map_smul, Finsupp.coe_smul, Pi.smul_apply,
@@ -239,8 +239,8 @@ noncomputable def LinearMap.prodsnd (M N : Type*) [AddCommGroup M] [Module A M] 
 instance Module.instCommAdd {P : Type*} [AddCommGroup P] [Module A P]:
 @ContinuousAdd P (Module.topology A) _ := by
   apply @ContinuousAdd.mk _ (topology A)
-  rw [Module.prod_canonical A]
-  exact Module.continuous_linear A (LinearMap.add A P)
+  rw [prod_canonical A]
+  exact continuous_linear A (LinearMap.add A P)
 
 variable [Module.Finite A M] [Module.Free A M] [Module.Finite A N] [Module.Free A N]
 
@@ -254,8 +254,7 @@ instance Module.instContinuousSMul : @ContinuousSMul A M _ _ (topology A) := by
   let ι := Free.ChooseBasisIndex A M
   have b : Basis ι A M := Free.chooseBasis A M
   suffices Continuous fun (p : A × M) ↦ ∑ i : ι, p.1 • b.repr p.2 i • b i by
-    convert this using 1
-    simp_rw [← Finset.smul_sum, Basis.sum_repr]
+    simpa [← Finset.smul_sum, Basis.sum_repr]
   apply continuous_finset_sum
   intro i _
   simp_rw [← mul_smul]
@@ -285,8 +284,7 @@ Continuous fun (mn : M × N) ↦ f mn.1 mn.2 := by
   apply continuous_finset_sum
   intro k _
   suffices Continuous fun (a : M × N) ↦ ∑ i : ι, ((d.repr a.2 k • b.repr a.1 i • f (b i)) (d k)) by
-    convert this using 1
-    simp only [LinearMap.coeFn_sum, Finset.sum_apply, LinearMap.smul_apply]
+    simpa [LinearMap.coeFn_sum, Finset.sum_apply, LinearMap.smul_apply]
   apply continuous_finset_sum
   intro i _
   exact contonbasis k i
@@ -307,9 +305,7 @@ lemma Module.continuous_bilinear {P : Type*} [AddCommGroup P] [Module A P] [Modu
   rw [← prod_canonical]
   apply Module.bilinear_continuous_of_continuous_on_basis A b d f
   intro k i
-  convert Continuous.smul ?_ ?_
-  · exact iA
-  · infer_instance
+  apply Continuous.smul ?_ ?_
   · suffices Continuous ((LinearMap.basis₁ A N κ d k) ∘ Prod.snd) from this
     apply Continuous.comp
     · exact Module.continuous_linear_to_ring A (LinearMap.basis₁ A N κ d k)

--- a/FLT/HIMExperiments/module_topology.lean
+++ b/FLT/HIMExperiments/module_topology.lean
@@ -164,19 +164,20 @@ lemma LinearMap.continuous_on_prod (f : (M × N) →ₗ[A] A) :
   let _τM : TopologicalSpace M := Module.topology A
   let _τN : TopologicalSpace N := Module.topology A
   suffices Continuous fun (⟨m, n⟩ : M × N) ↦ f (⟨m, 0⟩) + f (⟨0, n⟩) by
-    convert this
-    simp_rw [← LinearMap.map_add, Prod.mk_add_mk, add_zero, zero_add]
+    simpa [← LinearMap.map_add, Prod.mk_add_mk, add_zero, zero_add]
   apply Continuous.add
   . refine Continuous.fst' (?_ : Continuous fun m ↦ f (m, 0))
     exact Module.continuous_linear_to_ring A
       ({toFun := fun m ↦ f (m, 0),
         map_add' := by {intro x y; rw [← LinearMap.map_add, Prod.mk_add_mk, zero_add]},
-        map_smul' := by {intro m x; rw [← LinearMap.map_smul, RingHom.id_apply, Prod.smul_mk, smul_zero]}})
+        map_smul' := by intro m x; rw [←LinearMap.map_smul,
+          RingHom.id_apply, Prod.smul_mk, smul_zero]})
   . apply @Continuous.snd' _ _ _ _ _ _ (fun n ↦ f (0, n))
     exact Module.continuous_linear_to_ring A
       ({toFun := fun n ↦ f (0, n),
         map_add' := by {intro x y; rw [← LinearMap.map_add, Prod.mk_add_mk, add_zero]},
-        map_smul' := by {intro m x; rw [← LinearMap.map_smul, RingHom.id_apply, Prod.smul_mk, smul_zero]}})
+        map_smul' := by intro m x; rw [← LinearMap.map_smul,
+          RingHom.id_apply, Prod.smul_mk, smul_zero]})
 
 -- We need that the module topology on a product is the product topology
 lemma Module.prod_canonical :
@@ -201,7 +202,6 @@ lemma Module.prod_canonical :
       exact iInf_le _ (LinearMap.lcomp _ _ (LinearMap.snd _ _ _) _)
 
 -- Linear maps are automatically continuous, so let's make a couple of handy ones:
--- they're probably there already but I couldn't find them
 /-- Negation on a module as a linear map. -/
 noncomputable def LinearMap.neg (M : Type*) [AddCommGroup M] [Module A M] :
     M →ₗ[A] M where
@@ -245,9 +245,6 @@ instance Module.instCommAdd {P : Type*} [AddCommGroup P] [Module A P]:
 variable [Module.Finite A M] [Module.Free A M] [Module.Finite A N] [Module.Free A N]
 
 
--- I really shouldn't start with iA instead of topology A here.
--- But I need it like this in the next proof and don't know how to rewrite it there
--- Sorry for leaving it like this...
 instance Module.instContinuousSMul : @ContinuousSMul A M _ _ (topology A) := by
   let _τM : TopologicalSpace M := Module.topology A
   apply @ContinuousSMul.mk A M _ _ (topology A)
@@ -270,11 +267,12 @@ instance Module.instContinuousSMul : @ContinuousSMul A M _ _ (topology A) := by
 
 
 lemma Module.bilinear_continuous_of_continuous_on_basis {P : Type*} {ι κ : Type*} [Fintype ι]
-[Fintype κ] [AddCommGroup P] [Module A P] [TopologicalSpace M] [TopologicalSpace N]
-[TopologicalSpace P] [ContinuousAdd P] (b : Basis ι A M) (d : Basis κ A N) (f : M →ₗ[A] N →ₗ[A] P)
-(contonbasis : ∀ (k : κ) (i : ι), Continuous fun (mn : M × N) ↦ ((d.repr mn.2) k • (b.repr mn.1) i • f (b i)) (d k)) :
-Continuous fun (mn : M × N) ↦ f mn.1 mn.2 := by
-  suffices Continuous fun (mn : M × N) ↦  (∑ k : κ, (∑ i : ι, d.repr mn.2 k • b.repr mn.1 i • f (b i)) (d k)) by
+    [Fintype κ] [AddCommGroup P] [Module A P] [TopologicalSpace M] [TopologicalSpace N]
+    [TopologicalSpace P] [ContinuousAdd P] (b : Basis ι A M) (d : Basis κ A N) (f : M →ₗ[A] N →ₗ[A] P)
+    (contonbasis : ∀ (k : κ) (i : ι), Continuous fun (mn : M × N) ↦ ((d.repr mn.2) k •
+    (b.repr mn.1) i • f (b i)) (d k)) :Continuous fun (mn : M × N) ↦ f mn.1 mn.2 := by
+  suffices Continuous fun (mn : M × N) ↦  (∑ k : κ, (∑ i : ι, d.repr mn.2 k •
+    b.repr mn.1 i • f (b i)) (d k)) by
     convert this using 1
     ext mn
     rw [← Basis.sum_repr b mn.1, ← Basis.sum_repr d mn.2]
@@ -290,8 +288,8 @@ Continuous fun (mn : M × N) ↦ f mn.1 mn.2 := by
   exact contonbasis k i
 
 -- I assume this is true! Lots of things like this seem to be true.
-lemma Module.continuous_bilinear {P : Type*} [AddCommGroup P] [Module A P] [Module.Finite A P] [Module.Free A P]
-    (f : M →ₗ[A] N →ₗ[A] P) :
+lemma Module.continuous_bilinear {P : Type*} [AddCommGroup P] [Module A P] [Module.Finite A P]
+    [Module.Free A P] (f : M →ₗ[A] N →ₗ[A] P) :
     let _τMN : TopologicalSpace (M × N) := Module.topology A
     let _τP : TopologicalSpace P := Module.topology A
     Continuous (fun mn ↦ f mn.1 mn.2 : M × N → P)  := by

--- a/FLT/HIMExperiments/module_topology.lean
+++ b/FLT/HIMExperiments/module_topology.lean
@@ -142,8 +142,6 @@ example (ι : Type*) [Finite ι] :
     -- it's linear, because Lean has the projections as linear maps.
     exact ⟨LinearMap.proj i, rfl⟩
 
---maybe I should conclude this from the example above but don't know how
---otherwise this should be very easy to do by hand
 lemma Module.topology_self : (iA :TopologicalSpace A) = Module.topology A := by
   refine le_antisymm (le_iInf (fun i ↦ ?_)) <| sInf_le ⟨LinearMap.id, induced_id⟩
   rw [← continuous_iff_le_induced, show i = LinearMap.lsmul A A (i 1) by ext; simp]
@@ -201,21 +199,6 @@ lemma Module.prod_canonical :
       rw [induced_compose]
       exact iInf_le _ (LinearMap.lcomp _ _ (LinearMap.snd _ _ _) _)
 
--- Linear maps are automatically continuous, so let's make a couple of handy ones:
-/-- Negation on a module as a linear map. -/
-noncomputable def LinearMap.neg (M : Type*) [AddCommGroup M] [Module A M] :
-    M →ₗ[A] M where
-  toFun := (- .)
-  map_add' := neg_add
-  map_smul' r m := (smul_neg r m).symm
-
-/-- Addition on a module as a linear map from `M²` to `M`. -/
-noncomputable def LinearMap.add (M : Type*) [AddCommGroup M] [Module A M] :
-    M × M →ₗ[A] M where
-  toFun mn := mn.1 + mn.2
-  map_add' _ _ := add_add_add_comm _ _ _ _
-  map_smul' _ _ := (DistribSMul.smul_add _ _ _).symm
-
 /-- Basis.repr in the first variable as a linear map. -/
 noncomputable def LinearMap.basis₁ (M : Type*) (ι : Type*) [Finite ι] [AddCommGroup M] [Module A M]
     (b : Basis ι A M) (i : ι) : M →ₗ[A] A where
@@ -224,26 +207,13 @@ noncomputable def LinearMap.basis₁ (M : Type*) (ι : Type*) [Finite ι] [AddCo
   map_smul' _ _  := by simp only [LinearMapClass.map_smul, Finsupp.coe_smul, Pi.smul_apply,
     smul_eq_mul, RingHom.id_apply]
 
-noncomputable def LinearMap.prodfst (M N : Type*) [AddCommGroup M] [Module A M] [AddCommGroup N]
-  [Module A N] : M × N →ₗ[A] M where
-  toFun := Prod.fst
-  map_add' _ _ := rfl
-  map_smul' _ _ := rfl
-
-noncomputable def LinearMap.prodsnd (M N : Type*) [AddCommGroup M] [Module A M] [AddCommGroup N]
-  [Module A N] : M × N →ₗ[A] N where
-  toFun := Prod.snd
-  map_add' _ _ := rfl
-  map_smul' _ _:= rfl
-
 instance Module.instCommAdd {P : Type*} [AddCommGroup P] [Module A P]:
 @ContinuousAdd P (Module.topology A) _ := by
   apply @ContinuousAdd.mk _ (topology A)
   rw [prod_canonical A]
-  exact continuous_linear A (LinearMap.add A P)
+  exact continuous_linear A ((LinearMap.fst A P P) + (LinearMap.snd A P P))
 
 variable [Module.Finite A M] [Module.Free A M] [Module.Finite A N] [Module.Free A N]
-
 
 instance Module.instContinuousSMul : @ContinuousSMul A M _ _ (topology A) := by
   let _τM : TopologicalSpace M := Module.topology A
@@ -331,7 +301,7 @@ instance moobar : @TopologicalRing D (Module.topology A) _ :=
       -- the product topology is the module topology
       rw [Module.prod_canonical A]
       -- and addition is linear so it's continuous for the module topology
-      exact Module.continuous_linear A (LinearMap.add A D)
+      exact Module.continuous_linear A ((LinearMap.fst A D D) + (LinearMap.snd A D D))
     -- multiplication is continuous:
     continuous_mul := by
       -- the product topology is the module topology
@@ -339,4 +309,4 @@ instance moobar : @TopologicalRing D (Module.topology A) _ :=
       -- and multiplication is bilinear so it's continuous for the module topology (I hope)
       apply Module.continuous_bilinear A (LinearMap.mul A D)
     -- finally negation is continuous because it's linear.
-    continuous_neg := Module.continuous_linear A (LinearMap.neg _ _) }
+    continuous_neg := Module.continuous_linear A (-LinearMap.id) }

--- a/FLT/HIMExperiments/module_topology.lean
+++ b/FLT/HIMExperiments/module_topology.lean
@@ -1,5 +1,6 @@
 import Mathlib.RingTheory.TensorProduct.Basic -- we need tensor products of rings at some point
 import Mathlib.Topology.Algebra.Module.Basic -- and we need topological rings and modules
+import Mathlib.Topology.Algebra.Module.FiniteDimension
 /-
 
 # The "module topology" for a module over a topological ring.
@@ -142,7 +143,8 @@ lemma Module.topology_self : (iA :TopologicalSpace A) = Module.topology A := by
   rw [← continuous_iff_le_induced, show i = LinearMap.lsmul A A (i 1) by ext;simp]
   exact continuous_const.mul continuous_id
 
-lemma LinearMap.continuous_on_prod (f : (M × N) →ₗ[A] A) :  @Continuous _ _ (@instTopologicalSpaceProd M N (Module.topology A) (Module.topology A)) _ f := by
+lemma LinearMap.continuous_on_prod (f : (M × N) →ₗ[A] A) :
+  @Continuous _ _ (@instTopologicalSpaceProd M N (Module.topology A) (Module.topology A)) _ f := by
   have : ⇑f = fun ⟨m, n⟩ ↦ f (⟨m, 0⟩) + f (⟨0, n⟩) := by
     ext x
     simp only
@@ -151,7 +153,8 @@ lemma LinearMap.continuous_on_prod (f : (M × N) →ₗ[A] A) :  @Continuous _ _
     apply LinearMap.map_add
   rw [this]
   simp only
-  apply @Continuous.add _ _ (@instTopologicalSpaceProd M N (Module.topology A) (Module.topology A)) _ _ _ (fun x ↦ (fun m ↦ f (m, 0)) x.1) (fun x ↦ (fun n ↦ f (0, n)) x.2)
+  apply @Continuous.add _ _ (@instTopologicalSpaceProd M N (Module.topology A) (Module.topology A))
+    _ _ _ (fun x ↦ (fun m ↦ f (m, 0)) x.1) (fun x ↦ (fun n ↦ f (0, n)) x.2)
   . apply @Continuous.fst' _ _ _ (Module.topology A) (Module.topology A) _ (fun m ↦ f (m, 0))
     nth_rewrite 2 [Module.topology_self A]
     exact Module.continuous_linear A ({toFun := fun m ↦ f (m, 0), map_add' := by
@@ -185,12 +188,6 @@ lemma Module.prod_canonical :
       rw [induced_compose]
       exact iInf_le _ (LinearMap.lcomp _ _ (LinearMap.snd _ _ _) _)
 
--- I assume this is true! Lots of things like this seem to be true.
-lemma Module.continuous_bilinear {P : Type*} [AddCommGroup P] [Module A P]
-    (b : M →ₗ[A] N →ₗ[A] P) :
-    @Continuous (M × N) P (Module.topology A) (Module.topology A) (fun mn ↦ b mn.1 mn.2) := by
-  sorry
-
 -- Linear maps are automatically continuous, so let's make a couple of handy ones:
 -- they're probably there already but I couldn't find them
 /-- Negation on a module as a linear map. -/
@@ -200,12 +197,164 @@ noncomputable def LinearMap.neg (M : Type*) [AddCommGroup M] [Module A M] :
   map_add' := neg_add
   map_smul' r m := (smul_neg r m).symm
 
+/-- Scalar multiplication in the second variable as a linear map. -/
+noncomputable def LinearMap.smul₂ (M : Type*) [AddCommGroup M] [Module A M] (a : A):
+    M →ₗ[A] M where
+  toFun m := (a • m)
+  map_add' := by simp
+  map_smul' r m := by
+    simp
+    rw [@smul_algebra_smul_comm]
+
+/-- Scalar multiplication in the first variable as a linear map. -/
+noncomputable def LinearMap.smul₁ (M : Type*) [AddCommGroup M] [Module A M] (m : M):
+    A →ₗ[A] M where
+  toFun a := a • m
+  map_add' := by simp [add_smul]
+  map_smul' r n := by simp [mul_smul]
+
 /-- Addition on a module as a linear map from `M²` to `M`. -/
 noncomputable def LinearMap.add (M : Type*) [AddCommGroup M] [Module A M] :
     M × M →ₗ[A] M where
   toFun mn := mn.1 + mn.2
   map_add' _ _ := add_add_add_comm _ _ _ _
   map_smul' _ _ := (DistribSMul.smul_add _ _ _).symm
+
+/-- Basis.equivFun in the first variable as a linear map. -/
+noncomputable def LinearMap.basis₁ (M : Type*) (ι : Type*) [Finite ι] [AddCommGroup M] [Module A M] (b : Basis ι A M) (i : ι):
+    M →ₗ[A] A where
+  toFun m := b.equivFun m i
+  map_add' := by simp
+  map_smul' r n := by simp
+
+noncomputable def LinearMap.prodfst (M N : Type*) [AddCommGroup M] [Module A M] [AddCommGroup N] [Module A N] :
+    M × N →ₗ[A] M where
+  toFun := Prod.fst
+  map_add' := by simp
+  map_smul' r n := by simp
+
+noncomputable def LinearMap.prodsnd (M N : Type*) [AddCommGroup M] [Module A M] [AddCommGroup N] [Module A N] :
+    M × N →ₗ[A] N where
+  toFun := Prod.snd
+  map_add' := by simp
+  map_smul' r n := by simp
+
+--local instance : TopologicalSpace P := Module.topology A
+
+instance Module.instCommAdd {P : Type*} [AddCommGroup P] [Module A P]:
+@ContinuousAdd P (Module.topology A) _ := by
+  apply @ContinuousAdd.mk _ (topology A)
+  rw [Module.prod_canonical A]
+  exact Module.continuous_linear A (LinearMap.add A P)
+
+variable [Module.Finite A M] [Module.Free A M] [Module.Finite A N] [Module.Free A N]
+
+
+-- I really shoouldn't start with iA instead of topology A here.
+-- But I need it like this in the next proof and don't know how to rewrite it there
+-- Sorry for leaving it like this...
+instance Module.instContinuousSMul : @ContinuousSMul A M _ (topology A) (topology A) := by
+  rw [← Module.topology_self]
+  apply @ContinuousSMul.mk A M _ _ (topology A)
+  let ι := Free.ChooseBasisIndex A M
+  have b : Basis ι A M := by
+    simp only [ι]
+    exact Free.chooseBasis A M
+  have : (fun (p : A × M) ↦ p.1 • p.2) = (fun p ↦ ∑ i : ι, p.1 • b.equivFun p.2 i • b i) := by
+    ext x
+    rw [← Finset.smul_sum, Basis.sum_equivFun]
+  rw [this]
+  apply @continuous_finset_sum _ _ _ (@instTopologicalSpaceProd _  _ _ (topology A)) (topology A) _ _ _ _
+  intro i _
+  have : (fun (a : A × M) ↦ a.1 • b.equivFun a.2 i • b i) = (fun a ↦ (a.1 * b.equivFun a.2 i) • b i) := by
+    ext
+    rw [← mul_smul]
+  rw [this]
+  have dcef: (fun a ↦ (a.1 * b.equivFun a.2 i) • b i) = (fun (a : A) ↦ a • b i) ∘ (fun (m : A × A) ↦ m.1 * m.2) ∘ (fun (m : A × M) ↦ (m.1, b.equivFun m.2 i)) := by
+    ext a
+    simp
+  rw [dcef]
+  apply @Continuous.comp _ _ _ (@instTopologicalSpaceProd _ _ _ (topology A)) _ (topology A) _ _
+  · have : (fun a ↦ a • b i) = (LinearMap.smul₁ A M (b i)) := by
+      unfold LinearMap.smul₁
+      simp
+    rw [this, Module.topology_self A]
+    -- this is legit the same. Why does this not work ?????
+    ---apply Module.continuous_linear A (LinearMap.smul₁ A M (b i))
+    sorry
+  apply @Continuous.comp _ _ _ (@instTopologicalSpaceProd _ _ _ (topology A)) _ _ _ _
+  exact continuous_mul
+  apply @Continuous.prod_map _ _ _ _ _ _ _ (topology A) (fun m ↦ m) (fun m ↦ b.equivFun m i)
+  exact continuous_id
+  have : (fun m ↦ b.equivFun m i) = LinearMap.basis₁ A M ι b i := by
+    unfold LinearMap.basis₁
+    simp
+  rw [this, Module.topology_self A]
+  -- again this looks the exact same
+  --apply Module.continuous_linear A (LinearMap.basis₁ A M ι b i)
+  sorry
+
+
+
+-- I assume this is true! Lots of things like this seem to be true.
+lemma Module.continuous_bilinear {P : Type*} [AddCommGroup P] [Module A P] [Module.Finite A P] [Module.Free A P]
+    (f : M →ₗ[A] N →ₗ[A] P) :
+    @Continuous (M × N) P (Module.topology A) (Module.topology A) (fun mn ↦ f mn.1 mn.2) := by
+  let ι := Free.ChooseBasisIndex A M
+  let κ := Free.ChooseBasisIndex A N
+  have b : Basis ι A M := by --how can I name the index ι without doing all this?
+    simp only [ι]
+    exact Free.chooseBasis A M
+  have d : Basis κ A N := by
+    simp only [κ]
+    exact Free.chooseBasis A N
+  rw [← prod_canonical]
+  have : (fun (mn : M × N) ↦ (f mn.1) mn.2) =
+    (fun (mn : M × N) ↦  (∑ k : κ, (∑ i : ι, d.equivFun mn.2 k • b.equivFun mn.1 i • f (b i)) (d k))) := by
+    ext ⟨x, y⟩
+    simp only
+    calc
+      (f x) y = (f (∑ i : ι, b.equivFun x i • b i)) (∑ k : κ, d.equivFun y k • d k) := by
+        rw [Basis.sum_equivFun, Basis.sum_equivFun]
+      _ = ∑ k : κ, (∑ i : ι, d.equivFun y k • b.equivFun x i • f (b i)) (d k) := by simp [Finset.smul_sum]
+  rw [this]
+  apply @continuous_finset_sum _ _ _ (@instTopologicalSpaceProd _  _ (topology A) (topology A))
+    (topology A) _ _ _ Finset.univ
+  intro k _
+  have : (fun (a : M × N) ↦ (∑ i : ι, d.equivFun a.2 k • b.equivFun a.1 i • f (b i)) (d k)) =
+    fun (a : M × N) ↦ ∑ i : ι, ((d.equivFun a.2 k • b.equivFun a.1 i • f (b i)) (d k)) := by
+    simp
+  rw [this]
+  apply @continuous_finset_sum _ _ _ (@instTopologicalSpaceProd _  _ (topology A) (topology A))
+    (topology A) _ _ _ Finset.univ
+  intro i _
+  apply @Continuous.smul _ _ _ (topology A) (topology A) (@instTopologicalSpaceProd _ _ (topology A) (topology A)) _ (@Module.instContinuousSMul _ _ iA _ _ _ _ _ _ ) _ _
+  · have : (fun (x : M × N) ↦ d.equivFun x.2 k) = (LinearMap.basis₁ A N κ d k) ∘ Prod.snd := by
+      ext
+      unfold LinearMap.basis₁
+      simp
+    rw [this, ← Module.topology_self]
+    apply @Continuous.comp _ _ _ (@instTopologicalSpaceProd _ _ (topology A) (topology A)) (topology A) _ _ _
+    · rw [Module.topology_self A]
+      -- another mysterious sorry
+      --apply Module.continuous_linear A (LinearMap.basis₁ A N κ d k)
+      sorry
+    rw [Module.prod_canonical]
+    exact Module.continuous_linear A (LinearMap.prodsnd A M N)
+  apply @Continuous.smul _ _ _ (topology A) (topology A) (@instTopologicalSpaceProd _ _ (topology A) (topology A)) _ (@Module.instContinuousSMul _ _ iA _ _ _ _ _ _ ) _ _
+  · have : (fun (x : M × N) ↦ b.equivFun x.1 i) = (LinearMap.basis₁ A M ι b i) ∘ Prod.fst := by
+      ext
+      unfold LinearMap.basis₁
+      simp
+    rw [this, ← Module.topology_self]
+    apply @Continuous.comp _ _ _ (@instTopologicalSpaceProd _ _ (topology A) (topology A)) (topology A) _ _ _
+    · rw [Module.topology_self A]
+      -- another mysterious sorry
+      --apply Module.continuous_linear A (LinearMap.basis₁ A M ι b i)
+      sorry
+    rw [Module.prod_canonical]
+    exact Module.continuous_linear A (LinearMap.prodfst A M N)
+  · apply @continuous_const _ _ (@instTopologicalSpaceProd _ _ (topology A) (topology A)) (topology A) _
 
 -- Note that we have multiplication as a bilinear map.
 

--- a/FLT/HIMExperiments/module_topology.lean
+++ b/FLT/HIMExperiments/module_topology.lean
@@ -270,18 +270,17 @@ instance Module.instContinuousSMul : @ContinuousSMul A M _ (topology A) (topolog
     ext
     rw [← mul_smul]
   rw [this]
-  have dcef: (fun a ↦ (a.1 * b.equivFun a.2 i) • b i) = (fun (a : A) ↦ a • b i) ∘ (fun (m : A × A) ↦ m.1 * m.2) ∘ (fun (m : A × M) ↦ (m.1, b.equivFun m.2 i)) := by
+  have : (fun a ↦ (a.1 * b.equivFun a.2 i) • b i) = (fun (a : A) ↦ a • b i) ∘ (fun (m : A × A) ↦ m.1 * m.2) ∘ (fun (m : A × M) ↦ (m.1, b.equivFun m.2 i)) := by
     ext a
     simp
-  rw [dcef]
+  rw [this]
   apply @Continuous.comp _ _ _ (@instTopologicalSpaceProd _ _ _ (topology A)) _ (topology A) _ _
   · have : (fun a ↦ a • b i) = (LinearMap.smul₁ A M (b i)) := by
       unfold LinearMap.smul₁
       simp
-    rw [this, Module.topology_self A]
-    -- this is legit the same. Why does this not work ?????
-    ---apply Module.continuous_linear A (LinearMap.smul₁ A M (b i))
-    sorry
+    rw [this]
+    nth_rewrite 1 [Module.topology_self A]
+    apply Module.continuous_linear A (LinearMap.smul₁ A M (b i))
   apply @Continuous.comp _ _ _ (@instTopologicalSpaceProd _ _ _ (topology A)) _ _ _ _
   exact continuous_mul
   apply @Continuous.prod_map _ _ _ _ _ _ _ (topology A) (fun m ↦ m) (fun m ↦ b.equivFun m i)
@@ -289,10 +288,9 @@ instance Module.instContinuousSMul : @ContinuousSMul A M _ (topology A) (topolog
   have : (fun m ↦ b.equivFun m i) = LinearMap.basis₁ A M ι b i := by
     unfold LinearMap.basis₁
     simp
-  rw [this, Module.topology_self A]
-  -- again this looks the exact same
-  --apply Module.continuous_linear A (LinearMap.basis₁ A M ι b i)
-  sorry
+  rw [this]
+  nth_rewrite 2 [Module.topology_self A]
+  apply Module.continuous_linear A (LinearMap.basis₁ A M ι b i)
 
 
 
@@ -335,10 +333,8 @@ lemma Module.continuous_bilinear {P : Type*} [AddCommGroup P] [Module A P] [Modu
       simp
     rw [this, ← Module.topology_self]
     apply @Continuous.comp _ _ _ (@instTopologicalSpaceProd _ _ (topology A) (topology A)) (topology A) _ _ _
-    · rw [Module.topology_self A]
-      -- another mysterious sorry
-      --apply Module.continuous_linear A (LinearMap.basis₁ A N κ d k)
-      sorry
+    · nth_rewrite 2 [Module.topology_self A]
+      apply Module.continuous_linear A (LinearMap.basis₁ A N κ d k)
     rw [Module.prod_canonical]
     exact Module.continuous_linear A (LinearMap.prodsnd A M N)
   apply @Continuous.smul _ _ _ (topology A) (topology A) (@instTopologicalSpaceProd _ _ (topology A) (topology A)) _ (@Module.instContinuousSMul _ _ iA _ _ _ _ _ _ ) _ _
@@ -348,10 +344,8 @@ lemma Module.continuous_bilinear {P : Type*} [AddCommGroup P] [Module A P] [Modu
       simp
     rw [this, ← Module.topology_self]
     apply @Continuous.comp _ _ _ (@instTopologicalSpaceProd _ _ (topology A) (topology A)) (topology A) _ _ _
-    · rw [Module.topology_self A]
-      -- another mysterious sorry
-      --apply Module.continuous_linear A (LinearMap.basis₁ A M ι b i)
-      sorry
+    · nth_rewrite 2 [Module.topology_self A]
+      apply Module.continuous_linear A (LinearMap.basis₁ A M ι b i)
     rw [Module.prod_canonical]
     exact Module.continuous_linear A (LinearMap.prodfst A M N)
   · apply @continuous_const _ _ (@instTopologicalSpaceProd _ _ (topology A) (topology A)) (topology A) _

--- a/FLT/HIMExperiments/module_topology.lean
+++ b/FLT/HIMExperiments/module_topology.lean
@@ -199,14 +199,6 @@ lemma Module.prod_canonical :
       rw [induced_compose]
       exact iInf_le _ (LinearMap.lcomp _ _ (LinearMap.snd _ _ _) _)
 
-/-- Basis.repr in the first variable as a linear map. -/
-noncomputable def LinearMap.basis₁ (M : Type*) (ι : Type*) [Finite ι] [AddCommGroup M] [Module A M]
-    (b : Basis ι A M) (i : ι) : M →ₗ[A] A where
-  toFun m := b.repr m i
-  map_add' := by simp only [map_add, Finsupp.coe_add, Pi.add_apply, implies_true]
-  map_smul' _ _  := by simp only [LinearMapClass.map_smul, Finsupp.coe_smul, Pi.smul_apply,
-    smul_eq_mul, RingHom.id_apply]
-
 instance Module.instCommAdd {P : Type*} [AddCommGroup P] [Module A P]:
 @ContinuousAdd P (Module.topology A) _ := by
   apply @ContinuousAdd.mk _ (topology A)
@@ -233,8 +225,7 @@ instance Module.instContinuousSMul : @ContinuousSMul A M _ _ (topology A) := by
   · exact continuous_mul
   · apply @Continuous.prod_map _ _ _ _ _ _ _ (topology A) (fun m ↦ m) (fun m ↦ b.repr m i)
     exact continuous_id
-    exact Module.continuous_linear_to_ring A (LinearMap.basis₁ A M ι b i)
-
+    exact Module.continuous_linear_to_ring A (b.coord i)
 
 lemma Module.bilinear_continuous_of_continuous_on_basis {P : Type*} {ι κ : Type*} [Fintype ι]
     [Fintype κ] [AddCommGroup P] [Module A P] [TopologicalSpace M] [TopologicalSpace N]
@@ -257,7 +248,6 @@ lemma Module.bilinear_continuous_of_continuous_on_basis {P : Type*} {ι κ : Typ
   intro i _
   exact contonbasis k i
 
--- I assume this is true! Lots of things like this seem to be true.
 lemma Module.continuous_bilinear {P : Type*} [AddCommGroup P] [Module A P] [Module.Finite A P]
     [Module.Free A P] (f : M →ₗ[A] N →ₗ[A] P) :
     let _τMN : TopologicalSpace (M × N) := Module.topology A
@@ -274,14 +264,14 @@ lemma Module.continuous_bilinear {P : Type*} [AddCommGroup P] [Module A P] [Modu
   apply Module.bilinear_continuous_of_continuous_on_basis A b d f
   intro k i
   apply Continuous.smul ?_ ?_
-  · suffices Continuous ((LinearMap.basis₁ A N κ d k) ∘ Prod.snd) from this
+  · suffices Continuous ((d.coord k) ∘ Prod.snd) from this
     apply Continuous.comp
-    · exact Module.continuous_linear_to_ring A (LinearMap.basis₁ A N κ d k)
+    · exact Module.continuous_linear_to_ring A (d.coord k)
     · exact continuous_snd
   apply Continuous.smul
-  · suffices Continuous ((LinearMap.basis₁ A M ι b i) ∘ Prod.fst) from this
+  · suffices Continuous ((b.coord i) ∘ Prod.fst) from this
     apply Continuous.comp
-    · apply Module.continuous_linear_to_ring A (LinearMap.basis₁ A M ι b i)
+    · apply Module.continuous_linear_to_ring A (b.coord i)
     · exact continuous_fst
   · apply continuous_const
 

--- a/FLT/HIMExperiments/module_topology.lean
+++ b/FLT/HIMExperiments/module_topology.lean
@@ -58,17 +58,7 @@ and target.
 --   exact (Continuous.comp (continuous_apply _) (continuous_snd))
 
 -- Non-commutative variables
-variable (B : Type*) [Ring B] [iB: TopologicalSpace B] [TopologicalRing B]
-
--- let M be an B-module
-variable {V : Type*} [AddCommGroup V] [Module B V]
-
--- let `N` be another module
-variable {W : Type*} [AddCommGroup W] [Module B W]
-
-
--- Commutative variables
-variable (A : Type*) [CommRing A] [iA: TopologicalSpace A] [TopologicalRing A]
+variable (A : Type*) [Ring A] [iA: TopologicalSpace A] [TopologicalRing A]
 
 -- let M be an A-module
 variable {M : Type*} [AddCommGroup M] [Module A M]
@@ -76,32 +66,26 @@ variable {M : Type*} [AddCommGroup M] [Module A M]
 -- let `N` be another module
 variable {N : Type*} [AddCommGroup N] [Module A N]
 
-
--- Now say we have a non-commutative `A`-algebra `D` which is free of finite type.
-variable (D : Type*) [Ring D] [Algebra A D] [Module.Finite A D] [Module.Free A D]
-
-
-
 -- Here is a conceptual way to put a topology on `M`. Let's define it to be
 -- the coarsest topology such that all `A`-linear maps from `M` to `A` are continuous
 -- (recall that `A` already has a topology). If M is free of finite rank then
 -- we'll see that this is the same as just choosing an isomorphism M = A^n and giving
 -- it the product topology
 
-/-- The "canonical topology" on a module `V` over a topological ring `B`. It's defined as
-the weakest topology on `V` which makes every `B`-linear map `V → B` continuous. -/
+/-- The "canonical topology" on a module `M` over a topological ring `A`. It's defined as
+the weakest topology on `M` which makes every `A`-linear map `M → A` continuous. -/
 -- make it an abbreviation not a definition; this means that Lean "prints `Module.topology`
 -- in the tactic state for the human reader" but interally is syntactically equal to
 -- to the `iInf`, meaning that all the `iInf` rewrites still work.
-abbrev Module.topology : TopologicalSpace V :=
+abbrev Module.topology : TopologicalSpace M :=
 -- Topology defined as greatest lower bound of pullback topologies. So it's the biggest
 -- topology making all the `f`s continuous.
-  ⨅ (f : V →ₗ[B] B), TopologicalSpace.induced f inferInstance
+  ⨅ (f : M →ₗ[A] A), TopologicalSpace.induced f inferInstance
 
 
-/-- Every `B`-linear map between two `B`-modules with the canonical topology is continuous. -/
-lemma Module.continuous_linear (e : V →ₗ[B] W) :
-    @Continuous V W (Module.topology B) (Module.topology B) e := by
+/-- Every `A`-linear map between two `A`-modules with the canonical topology is continuous. -/
+lemma Module.continuous_linear (e : M →ₗ[A] N) :
+    @Continuous M N (Module.topology A) (Module.topology A) e := by
   -- rewrite the goal (continuity of `e`) as in inequality:
   --(canonical topology) ≤ (pullback of induced topology)
   rw [continuous_iff_le_induced]
@@ -120,26 +104,26 @@ lemma Module.continuous_linear (e : V →ₗ[B] W) :
   exact ⟨φ ∘ₗ e, rfl⟩
 
 -- A formal corollary should be that
-def Module.homeomorphism_equiv (e : V ≃ₗ[B] W) :
+def Module.homeomorphism_equiv (e : M ≃ₗ[A] N) :
     -- lean needs to be told the topologies explicitly in the statement
-    let _τM : TopologicalSpace V := Module.topology B
-    let _τN : TopologicalSpace W := Module.topology B
-    V ≃ₜ W :=
+    let _τM : TopologicalSpace M := Module.topology A
+    let _τN : TopologicalSpace N := Module.topology A
+    M ≃ₜ N :=
   -- And also at the point where lean puts the structure together, unfortunately
-  let _τM : TopologicalSpace V := Module.topology B
-  let _τN : TopologicalSpace W := Module.topology B
+  let _τM : TopologicalSpace M := Module.topology A
+  let _τN : TopologicalSpace N := Module.topology A
   -- all the sorries should be formal.
   { toFun := e
     invFun := e.symm
     left_inv := e.left_inv
     right_inv := e.right_inv
-    continuous_toFun := Module.continuous_linear B e
-    continuous_invFun := Module.continuous_linear B e.symm
+    continuous_toFun := Module.continuous_linear A e
+    continuous_invFun := Module.continuous_linear A e.symm
   }
 
 -- sanity check: the topology on A^n is the product topology
 example (ι : Type*) [Finite ι] :
-    (Pi.topologicalSpace : TopologicalSpace (ι → B)) = Module.topology B := by
+    (Pi.topologicalSpace : TopologicalSpace (ι → A)) = Module.topology A := by
   -- suffices to prove that each topology is ≤ the other one
   apply le_antisymm
   · -- you're ≤ `iInf S` iff you're ≤ all elements of `S`
@@ -161,25 +145,33 @@ example (ι : Type*) [Finite ι] :
     -- it's linear, because Lean has the projections as linear maps.
     exact ⟨LinearMap.proj i, rfl⟩
 
---! Needs CommRing A
+-- Commutative variables
+variable (A : Type*) [CommRing A] [iA: TopologicalSpace A] [TopologicalRing A]
+
+-- let M be an A-module
+variable {M : Type*} [AddCommGroup M] [Module A M]
+
+-- let `N` be another module
+variable {N : Type*} [AddCommGroup N] [Module A N]
+
+-- Now say we have a non-commutative `A`-algebra `D` which is free of finite type.
+variable (D : Type*) [Ring D] [Algebra A D] [Module.Finite A D] [Module.Free A D]
+
 lemma Module.topology_self : (iA :TopologicalSpace A) = Module.topology A := by
   refine le_antisymm (le_iInf (fun i ↦ ?_)) <| sInf_le ⟨LinearMap.id, induced_id⟩
   rw [← continuous_iff_le_induced, show i = LinearMap.lsmul A A (i 1) by ext; simp]
   exact continuous_const.mul continuous_id
 
---! topology_self Needs CommRing A
 lemma Module.continuous_linear_from_ring (e : A →ₗ[A] M) :
     @Continuous A M _ (Module.topology A) e := by
   nth_rw 1 [Module.topology_self A]
   exact Module.continuous_linear A e
 
---! topology_self Needs CommRing A
 lemma Module.continuous_linear_to_ring (e : M →ₗ[A] A) :
     @Continuous M A (Module.topology A) _ e := by
   nth_rw 2 [Module.topology_self A]
   exact Module.continuous_linear A e
 
---! Module.continuous_linear_to_ring Needs CommRing A
 lemma LinearMap.continuous_on_prod (f : (M × N) →ₗ[A] A) :
     @Continuous _ _ (@instTopologicalSpaceProd M N (Module.topology A) (Module.topology A)) _ f := by
   let _τM : TopologicalSpace M := Module.topology A
@@ -200,7 +192,6 @@ lemma LinearMap.continuous_on_prod (f : (M × N) →ₗ[A] A) :
         map_smul' := by intro m x; rw [← LinearMap.map_smul,
           RingHom.id_apply, Prod.smul_mk, smul_zero]})
 
---! LinearMap.continuous_on_prod Needs CommRing A
 -- We need that the module topology on a product is the product topology
 lemma Module.prod_canonical :
     @instTopologicalSpaceProd M N (Module.topology A) (Module.topology A) =
@@ -223,7 +214,6 @@ lemma Module.prod_canonical :
       rw [induced_compose]
       exact iInf_le _ (LinearMap.lcomp _ _ (LinearMap.snd _ _ _) _)
 
---! prod_canonical Needs CommRing A
 instance Module.instCommAdd {P : Type*} [AddCommGroup P] [Module A P]:
 @ContinuousAdd P (Module.topology A) _ := by
   apply @ContinuousAdd.mk _ (topology A)
@@ -232,7 +222,6 @@ instance Module.instCommAdd {P : Type*} [AddCommGroup P] [Module A P]:
 
 variable [Module.Finite A M] [Module.Free A M] [Module.Finite A N] [Module.Free A N]
 
---! continuous_linear_from_ring Needs CommRing A therefore the rest does too
 instance Module.instContinuousSMul : @ContinuousSMul A M _ _ (topology A) := by
   let _τM : TopologicalSpace M := Module.topology A
   apply @ContinuousSMul.mk A M _ _ (topology A)


### PR DESCRIPTION
Proof of continuous_bilinear under the conditions that the modules  ``A M`` and ``A N`` are free and finite. For this we added:

- def LinearMap.smul₁ /.smul₂ the definition of left and right scalar multiplication
- instance Module.instContinuousSMul show scalar multiplicationis Continuous
- def LinearMap.prodfst /.prodsnd the definition of the projection of the product space on its components
- instance Module.instCommAdd show addition is commutative
- def LinearMap.basis₁ representation of object by there basis
- lemma continuous_bilinear