### PR TITLE
fix: TotallyDefiniteQuaternionAlgebra.AutomorphicForm.add should not be an instance

### DIFF
--- a/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
@@ -107,7 +107,7 @@ instance : Neg (AutomorphicForm F D R W U χ) where
 theorem neg_apply (φ : AutomorphicForm F D R W U χ) (x : (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ) :
     (-φ : AutomorphicForm F D R W U χ) x = -(φ x) := rfl
 
-instance add (φ ψ : AutomorphicForm F D R W U χ) : AutomorphicForm F D R W U χ where
+def add (φ ψ : AutomorphicForm F D R W U χ) : AutomorphicForm F D R W U χ where
   toFun x := φ x + ψ x
   left_invt := by simp [left_invt]
   has_character := by simp [has_character]


### PR DESCRIPTION
Noticed because it causes an error in documentation generation:

PANIC at _private.DocGen4.Process.InstanceInfo.0.DocGen4.Process.InstanceInfo.ofDefinitionInfo DocGen4.Process.InstanceInfo:50:39: isClass? on TotallyDefiniteQuaternionAlgebra.AutomorphicForm.add returned none