### PR TITLE
Bump GitHub actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build project
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
         run: ~/.elan/bin/lake build FLT
 
       - name: Cache mathlib docs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .lake/build/doc/Init
@@ -88,7 +88,7 @@ jobs:
         run: |
           sudo chown -R runner docs
           cp -r .lake/build/doc docs/docs
-      
+
       - name: Bundle dependencies
         uses: ruby/setup-ruby@v1
         with:
@@ -101,18 +101,18 @@ jobs:
         run: JEKYLL_ENV=production bundle exec jekyll build
 
       - name: Upload docs & blueprint artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/
 
       - name: Upload docs & blueprint artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/_site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
 
       - name: Make sure the cache works
         run: |

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build project
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Changes

- [x] Bump actions/cache from 3 to 4
- [x] Bump actions/upload-pages-artifact from 1 to 3
- [x] Bump actions/deploy-pages from 1 to 4
- [x] Bump actions/checkout from 2 to 4

## Effects

- Solved all warnings 
- Disk space usage seems to be reduced significantly, but I think it's nothing but a change in the variable displayed (from uncompressed to compressed size)