### PR TITLE
[BLUEPRINT]: Make the dependency graph colour scheme explicit

### DIFF
--- a/blueprint/src/web.tex
+++ b/blueprint/src/web.tex
@@ -19,6 +19,15 @@
 \github{https://github.com/ImperialCollegeLondon/FLT/}
 \dochome{https://ImperialCollegeLondon.github.io/FLT/docs}
 
+% Configure the color scheme and legend description: \graphcolor{node_type}{color}{description}
+\graphcolor{stated}{green}{Green}              % Default values: stated, green, Green
+\graphcolor{can_state}{blue}{Blue}             % Default values: can_state, blue, Blue
+\graphcolor{not_ready}{#FFAA33}{Orange}        % Default values: not_ready, #FFAA33, Orange
+\graphcolor{proved}{#9CEC8B}{Green}            % Default values: proved, #9CEC8B, Green
+\graphcolor{can_prove}{#A3D6FF}{Blue}          % Default values: can_prove, #A3D6FF, Blue
+\graphcolor{defined}{#B0ECA3}{Light green}     % Default values: defined, #B0ECA3, Light green
+\graphcolor{fully_proved}{#1CAC78}{Dark green} % Default values: fully_proved, #1CAC78, Dark green
+
 \title{A Blueprint for Fermat's Last Theorem}
 \author{Kevin Buzzard, Richard Taylor}
 


### PR DESCRIPTION
This PR makes the dependency graph’s color scheme explicit and easily editable.

Closes #69