### PR TITLE
chore: update lakefile.toml to compile FLT file, not FLT dir

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -16,4 +16,4 @@ git = "https://github.com/PatrickMassot/checkdecls.git"
 
 [[lean_lib]]
 name = "FLT"
-globs = ["FLT.*", "FermatsLastTheorem"]
+globs = ["FLT", "FermatsLastTheorem"]


### PR DESCRIPTION
Now we use FLT.lean we don't need to compile `FLT.*`, we can just compile `FLT`.