### PR TITLE
Deduplicate upload action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -103,11 +103,6 @@ jobs:
       - name: Upload docs & blueprint artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/
-
-      - name: Upload docs & blueprint artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
           path: docs/_site
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
There is no reason for "Upload docs & blueprint artifact" action to exist twice, and indeed its duplication is currently causing CI to fail.