### PR TITLE
Blueprint: Fix label error

### DIFF
--- a/blueprint/src/chapter/ch07exampleGLn.tex
+++ b/blueprint/src/chapter/ch07exampleGLn.tex
@@ -142,7 +142,7 @@ From here on there is no more Lean right now, only LaTeX.
   \label{AutomorphicForm.GLn.AutomorphicFormForGLnOverQ}
   \lean{AutomorphicForm.GLn.AutomorphicFormForGLnOverQ}
   \uses{AutomorphicForm.GLn.IsSmooth, AutomorphicForm.GLn.IsSlowlyIncreasing,
-    AutomorphicForm.GLn.weight, instCentreAction}
+    AutomorphicForm.GLn.Weight, instCentreAction}
   A smooth function $f:\GL_n(\A_{\Q}^f)\times\GL_n(\R)\to\bbC$ is
   an $O_n(\R)$-\emph{automorphic form} on $\GL_n(\A_{\Q})$ if it satisfies the following
   five conditions.


### PR DESCRIPTION
Fix LaTeX error: 

> ERROR: Label 'AutomorphicForm.GLn.weight' could not be resolved