### PR TITLE
The map B tensor_A O_v -> \prod_{w|v} O_w is an isomorphism (#329)

### DIFF
--- a/FLT/DedekindDomain/AdicValuation.lean
+++ b/FLT/DedekindDomain/AdicValuation.lean
@@ -8,9 +8,9 @@ import Mathlib.Algebra.Algebra.Subalgebra.Pi
 
 # Adic Completions
 
-If `A` is a valued ring with field of fractions `K` there are two ways one
-might define the integers of the completion `K_v`, first by
-`𝒪_v = {x ∈ K_v | v x ≤ 1}` and second by taking the `v-adic` completion of `A`.
+If `A` is a valued ring with field of fractions `K` there are two different
+complete rings containing `A` one might define, the first is
+`𝒪_v = {x ∈ K_v | v x ≤ 1}` and the second is the `v-adic` completion of `A`.
 In the case when `A` is a Dedekind domain these definitions give isomorphic
 topological `A`-algebras. This file makes some progress towards this.
 

--- a/FLT/DedekindDomain/AdicValuation.lean
+++ b/FLT/DedekindDomain/AdicValuation.lean
@@ -132,7 +132,7 @@ lemma exists_adicValued_sub_lt_of_adicValued_le_one { x : (WithVal (v.valuation 
       HeightOneSpectrum.intValuation_apply]
   apply lt_of_le_of_lt hval hku
 
-/-- The closure of `A` in `K_v` is `O_[K_v]`. -/
+/-- The closure of `A` in `K_v` is `𝒪_v`. -/
 theorem closureAlgebraMapIntegers_eq_integers :
     closure (algebraMap A (v.adicCompletion K)).range =
     SetLike.coe (v.adicCompletionIntegers K) := by
@@ -140,7 +140,7 @@ theorem closureAlgebraMapIntegers_eq_integers :
   . apply closure_minimal _ Valued.valuationSubring_isClosed
     rintro b ⟨a, rfl⟩
     exact HeightOneSpectrum.coe_mem_adicCompletionIntegers v a
-  -- Show `O_[K_v] ⊆ closure A` from `O_[K_v] ⊆ closure O_[K]` and `closure O_[K] ⊆ closure A`
+  -- Show `𝒪_v ⊆ closure A` from `𝒪_v ⊆ closure O_[K]` and `closure O_[K] ⊆ closure A`
   let f := fun (k : WithVal (v.valuation K)) => (k : v.adicCompletion K)
   suffices h : closure (f '' (f ⁻¹' (HeightOneSpectrum.adicCompletionIntegers K v))) ⊆
       closure (algebraMap A (HeightOneSpectrum.adicCompletion K v)).range by
@@ -165,7 +165,7 @@ theorem closureAlgebraMapIntegers_eq_integers :
   apply hγ
   simpa
 
-/-- A is dense in `O_[K_v]`. -/
+/-- A is dense in `𝒪_v`. -/
 theorem denseRange_of_integerAlgebraMap :
     DenseRange (algebraMap A (v.adicCompletionIntegers K)) := by
   rw [denseRange_iff_closure_range]
@@ -179,7 +179,7 @@ theorem denseRange_of_integerAlgebraMap :
   simp only [RingHom.coe_range, ← Set.range_comp']
   rfl
 
-/-- An element of `O_[K_v]` can be approximated by an element of `A`. -/
+/-- An element of `𝒪_v` can be approximated by an element of `A`. -/
 theorem exists_adicValued_sub_lt_of_adicCompletionInteger ( x : v.adicCompletionIntegers K )
     ( γ : (WithZero (Multiplicative ℤ))ˣ ) :
     ∃a, Valued.v ((algebraMap A K a) - (x : v.adicCompletion K)) < γ.val := by
@@ -196,7 +196,7 @@ theorem exists_adicValued_sub_lt_of_adicCompletionInteger ( x : v.adicCompletion
   rw [HeightOneSpectrum.algebraMap_adicCompletion, Function.comp_apply] at ha
   rwa [ha]
 
-/-- An element of `∏_{v ∈ s} O_[K_v]`, with `s` finite, can be approximated by an element of `A`.
+/-- An element of `∏_{v ∈ s} 𝒪_v`, with `s` finite, can be approximated by an element of `A`.
   -/
 theorem exists_forall_adicValued_sub_lt {ι : Type*} (s : Finset ι)
     (e : ι → (WithZero (Multiplicative ℤ))ˣ ) (valuation : ι → HeightOneSpectrum A)
@@ -253,7 +253,7 @@ theorem exists_forall_adicValued_sub_lt {ι : Type*} (s : Finset ι)
     add_comm_sub, add_sub, eq_sub_iff_add_eq]
   rfl
 
-/-- The closure of `A` in `∏_{v ∈ s} K_v` is `∏_{v ∈ s} O_[K_v]`. `s` may be infinite. -/
+/-- The closure of `A` in `∏_{v ∈ s} K_v` is `∏_{v ∈ s} 𝒪_v`. `s` may be infinite. -/
 theorem closureAlgebraMapIntegers_eq_prodIntegers {ι : Type*}
     (valuation : ι → HeightOneSpectrum A) (injective : Function.Injective valuation) :
     closure (SetLike.coe (algebraMap A ((i : ι) → (valuation i).adicCompletion K)).range) =

--- a/FLT/DedekindDomain/AdicValuation.lean
+++ b/FLT/DedekindDomain/AdicValuation.lean
@@ -1,7 +1,6 @@
 import FLT.Mathlib.Topology.Algebra.Valued.ValuationTopology
 import Mathlib.Topology.Algebra.Valued.NormedValued
 import Mathlib.RingTheory.DedekindDomain.AdicValuation
-import Mathlib.RingTheory.DedekindDomain.Dvr
 import Mathlib.Algebra.Algebra.Subalgebra.Pi
 import Mathlib.Algebra.Order.GroupWithZero.Canonical
 
@@ -57,7 +56,7 @@ lemma exists_approxInverse { a b : A } { n : ℕ } ( hnz : a ≠ 0 )
       Ideal.dvd_span_singleton, neg_mem_iff]
 
 open scoped Multiplicative in
-lemma mul_int_lower_bound { x y : ℤₘ₀ } ( hx : x ≠ 0 ) ( hy : y ≠ 0) :
+lemma exists_ofAdd_lt_and_ofAdd_lt { x y : ℤₘ₀ } ( hx : x ≠ 0 ) ( hy : y ≠ 0) :
     ∃ (k : ℕ), (Multiplicative.ofAdd (-(k : ℤ))) < x ∧ (Multiplicative.ofAdd (-(k : ℤ))) < y := by
   let u := WithZero.unzero hx
   let v := WithZero.unzero hy
@@ -79,7 +78,9 @@ lemma mul_int_lower_bound { x y : ℤₘ₀ } ( hx : x ≠ 0 ) ( hy : y ≠ 0) :
     rfl
   decide
 
-lemma approx_of_valued_le_one { x : (WithVal (v.valuation K)) }
+/-- An element of `K` with valuation ≤ 1 can be approximated by an element of `A`.
+  -/
+lemma exists_adicValued_sub_lt_of_adicValued_le_one { x : (WithVal (v.valuation K)) }
     ( γ : (WithZero (Multiplicative ℤ))ˣ ) ( hx : Valued.v x ≤ 1 ) :
     ∃a, Valued.v ((algebraMap A K a) - (x : v.adicCompletion K)) < γ.val := by
   obtain ⟨⟨n, d, hd⟩, hnd⟩ := IsLocalization.surj (nonZeroDivisors A) x
@@ -104,7 +105,7 @@ lemma approx_of_valued_le_one { x : (WithVal (v.valuation K)) }
   let hu : Valued.v ((algebraMap A (WithVal (v.valuation K)) d)) * γ.val ≠ 0 := by
     rw [mul_ne_zero_iff]
     exact ⟨hv, γ.ne_zero⟩
-  obtain ⟨k, hku, hkv⟩ := mul_int_lower_bound hu hv
+  obtain ⟨k, hku, hkv⟩ := exists_ofAdd_lt_and_ofAdd_lt hu hv
   simp only [WithVal, HeightOneSpectrum.adicValued_apply,
     HeightOneSpectrum.valuation_of_algebraMap, HeightOneSpectrum.intValuation_apply] at hkv
   obtain ⟨a, hval⟩ := exists_approxInverse v (nonZeroDivisors.ne_zero hd) hkv.le hge
@@ -119,22 +120,20 @@ lemma approx_of_valued_le_one { x : (WithVal (v.valuation K)) }
       HeightOneSpectrum.intValuation_apply]
   apply lt_of_le_of_lt hval hku
 
+/-- The closure of `A` in `K_v` is `O_[K_v]`. -/
 theorem closureAlgebraMapIntegers_eq_integers :
     closure (algebraMap A (v.adicCompletion K)).range =
     SetLike.coe (v.adicCompletionIntegers K) := by
-  have hopen : IsOpen (SetLike.coe (v.adicCompletionIntegers K)) := by
-    apply Valued.integer_isOpen
-  let f := fun (k : WithVal (v.valuation K)) => (k : v.adicCompletion K)
-  have hd : DenseRange f := by
-    apply UniformSpace.Completion.denseRange_coe
   apply subset_antisymm
   . apply closure_minimal _ Valued.valuationSubring_isClosed
     rintro b ⟨a, rfl⟩
     exact HeightOneSpectrum.coe_mem_adicCompletionIntegers v a
+  let f := fun (k : WithVal (v.valuation K)) => (k : v.adicCompletion K)
   suffices h : closure (algebraMap A (HeightOneSpectrum.adicCompletion K v)).range =
       closure (f '' (f ⁻¹' (HeightOneSpectrum.adicCompletionIntegers K v))) by
     rw [h]
-    exact DenseRange.subset_closure_image_preimage_of_isOpen hd hopen
+    exact DenseRange.subset_closure_image_preimage_of_isOpen
+      UniformSpace.Completion.denseRange_coe (Valued.valuationSubring_isOpen _)
   apply subset_antisymm
   . apply closure_mono
     rintro b ⟨a, rfl⟩
@@ -142,27 +141,26 @@ theorem closureAlgebraMapIntegers_eq_integers :
     rw [Set.mem_preimage, SetLike.mem_coe]
     constructor
     . exact HeightOneSpectrum.coe_algebraMap_mem A K v a
-    unfold f
     rw [HeightOneSpectrum.algebraMap_adicCompletion, Function.comp_apply]
   apply closure_minimal _ isClosed_closure
   rintro k ⟨x, hx, rfl⟩
-  rw [mem_closure_iff_nhds_zero]
-  intro U hU
-  rw [Valued.mem_nhds] at hU
   unfold f at hx
   rw [Set.mem_preimage, SetLike.mem_coe, HeightOneSpectrum.mem_adicCompletionIntegers,
       Valued.valuedCompletion_apply, HeightOneSpectrum.adicValued_apply'] at hx
+  rw [mem_closure_iff_nhds_zero]
+  intro U hU
+  rw [Valued.mem_nhds] at hU
   obtain ⟨γ, hγ⟩ := hU
-  obtain ⟨a, ha⟩ := approx_of_valued_le_one K v γ hx
+  obtain ⟨a, ha⟩ := exists_adicValued_sub_lt_of_adicValued_le_one K v γ hx
   use algebraMap A K a
   constructor
   . use a
     rfl
   apply hγ
-  simp only [sub_zero, Set.mem_setOf_eq]
-  exact ha
+  simpa
 
-theorem denseRange_of_integerAlgerbaMap :
+/-- A is dense in `O_[K_v]`. -/
+theorem denseRange_of_integerAlgebraMap :
     DenseRange (algebraMap A (v.adicCompletionIntegers K)) := by
   rw [denseRange_iff_closure_range]
   ext x
@@ -175,7 +173,8 @@ theorem denseRange_of_integerAlgerbaMap :
   simp only [RingHom.coe_range, ← Set.range_comp']
   rfl
 
-theorem completionInteger_approx_eq_integer ( x : v.adicCompletionIntegers K )
+/-- An element of `O_[K_v]` can be approximated by an element of `A`. -/
+theorem exists_adicValued_sub_lt_of_adicCompletionInteger ( x : v.adicCompletionIntegers K )
     ( γ : (WithZero (Multiplicative ℤ))ˣ ) :
     ∃a, Valued.v ((algebraMap A K a) - (x : v.adicCompletion K)) < γ.val := by
   have h := closureAlgebraMapIntegers_eq_integers K v
@@ -191,7 +190,9 @@ theorem completionInteger_approx_eq_integer ( x : v.adicCompletionIntegers K )
   rw [HeightOneSpectrum.algebraMap_adicCompletion, Function.comp_apply] at ha
   rwa [ha]
 
-theorem prodCompletionInteger_approx_eq_integer {ι : Type*} (s : Finset ι)
+/-- An element of `∏_{v ∈ s} O_[K_v]`, with `s` finite, can be approximated by an element of `A`.
+  -/
+theorem exists_forall_adicValued_sub_lt {ι : Type*} (s : Finset ι)
     (e : ι → (WithZero (Multiplicative ℤ))ˣ ) (valuation : ι → HeightOneSpectrum A)
     (injective : Function.Injective valuation)
     (x : (i : ι) → (valuation i).adicCompletionIntegers K) :
@@ -215,16 +216,20 @@ theorem prodCompletionInteger_approx_eq_integer {ι : Type*} (s : Finset ι)
       apply le_of_eq (Int.neg_neg (WithZero.unzero (e i).ne_zero))
     . norm_cast
     apply Units.zero_lt
-  have hinj : ∀ i ∈ s, ∀ j ∈ s, i ≠ j → (fun i ↦ (valuation i).asIdeal) i ≠ (fun i ↦ (valuation i).asIdeal) j := by
+  have hinj : ∀ i ∈ s, ∀ j ∈ s, i ≠ j →
+      (fun i ↦ (valuation i).asIdeal) i ≠ (fun i ↦ (valuation i).asIdeal) j := by
     intro i hi j hj
     contrapose!
     intro hij
     apply injective
     apply HeightOneSpectrum.ext hij
-  let f (i : s) : A := (completionInteger_approx_eq_integer K (valuation i) (x i) (e i)).choose
+  let f (i : s) : A :=
+    (exists_adicValued_sub_lt_of_adicCompletionInteger K (valuation i) (x i) (e i)).choose
   have hf : ∀ (i : s), Valued.v (((algebraMap A K) (f i)) - (x i : (valuation i).adicCompletion K))
       < (e i) :=
-    fun (i : s) => (completionInteger_approx_eq_integer K (valuation i) (x i) (e i)).choose_spec
+    fun (i : s) =>
+      (exists_adicValued_sub_lt_of_adicCompletionInteger K (valuation i) (x i) (e i)).choose_spec
+
   obtain ⟨a, ha⟩ := IsDedekindDomain.exists_forall_sub_mem_ideal (s := s)
     (fun i => (valuation i).asIdeal) e' (fun i hi => (valuation i).prime) hinj f
   use a
@@ -232,18 +237,17 @@ theorem prodCompletionInteger_approx_eq_integer {ι : Type*} (s : Finset ι)
   specialize ha i hi
   specialize hf ⟨i, hi⟩
   rw [← Ideal.dvd_span_singleton, ← HeightOneSpectrum.intValuation_le_pow_iff_dvd,
-      ← HeightOneSpectrum.intValuation_apply,
-      ← HeightOneSpectrum.valuation_of_algebraMap (K := K),
-      ← HeightOneSpectrum.valuedAdicCompletion_eq_valuation,
-      algebraMap.coe_sub] at ha
-  apply lt_of_le_of_lt _ (Valuation.map_add_lt _ (ha.trans_lt (he' i)) hf)
+      ← HeightOneSpectrum.intValuation_apply, ← HeightOneSpectrum.valuation_of_algebraMap (K := K),
+      ← HeightOneSpectrum.valuedAdicCompletion_eq_valuation, algebraMap.coe_sub] at ha
+  refine lt_of_le_of_lt ?_ (Valuation.map_add_lt _ (ha.trans_lt (he' i)) hf)
   apply le_of_eq
   congr
   rw [add_sub, sub_eq_sub_iff_add_eq_add, add_right_cancel_iff,
     add_comm_sub, add_sub, eq_sub_iff_add_eq]
   rfl
 
-theorem closureAlgebraMapIntergers_eq_prodIntegers {ι : Type*}
+/-- The closure of `A` in `∏_{v ∈ s} K_v` is `∏_{v ∈ s} O_[K_v]`. `s` may be infinite. -/
+theorem closureAlgebraMapIntegers_eq_prodIntegers {ι : Type*}
     (valuation : ι → HeightOneSpectrum A) (injective : Function.Injective valuation) :
     closure (SetLike.coe (algebraMap A ((i : ι) → (valuation i).adicCompletion K)).range) =
     (Set.pi Set.univ (fun (i : ι) ↦ HeightOneSpectrum.adicCompletionIntegers K (valuation i))) := by
@@ -264,8 +268,7 @@ theorem closureAlgebraMapIntergers_eq_prodIntegers {ι : Type*}
   obtain ⟨g, hg⟩ := Classical.axiomOfChoice
     (fun w => (Valued.is_topological_valuation (t w)).mp (htn w))
   obtain ⟨a, ha⟩ :=
-    prodCompletionInteger_approx_eq_integer K I g
-      valuation injective (fun w => ⟨f w, hf w ⟨⟩⟩)
+    exists_forall_adicValued_sub_lt K I g valuation injective (fun w => ⟨f w, hf w ⟨⟩⟩)
   use algebraMap A _ a
   constructor
   . rw [RingHom.coe_range]

--- a/FLT/DedekindDomain/DenseIntegers.lean
+++ b/FLT/DedekindDomain/DenseIntegers.lean
@@ -1,0 +1,273 @@
+import FLT.Mathlib.Topology.Algebra.Valued.ValuationTopology
+import Mathlib.Topology.Algebra.Valued.NormedValued
+import Mathlib.RingTheory.DedekindDomain.AdicValuation
+import Mathlib.Algebra.Algebra.Subalgebra.Pi
+import Mathlib.Algebra.Order.GroupWithZero.Canonical
+
+namespace IsDedekindDomain
+
+variable { A : Type* } ( K : Type* ) [CommRing A] [Field K] [Algebra A K] [IsFractionRing A K]
+    [IsDedekindDomain A] (v : HeightOneSpectrum A)
+
+/-- `IsDedekindDomain.irreducible_pow_sup_of_ge`, stated using intValuation instead of
+    multiplicity -/
+lemma asIdeal_pow_sup_of_ge { a : A } { k n : ℕ } ( hnz : a ≠ 0 ) ( hle : k ≤ n )
+    (hv : (Multiplicative.ofAdd (-(k : ℤ))) = v.intValuationDef a) :
+    v.asIdeal ^ n ⊔ Ideal.span {a} = v.asIdeal ^ k := by
+  classical
+  have hnb : Ideal.span {a} ≠ ⊥ := by
+    rwa [ne_eq, Ideal.span_singleton_eq_bot]
+  have hk : emultiplicity v.asIdeal (Ideal.span {a}) = k := by
+    rw [HeightOneSpectrum.intValuationDef_if_neg _ hnz] at hv
+    simp only [ofAdd_neg, WithZero.coe_inv, inv_inj, WithZero.coe_inj,
+        EmbeddingLike.apply_eq_iff_eq, Nat.cast_inj] at hv
+    rw [hv, UniqueFactorizationMonoid.emultiplicity_eq_count_normalizedFactors v.irreducible hnb,
+        count_associates_factors_eq hnb v.isPrime v.ne_bot, normalize_eq]
+  have hm : emultiplicity v.asIdeal (Ideal.span {a}) ≤ n :=
+    le_of_eq_of_le hk (ENat.coe_le_coe.mpr hle)
+  rw [irreducible_pow_sup_of_ge hnb (HeightOneSpectrum.irreducible v) n hm]
+  congr
+  exact multiplicity_eq_of_emultiplicity_eq_some hk
+
+-- This should probably make use of the multiplicity
+lemma exists_nat_coeEq_intValuation { a : A } ( hnz : a ≠ 0 ) :
+    ∃ (n : ℕ), v.intValuationDef a = (Multiplicative.ofAdd (-(n : ℤ))) := by
+  classical
+  rw [HeightOneSpectrum.intValuationDef_if_neg _ hnz]
+  exact Exists.intro ((Associates.mk v.asIdeal).count (Associates.mk (Ideal.span {a})).factors) rfl
+
+lemma exists_approxInverse { a b : A } { n : ℕ } ( hnz : a ≠ 0 )
+  ( hle : Multiplicative.ofAdd (-(n : ℤ)) ≤ v.intValuationDef a)
+  ( hle' : v.intValuationDef b ≤ v.intValuationDef a ) :
+    ∃ y, v.intValuationDef (y * a - b) ≤ (Multiplicative.ofAdd (-(n : ℤ))) := by
+  obtain ⟨k, hk⟩ := exists_nat_coeEq_intValuation v hnz
+  rw [hk, WithZero.coe_le_coe, Multiplicative.ofAdd_le, neg_le_neg_iff, Int.ofNat_le] at hle
+  have hb : b ∈ v.asIdeal ^ k := by
+    rwa [← Ideal.dvd_span_singleton, ← HeightOneSpectrum.intValuation_le_pow_iff_dvd, ← hk]
+  rw [← asIdeal_pow_sup_of_ge v hnz hle hk.symm] at hb
+  obtain ⟨x, hx, z, hz, hxz⟩ := Submodule.mem_sup.mp hb
+  obtain ⟨y, hy⟩ := Ideal.mem_span_singleton'.mp hz
+  use y
+  rwa [hy, ← hxz, sub_add_cancel_right, HeightOneSpectrum.intValuation_le_pow_iff_dvd,
+      Ideal.dvd_span_singleton, neg_mem_iff]
+
+open scoped Multiplicative in
+lemma mul_int_lower_bound { x y : ℤₘ₀ } ( hx : x ≠ 0 ) ( hy : y ≠ 0) :
+    ∃ (k : ℕ), (Multiplicative.ofAdd (-(k : ℤ))) < x ∧ (Multiplicative.ofAdd (-(k : ℤ))) < y := by
+  let u := WithZero.unzero hx
+  let v := WithZero.unzero hy
+  use (u⁻¹.toNat ⊔ v⁻¹.toNat) + 1
+  rw [← WithZero.coe_unzero hx, ← WithZero.coe_unzero hy]
+  simp only [WithZero.coe_lt_coe, ofAdd_neg, inv_lt', ofAdd_add, Lean.Omega.Int.ofNat_max,
+    Int.natCast_add]
+  constructor
+  . apply lt_mul_of_le_of_one_lt
+    . apply le_sup_of_le_left
+      rw [Int.ofNat_toNat, le_sup_iff]
+      left
+      rfl
+    decide
+  apply lt_mul_of_le_of_one_lt
+  . apply le_sup_of_le_right
+    rw [Int.ofNat_toNat, le_sup_iff]
+    left
+    rfl
+  decide
+
+lemma approx_of_valued_le_one { x : (WithVal (v.valuation K)) }
+    ( γ : (WithZero (Multiplicative ℤ))ˣ ) ( hx : Valued.v x ≤ 1 ) :
+    ∃a, Valued.v ((algebraMap A K a) - (x : v.adicCompletion K)) < γ.val := by
+  obtain ⟨⟨n, d, hd⟩, hnd⟩ := IsLocalization.surj (nonZeroDivisors A) x
+  dsimp only at hnd
+  have hnd' := congr_arg Valued.v hnd
+  simp only [HeightOneSpectrum.adicValued_apply', map_mul] at hnd'
+  have hge : Valued.v ((algebraMap A (WithVal (v.valuation K))) d) ≥
+      Valued.v ((algebraMap A (WithVal (v.valuation K))) n) :=
+    calc Valued.v ((algebraMap A (WithVal (v.valuation K))) d)
+          ≥ (HeightOneSpectrum.valuation K v) x *
+            (HeightOneSpectrum.valuation K v) ((algebraMap A (WithVal (v.valuation K))) d) :=
+                mul_le_of_le_one_left' hx
+        _ = Valued.v ((algebraMap A (WithVal (v.valuation K))) n) := hnd'
+  simp only [HeightOneSpectrum.adicValued_apply', ge_iff_le,
+    WithVal, HeightOneSpectrum.adicValued_apply,
+    HeightOneSpectrum.valuation_of_algebraMap] at hge
+  have hdz : (algebraMap A (WithVal (v.valuation K)) d) ≠ 0 :=
+    IsLocalization.to_map_ne_zero_of_mem_nonZeroDivisors _ (fun _ ↦ id) hd
+  have hv : Valued.v ((algebraMap A (WithVal (v.valuation K)) d)) ≠ 0 := by
+    rw [Valuation.ne_zero_iff]
+    exact hdz
+  let hu : Valued.v ((algebraMap A (WithVal (v.valuation K)) d)) * γ.val ≠ 0 := by
+    rw [mul_ne_zero_iff]
+    exact ⟨hv, γ.ne_zero⟩
+  obtain ⟨k, hku, hkv⟩ := mul_int_lower_bound hu hv
+  simp only [WithVal, HeightOneSpectrum.adicValued_apply,
+    HeightOneSpectrum.valuation_of_algebraMap, HeightOneSpectrum.intValuation_apply] at hkv
+  obtain ⟨a, hval⟩ := exists_approxInverse v (nonZeroDivisors.ne_zero hd) hkv.le hge
+  use a
+  rw [← eq_div_iff_mul_eq hdz] at hnd
+  rw [← UniformSpace.Completion.coe_sub,
+      HeightOneSpectrum.valuedAdicCompletion_eq_valuation',
+      hnd, sub_div' hdz, map_div₀]
+  unfold WithVal at hdz ⊢
+  rw [← Valuation.pos_iff (HeightOneSpectrum.valuation K v)] at hdz
+  rw [← map_mul, ← map_sub, div_lt_iff₀' hdz, HeightOneSpectrum.valuation_of_algebraMap,
+      HeightOneSpectrum.intValuation_apply]
+  apply lt_of_le_of_lt hval hku
+
+theorem closureAlgebraMapIntegers_eq_integers :
+    closure (algebraMap A (v.adicCompletion K)).range =
+    SetLike.coe (v.adicCompletionIntegers K) := by
+  have hopen : IsOpen (SetLike.coe (v.adicCompletionIntegers K)) := by
+    apply Valued.integer_isOpen
+  let f := fun (k : WithVal (v.valuation K)) => (k : v.adicCompletion K)
+  have hd : DenseRange f := by
+    apply UniformSpace.Completion.denseRange_coe
+  apply subset_antisymm
+  . apply closure_minimal _ Valued.valuationSubring_isClosed
+    rintro b ⟨a, rfl⟩
+    exact HeightOneSpectrum.coe_mem_adicCompletionIntegers v a
+  suffices h : closure (algebraMap A (HeightOneSpectrum.adicCompletion K v)).range =
+      closure (f '' (f ⁻¹' (HeightOneSpectrum.adicCompletionIntegers K v))) by
+    rw [h]
+    exact DenseRange.subset_closure_image_preimage_of_isOpen hd hopen
+  apply subset_antisymm
+  . apply closure_mono
+    rintro b ⟨a, rfl⟩
+    use algebraMap A K a
+    rw [Set.mem_preimage, SetLike.mem_coe]
+    constructor
+    . exact HeightOneSpectrum.coe_algebraMap_mem A K v a
+    unfold f
+    rw [HeightOneSpectrum.algebraMap_adicCompletion, Function.comp_apply]
+  apply closure_minimal _ isClosed_closure
+  rintro k ⟨x, hx, rfl⟩
+  rw [mem_closure_iff_nhds_zero]
+  intro U hU
+  rw [Valued.mem_nhds] at hU
+  unfold f at hx
+  rw [Set.mem_preimage, SetLike.mem_coe, HeightOneSpectrum.mem_adicCompletionIntegers,
+      Valued.valuedCompletion_apply, HeightOneSpectrum.adicValued_apply'] at hx
+  obtain ⟨γ, hγ⟩ := hU
+  obtain ⟨a, ha⟩ := approx_of_valued_le_one K v γ hx
+  use algebraMap A K a
+  constructor
+  . use a
+    rfl
+  apply hγ
+  simp only [sub_zero, Set.mem_setOf_eq]
+  exact ha
+
+theorem denseRange_of_integerAlgerbaMap :
+    DenseRange (algebraMap A (v.adicCompletionIntegers K)) := by
+  rw [denseRange_iff_closure_range]
+  ext x
+  simp only [Set.mem_univ, iff_true]
+  rw [closure_subtype]
+  suffices h : Subtype.val '' Set.range ((algebraMap A ↥(HeightOneSpectrum.adicCompletionIntegers K v))) =
+      (algebraMap A (v.adicCompletion K)).range by
+    rw [h, closureAlgebraMapIntegers_eq_integers K v]
+    exact Subtype.coe_prop x
+  simp only [RingHom.coe_range, ← Set.range_comp']
+  rfl
+
+theorem completionInteger_approx_eq_integer ( x : v.adicCompletionIntegers K )
+    ( γ : (WithZero (Multiplicative ℤ))ˣ ) :
+    ∃a, Valued.v ((algebraMap A K a) - (x : v.adicCompletion K)) < γ.val := by
+  have h := closureAlgebraMapIntegers_eq_integers K v
+  rw [Set.ext_iff] at h
+  specialize h x
+  simp_rw [RingHom.coe_range, Subtype.coe_prop, iff_true, mem_closure_iff_nhds] at h
+  specialize h { y | Valued.v (y  - (x : v.adicCompletion K)) < γ.val }
+  have hn : {y | Valued.v (y - (x : v.adicCompletion K)) < γ.val} ∈ nhds x.val := by
+    rw [Valued.mem_nhds]
+    use γ
+  obtain ⟨z, ⟨hz, a, ha⟩⟩ := h hn
+  use a
+  rw [HeightOneSpectrum.algebraMap_adicCompletion, Function.comp_apply] at ha
+  rwa [ha]
+
+theorem prodCompletionInteger_approx_eq_integer {ι : Type*} (s : Finset ι)
+    (e : ι → (WithZero (Multiplicative ℤ))ˣ ) (valuation : ι → HeightOneSpectrum A)
+    (injective : Function.Injective valuation)
+    (x : (i : ι) → (valuation i).adicCompletionIntegers K) :
+    ∃ a, ∀ i ∈ s, Valued.v ((algebraMap A K a) - (x i : (valuation i).adicCompletion K))
+      < (e i).val := by
+  let e' : ι → ℕ := fun i => (WithZero.unzero (e i).ne_zero)⁻¹.toNat + 1
+  have he' : ∀ (i : ι), (Multiplicative.ofAdd (-(e' i : ℤ))) < (e i).val := by
+    intro i
+    unfold e'
+    simp only [Nat.cast_add, Int.ofNat_toNat, Nat.cast_one, neg_add_rev, Int.reduceNeg, ofAdd_add,
+      ofAdd_neg, WithZero.coe_mul, WithZero.coe_inv]
+    have mul_lt_of_lt_one_of_le' {a b c : WithZero (Multiplicative ℤ)} (ha : a < 1) (bc : b ≤ c)
+      (a0 : 0 ≤ a) (c0 : 0 < c) : a * b < c :=
+      (mul_le_mul_of_nonneg_left bc a0).trans_lt <| mul_lt_of_lt_one_left c0 ha
+    apply mul_lt_of_lt_one_of_le'
+    . norm_cast
+    . rw [← WithZero.coe_inv]
+      apply le_of_le_of_eq _ (WithZero.coe_unzero (e i).ne_zero)
+      rw [WithZero.coe_le_coe, ← ofAdd_neg, neg_sup]
+      apply inf_le_of_left_le
+      apply le_of_eq (Int.neg_neg (WithZero.unzero (e i).ne_zero))
+    . norm_cast
+    apply Units.zero_lt
+  have hinj : ∀ i ∈ s, ∀ j ∈ s, i ≠ j → (fun i ↦ (valuation i).asIdeal) i ≠ (fun i ↦ (valuation i).asIdeal) j := by
+    intro i hi j hj
+    contrapose!
+    intro hij
+    apply injective
+    apply HeightOneSpectrum.ext hij
+  let f (i : s) : A := (completionInteger_approx_eq_integer K (valuation i) (x i) (e i)).choose
+  have hf : ∀ (i : s), Valued.v (((algebraMap A K) (f i)) - (x i : (valuation i).adicCompletion K))
+      < (e i) :=
+    fun (i : s) => (completionInteger_approx_eq_integer K (valuation i) (x i) (e i)).choose_spec
+  obtain ⟨a, ha⟩ := IsDedekindDomain.exists_forall_sub_mem_ideal (s := s)
+    (fun i => (valuation i).asIdeal) e' (fun i hi => (valuation i).prime) hinj f
+  use a
+  intro i hi
+  specialize ha i hi
+  specialize hf ⟨i, hi⟩
+  rw [← Ideal.dvd_span_singleton, ← HeightOneSpectrum.intValuation_le_pow_iff_dvd,
+      ← HeightOneSpectrum.intValuation_apply,
+      ← HeightOneSpectrum.valuation_of_algebraMap (K := K),
+      ← HeightOneSpectrum.valuedAdicCompletion_eq_valuation,
+      algebraMap.coe_sub] at ha
+  apply lt_of_le_of_lt _ (Valuation.map_add_lt _ (ha.trans_lt (he' i)) hf)
+  apply le_of_eq
+  congr
+  rw [add_sub, sub_eq_sub_iff_add_eq_add, add_right_cancel_iff,
+    add_comm_sub, add_sub, eq_sub_iff_add_eq]
+  rfl
+
+theorem closureAlgebraMapIntergers_eq_prodIntegers {ι : Type*}
+    (valuation : ι → HeightOneSpectrum A) (injective : Function.Injective valuation) :
+    closure (SetLike.coe (algebraMap A ((i : ι) → (valuation i).adicCompletion K)).range) =
+    (Set.pi Set.univ (fun (i : ι) ↦ HeightOneSpectrum.adicCompletionIntegers K (valuation i))) := by
+  apply Set.Subset.antisymm
+  . apply closure_minimal
+    . rintro c ⟨a, ha⟩ i -
+      rw [← ha]
+      simp only [Pi.algebraMap_apply, SetLike.mem_coe]
+      exact HeightOneSpectrum.coe_mem_adicCompletionIntegers (valuation i) a
+    apply isClosed_set_pi
+    rintro w -
+    exact Valued.valuationSubring_isClosed
+  intro f hf
+  rw [mem_closure_iff_nhds_zero]
+  intro U hU
+  rw [Pi.zero_def, nhds_pi, Filter.mem_pi'] at hU
+  obtain ⟨I, t, htn, hts⟩ := hU
+  obtain ⟨g, hg⟩ := Classical.axiomOfChoice
+    (fun w => (Valued.is_topological_valuation (t w)).mp (htn w))
+  obtain ⟨a, ha⟩ :=
+    prodCompletionInteger_approx_eq_integer K I g
+      valuation injective (fun w => ⟨f w, hf w ⟨⟩⟩)
+  use algebraMap A _ a
+  constructor
+  . rw [RingHom.coe_range]
+    exact Set.mem_range_self a
+  apply hts
+  rintro w hw
+  apply hg
+  apply ha w hw
+
+end IsDedekindDomain

--- a/FLT/DedekindDomain/FiniteAdeleRing/BaseChange.lean
+++ b/FLT/DedekindDomain/FiniteAdeleRing/BaseChange.lean
@@ -1,4 +1,4 @@
-import FLT.DedekindDomain.DenseIntegers
+import FLT.DedekindDomain.AdicValuation
 import FLT.Mathlib.Algebra.Algebra.Bilinear
 import FLT.Mathlib.Algebra.Algebra.Pi
 import FLT.Mathlib.LinearAlgebra.Dimension.Constructions
@@ -604,6 +604,10 @@ lemma tensorAdicCompletionIsClosedRange :
     -- continuous due to `K_v` module topologies on both sides, then restrict scalars to `K`
     IsModuleTopology.continuousLinearEquiv (comm.symm.trans π') |>.restrictScalars K
 
+  have equiv_product : ∀ a x, (equiv (b x ⊗ₜ a)) = (fun j ↦ (Finsupp.single x (1 : K)) j • a) := by
+    intro a x
+    simp [equiv]
+
   have preimage : equiv ⁻¹' (Set.pi Set.univ (fun _ => SetLike.coe (adicCompletionIntegers K v))) ⊆
       (tensorAdicCompletionIntegersTo A K L B v).range := by
     intro t ht
@@ -635,30 +639,8 @@ lemma tensorAdicCompletionIsClosedRange :
       Algebra.TensorProduct.includeRight_apply, Algebra.ofId_apply, hf_prop',
       Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul]
     apply equiv.injective
-    rw [map_sum]
-    -- TODO: Pull out the rewriting here
-    show ∑ x,
-        (let _ : DecidableEq ι := Classical.typeDecidableEq ι
-        let _ : Algebra (adicCompletion K v) (L ⊗[K] adicCompletion K v) :=
-          Algebra.TensorProduct.rightAlgebra
-        let comm :=
-          (AlgEquiv.extendScalars (adicCompletion K v) (Algebra.TensorProduct.comm K (adicCompletion K v) L)).toLinearEquiv;
-        let π := TensorProduct.piScalarRight K (adicCompletion K v) (adicCompletion K v) { x // x ∈ ι };
-        let π' :=
-          TensorProduct.AlgebraTensorModule.congr (LinearEquiv.refl (adicCompletion K v) (adicCompletion K v))
-              b.equivFun ≪≫ₗ
-            TensorProduct.piScalarRight K (adicCompletion K v) (adicCompletion K v) { x // x ∈ ι };
-        ContinuousLinearEquiv.restrictScalars K (IsModuleTopology.continuousLinearEquiv (comm.symm ≪≫ₗ π')))
-        (b x ⊗ₜ[K] equiv t x) = equiv t
-    simp only [AlgEquiv.toAlgHom_eq_coe, AlgHom.toRingHom_eq_coe, AlgEquiv.toLinearEquiv_symm,
-      ContinuousLinearEquiv.restrictScalars_apply, IsModuleTopology.continuousLinearEquiv_apply,
-      LinearEquiv.trans_apply, AlgEquiv.toLinearEquiv_apply, AlgEquiv.symmExtendScalars_apply,
-      Algebra.TensorProduct.comm_symm_tmul, congr_tmul, LinearEquiv.refl_apply,
-      Basis.equivFun_apply, Basis.repr_self, TensorProduct.piScalarRight_apply,
-      TensorProduct.piScalarRightHom_tmul, Finsupp.single_smul, one_smul]
-    rw [Finset.sum_fn]
-    ext i
-    rw [Finsupp.univ_sum_single_apply']
+    simp only [equiv_product, map_sum, Finsupp.single_smul, one_smul,
+      Finset.sum_fn, Finsupp.univ_sum_single_apply']
   use equiv ⁻¹' (Set.pi Set.univ (fun _ => SetLike.coe (adicCompletionIntegers K v))), preimage
   constructor
   . apply IsOpen.preimage equiv.continuous

--- a/FLT/DedekindDomain/FiniteAdeleRing/BaseChange.lean
+++ b/FLT/DedekindDomain/FiniteAdeleRing/BaseChange.lean
@@ -506,9 +506,7 @@ omit [IsIntegralClosure B A L] [FiniteDimensional K L] [Algebra.IsSeparable K L]
 lemma tensorAdicCompletionIntegersToRange_subset_closureIntegers :
   (tensorAdicCompletionIntegersTo A K L B v).range.carrier ⊆
       closure (algebraMap B (L ⊗[K] adicCompletion K v)).range := by
-  intro t ⟨s, hs⟩
-  rw [← hs]
-  clear t hs
+  rintro _ ⟨s, rfl⟩
   induction s with
     | zero =>
         apply subset_closure
@@ -524,7 +522,7 @@ lemma tensorAdicCompletionIntegersToRange_subset_closureIntegers :
         intro _ ha _ hb
         exact add_mem ha hb
     | tmul b a' =>
-        -- Rewrite tensorAdicCompletionIntegersTo `(b ⊗ₜ a')` to `b • (1 ⊗ₜ a')`
+        -- Rewrite `tensorAdicCompletionIntegersTo (b ⊗ₜ a')` to `b • (1 ⊗ₜ a')`
         simp only [RingHom.coe_range, tensorAdicCompletionIntegersTo, Algebra.comp_ofId,
           AlgHom.toRingHom_eq_coe, RingHom.coe_coe, Algebra.TensorProduct.lift_tmul,
           AlgHom.coe_comp, AlgHom.coe_restrictScalars', IsScalarTower.coe_toAlgHom',
@@ -539,13 +537,12 @@ lemma tensorAdicCompletionIntegersToRange_subset_closureIntegers :
               (y : adicCompletion K v) • (Algebra.ofId B (L ⊗[K] adicCompletion K v)) b := by
           ext y
           unfold f
-          rw [mul_comm]
-          rfl
+          exact mul_comm _ _
         have hcf : ContinuousAt f a' := by
           apply Continuous.continuousAt
           rw [hfval]
           apply Continuous.smul continuous_subtype_val continuous_const
-        -- So, because `A` is dense in `A'`, `b • (1 ⊗ₜ a') ∈ closure f '' A`
+        -- So, because `A` is dense in `𝒪_v`, `b • (1 ⊗ₜ a') ∈ f '' closure A ⊆ closure f '' A`
         have hy : a' ∈ closure (Set.range (algebraMap A _)) := by
           apply IsDedekindDomain.denseRange_of_integerAlgebraMap
         apply mem_closure_image hcf hy
@@ -562,7 +559,6 @@ lemma tensorAdicCompletionIntegersToRange_subset_closureIntegers :
         simp
 
 open TensorProduct.AlgebraTensorModule in
-open scoped Classical in
 attribute [local instance] Algebra.TensorProduct.rightAlgebra in
 omit [Algebra.IsSeparable K L] [IsDomain B] [Algebra.IsIntegral A B]
     [Module.Finite A B] [IsDedekindDomain B] [IsFractionRing B L]  in
@@ -571,10 +567,6 @@ lemma tensorAdicCompletionIsClosedRange :
   -- `B ⊗[A] 𝒪_v` is a subgroup of `L ⊗[K] K_v`, so we can show it's closed
   -- by showing that it's open.
   rw [← Subalgebra.coe_toSubring, ← Subring.coe_toAddSubgroup]
-  letI : Module (adicCompletion K v) (L ⊗[K] adicCompletion K v) :=
-      Algebra.TensorProduct.rightAlgebra.toModule
-  letI : SMul (adicCompletion K v) (L ⊗[K] adicCompletion K v) :=
-      Algebra.TensorProduct.rightAlgebra.toSMul
   have := ModuleTopology.continuousAdd (adicCompletion K v) (L ⊗[K] adicCompletion K v)
   apply AddSubgroup.isClosed_of_isOpen
   -- Further, we can show `B ⊗[A] 𝒪_v` is open by showing that it contains an
@@ -585,15 +577,16 @@ lemma tensorAdicCompletionIsClosedRange :
   -- Take a basis `b` of `L` over `K` with elements in `B` and use it to
   -- get a basis `b'` of `L ⊗[K] K_v` over `K_v`.
   obtain ⟨ι, b, hb⟩ := FiniteDimensional.exists_is_basis_integral A K L
-  let b' : Basis ι (adicCompletion K v) (L ⊗[K] (adicCompletion K v)) :=
-    Basis.rightBaseChange L b
+  let b' : Basis ι (adicCompletion K v) (L ⊗[K] (adicCompletion K v)) := by
+    classical
+    exact Basis.rightBaseChange L b
   -- Use the basis to get a continuous equivalence from `L ⊗[K] K_v` to `ι → K_v`.
   let equiv : L ⊗[K] (adicCompletion K v) ≃L[K] (ι → adicCompletion K v) :=
     IsModuleTopology.continuousLinearEquiv (b'.equivFun) |>.restrictScalars K
 
   -- Use the preimage of `∏ 𝒪_v` as the open neighbourhood.
   use equiv.symm '' (Set.pi Set.univ (fun _ => SetLike.coe (adicCompletionIntegers K v)))
-  refine ⟨?_, ?_, ?_⟩
+  refine ⟨?_, ?_, by simp [ValuationSubring.zero_mem]⟩
   . intro t ⟨g, hg, ht⟩
     -- We have `t = equiv g = ∑ i, b i ⊗ g i`, since `g in ∏ 𝒪_v` and
     -- `b i ∈ (algebraMap B L).range`, this is `tensorAdicCompletionIntegersTo`
@@ -601,7 +594,7 @@ lemma tensorAdicCompletionIsClosedRange :
     have hf : ∀ (i : ι), ∃ (w : B), (algebraMap B L w) = (b i) := by
       intro i
       apply IsIntegralClosure.isIntegral_iff.mp (hb i)
-    obtain ⟨f, hf_prop⟩ := Classical.axiomOfChoice hf
+    choose f hf_prop using hf
     have hf_prop' : ∀ (i : ι), (algebraMap B (L ⊗[K] adicCompletion K v) (f i)) = (b i) ⊗ₜ 1 := by
       intro i
       rw [Algebra.TensorProduct.algebraMap_apply, hf_prop]
@@ -626,7 +619,6 @@ lemma tensorAdicCompletionIsClosedRange :
     apply isOpen_set_pi Set.finite_univ
     rintro i -
     exact Valued.valuationSubring_isOpen (v.adicCompletion K)
-  simp [ValuationSubring.zero_mem]
 
 omit [Algebra.IsSeparable K L] [IsDomain B] [Algebra.IsIntegral A B] [Module.Finite A B]
     [IsDedekindDomain B] [IsFractionRing B L] in
@@ -635,11 +627,10 @@ lemma tensorAdicCompletionIntegersToRange_eq_closureIntegers :
         closure (algebraMap B (L ⊗[K] adicCompletion K v)).range := by
   apply Set.Subset.antisymm
   . apply tensorAdicCompletionIntegersToRange_subset_closureIntegers
-  apply closure_minimal
-  . intro c ⟨b, hb⟩
-    rw [← hb]
-    apply algebraMap_mem
-  apply tensorAdicCompletionIsClosedRange
+  . apply closure_minimal
+    . rintro _ ⟨b, rfl⟩
+      apply algebraMap_mem
+    . apply tensorAdicCompletionIsClosedRange
 
 omit [Algebra A L] [IsScalarTower A B L] [IsIntegralClosure B A L] [Module.Finite A B] in
 lemma prodAdicCompletionsIntegers_eq_closureIntegers :
@@ -647,7 +638,9 @@ lemma prodAdicCompletionsIntegers_eq_closureIntegers :
       (fun (w : Extension B v) ↦ adicCompletionIntegersSubalgebra L w.1)) =
     closure (SetLike.coe (algebraMap B _).range) := by
   rw [Subalgebra.coe_pi]
-  show (SetLike.coe (Submodule.pi _  _)) = _
+  let _ (w : Extension B v) : Module B (adicCompletion L w.val) :=
+    UniformSpace.Completion.instModule
+  show SetLike.coe (Submodule.pi _ _) = _
   rw [Submodule.coe_pi]
   let val := (fun (w : Extension B v) ↦ w.1)
   have hinj : Function.Injective val :=
@@ -655,7 +648,18 @@ lemma prodAdicCompletionsIntegers_eq_closureIntegers :
   rw [closureAlgebraMapIntegers_eq_prodIntegers L val hinj]
   rfl
 
-set_option synthInstance.maxHeartbeats 40000 in
+instance : MulActionHomClass
+    (L ⊗[K] adicCompletion K v →ₐ[L] (w : Extension B v) → adicCompletion L w.1) B
+    (L ⊗[K] adicCompletion K v) ((w : Extension B v) → adicCompletion L w.1) where
+  map_smulₛₗ φ b x := by
+    rw [← IsScalarTower.algebraMap_smul L, AlgHom.map_smul_of_tower,
+      IsScalarTower.algebraMap_smul, id_def]
+
+instance : OneHomClass
+    (L ⊗[K] adicCompletion K v →ₐ[L] (w : Extension B v) → adicCompletion L w.1)
+    (L ⊗[K] adicCompletion K v) ((w : Extension B v) → adicCompletion L w.1) where
+  map_one f := f.toRingHom.map_one
+
 theorem adicCompletionComapAlgEquiv_integral :
     AlgHom.range (((tensorAdicCompletionComapAlgHom A K L B v).restrictScalars B).comp
       (tensorAdicCompletionIntegersTo A K L B v)) =

--- a/FLT/Mathlib/Algebra/Algebra/Tower.lean
+++ b/FLT/Mathlib/Algebra/Algebra/Tower.lean
@@ -10,6 +10,22 @@ def AlgEquiv.extendScalars {A C D : Type*} (B : Type*) [CommSemiring A] [CommSem
   __ := f
   commutes' := fun _ => rfl
 
+@[simp]
+def AlgEquiv.extendScalars_apply {A C D : Type*} (B : Type*) [CommSemiring A] [CommSemiring C]
+    [CommSemiring D] [Algebra A C] [Algebra A D] [CommSemiring B] [Algebra A B] [Algebra B C]
+    [IsScalarTower A B C] (f : C ≃ₐ[A] D) (c : C) :
+    letI := (f.toAlgHom.restrictDomain B).toRingHom.toAlgebra
+    (AlgEquiv.extendScalars B f) c = f c := by
+  rfl
+
+@[simp]
+def AlgEquiv.symmExtendScalars_apply {A C D : Type*} (B : Type*) [CommSemiring A] [CommSemiring C]
+    [CommSemiring D] [Algebra A C] [Algebra A D] [CommSemiring B] [Algebra A B] [Algebra B C]
+    [IsScalarTower A B C] (f : C ≃ₐ[A] D) (d : D) :
+    letI := (f.toAlgHom.restrictDomain B).toRingHom.toAlgebra
+    (AlgEquiv.extendScalars B f).symm d = f.symm d := by
+  rfl
+
 /--
 Given the following
 ```

--- a/FLT/Mathlib/Algebra/Algebra/Tower.lean
+++ b/FLT/Mathlib/Algebra/Algebra/Tower.lean
@@ -1,6 +1,7 @@
 import Mathlib.Algebra.Algebra.Tower
 import Mathlib.RingTheory.AlgebraTower
 
+@[simps! apply symm_apply]
 def AlgEquiv.extendScalars {A C D : Type*} (B : Type*) [CommSemiring A] [CommSemiring C]
     [CommSemiring D] [Algebra A C] [Algebra A D] [CommSemiring B] [Algebra A B] [Algebra B C]
     [IsScalarTower A B C] (f : C ≃ₐ[A] D) :
@@ -8,23 +9,8 @@ def AlgEquiv.extendScalars {A C D : Type*} (B : Type*) [CommSemiring A] [CommSem
     C ≃ₐ[B] D where
   __ := (f.toAlgHom.restrictDomain B).toRingHom.toAlgebra
   __ := f
+  invFun := f.symm
   commutes' := fun _ => rfl
-
-@[simp]
-def AlgEquiv.extendScalars_apply {A C D : Type*} (B : Type*) [CommSemiring A] [CommSemiring C]
-    [CommSemiring D] [Algebra A C] [Algebra A D] [CommSemiring B] [Algebra A B] [Algebra B C]
-    [IsScalarTower A B C] (f : C ≃ₐ[A] D) (c : C) :
-    letI := (f.toAlgHom.restrictDomain B).toRingHom.toAlgebra
-    (AlgEquiv.extendScalars B f) c = f c := by
-  rfl
-
-@[simp]
-def AlgEquiv.symmExtendScalars_apply {A C D : Type*} (B : Type*) [CommSemiring A] [CommSemiring C]
-    [CommSemiring D] [Algebra A C] [Algebra A D] [CommSemiring B] [Algebra A B] [Algebra B C]
-    [IsScalarTower A B C] (f : C ≃ₐ[A] D) (d : D) :
-    letI := (f.toAlgHom.restrictDomain B).toRingHom.toAlgebra
-    (AlgEquiv.extendScalars B f).symm d = f.symm d := by
-  rfl
 
 /--
 Given the following

--- a/FLT/Mathlib/Algebra/Order/GroupWithZero.lean
+++ b/FLT/Mathlib/Algebra/Order/GroupWithZero.lean
@@ -1,0 +1,32 @@
+import Mathlib.Algebra.Order.GroupWithZero.Canonical
+
+namespace WithZero
+
+lemma exists_ne_zero_and_lt {G : Type*} [LinearOrder G] [NoMinOrder G]
+  {x : WithZero G} (hx : x ≠ 0) :
+    ∃ y, y ≠ 0 ∧ y < x := by
+  obtain ⟨z, hlt⟩ := exists_lt (WithZero.unzero hx)
+  rw [← WithZero.coe_lt_coe, WithZero.coe_unzero hx] at hlt
+  use z, WithZero.coe_ne_zero
+
+lemma exists_ne_zero_and_le_and_le {G : Type*} [LinearOrder G]
+  {x y : WithZero G} (hx : x ≠ 0) (hy : y ≠ 0) :
+    ∃ z, z ≠ 0 ∧ z ≤ x ∧ z ≤ y := by
+  let z := x ⊓ y
+  use z
+  constructor
+  . unfold z
+    intro hz
+    rw [min_eq_iff] at hz
+    tauto
+  . constructor <;> simp_all [z]
+
+lemma exists_ne_zero_and_lt_and_lt {G : Type*} [LinearOrder G] [NoMinOrder G]
+  {x y : WithZero G} (hx : x ≠ 0) (hy : y ≠ 0) :
+    ∃ z, z ≠ 0 ∧ z < x ∧ z < y := by
+  obtain ⟨z', hnz', hzx, hzy⟩ := exists_ne_zero_and_le_and_le hx hy
+  obtain ⟨z, hnz, hlt⟩ := exists_ne_zero_and_lt hnz'
+  use z, hnz
+  constructor <;> exact lt_of_lt_of_le hlt ‹z' ≤ _›
+
+end WithZero

--- a/FLT/Mathlib/Algebra/Order/GroupWithZero.lean
+++ b/FLT/Mathlib/Algebra/Order/GroupWithZero.lean
@@ -12,14 +12,10 @@ lemma exists_ne_zero_and_lt {G : Type*} [LinearOrder G] [NoMinOrder G]
 lemma exists_ne_zero_and_le_and_le {G : Type*} [LinearOrder G]
   {x y : WithZero G} (hx : x ≠ 0) (hy : y ≠ 0) :
     ∃ z, z ≠ 0 ∧ z ≤ x ∧ z ≤ y := by
-  let z := x ⊓ y
-  use z
-  constructor
-  . unfold z
-    intro hz
-    rw [min_eq_iff] at hz
-    tauto
-  . constructor <;> simp_all [z]
+  use x ⊓ y
+  refine ⟨fun hz ↦ ?_, by simp, by simp⟩
+  rw [min_eq_iff] at hz
+  tauto
 
 lemma exists_ne_zero_and_lt_and_lt {G : Type*} [LinearOrder G] [NoMinOrder G]
   {x y : WithZero G} (hx : x ≠ 0) (hy : y ≠ 0) :

--- a/FLT/Mathlib/RingTheory/TensorProduct/Basis.lean
+++ b/FLT/Mathlib/RingTheory/TensorProduct/Basis.lean
@@ -1,0 +1,51 @@
+import Mathlib.RingTheory.TensorProduct.Finite
+import Mathlib.LinearAlgebra.Basis.Basic
+import Mathlib.LinearAlgebra.TensorProduct.Pi
+import FLT.Mathlib.Algebra.Algebra.Tower
+
+section Basis
+
+open scoped TensorProduct
+
+attribute [local instance] Algebra.TensorProduct.rightAlgebra
+
+variable {R : Type*} (A : Type*) {B : Type*} {ι : Type*} [CommSemiring R]
+variable [CommSemiring A] [Algebra R A] [Fintype ι]
+variable [CommSemiring B] [Algebra R B]
+
+/-- The lift of an `R`-basis of `A` to a `B`-basis of the base change `A ⊗[R] B`. -/
+
+noncomputable
+def Basis.rightBaseChange (b : Basis ι R A) : Basis ι B (A ⊗[R] B) where
+  repr :=
+    letI : DecidableEq ι := Classical.typeDecidableEq ι
+    let comm := (Algebra.TensorProduct.comm R B A).extendScalars B |>.toLinearEquiv
+    let π : B ⊗[R] A ≃ₗ[B] (ι → B) :=
+      (TensorProduct.AlgebraTensorModule.congr
+        (LinearEquiv.refl B B)
+        b.equivFun).trans
+      (TensorProduct.piScalarRight _ _ _ _)
+    let finite : (ι →₀ B) ≃ₗ[B] (ι → B) := Finsupp.linearEquivFunOnFinite B B ι
+    comm.symm.trans π |>.trans finite.symm
+
+@[simp]
+lemma Basis.rightBaseChange_repr (b : Basis ι R A) (i) (x : B) :
+    (b.rightBaseChange A).repr (b i ⊗ₜ x) = Finsupp.single i x := by
+  letI : DecidableEq ι := Classical.typeDecidableEq ι
+  have : ∑ (j : ι), (Pi.single i (1 : R) : ι → R) j • (b j) = b i := by
+    conv =>
+      lhs
+      arg 2
+      intro j
+      rw [Pi.single_comm, Pi.single_apply_smul]
+    simp
+  rw [← LinearEquiv.eq_symm_apply]
+  simp [rightBaseChange, this]
+
+@[simp]
+lemma Basis.rightBaseChange_apply (b : Basis ι R A) (i) :
+    b.rightBaseChange A i = b i ⊗ₜ (1 : B) := by
+  rw [apply_eq_iff]
+  exact rightBaseChange_repr A b i 1
+
+end Basis

--- a/FLT/Mathlib/RingTheory/TensorProduct/Basis.lean
+++ b/FLT/Mathlib/RingTheory/TensorProduct/Basis.lean
@@ -16,9 +16,8 @@ variable [CommSemiring B] [Algebra R B]
 /-- The lift of an `R`-basis of `A` to a `B`-basis of the base change `A ⊗[R] B`. -/
 
 noncomputable
-def Basis.rightBaseChange (b : Basis ι R A) : Basis ι B (A ⊗[R] B) where
+def Basis.rightBaseChange [DecidableEq ι] (b : Basis ι R A) : Basis ι B (A ⊗[R] B) where
   repr :=
-    letI : DecidableEq ι := Classical.typeDecidableEq ι
     let comm := (Algebra.TensorProduct.comm R B A).extendScalars B |>.toLinearEquiv
     let π : B ⊗[R] A ≃ₗ[B] (ι → B) :=
       (TensorProduct.AlgebraTensorModule.congr
@@ -29,9 +28,8 @@ def Basis.rightBaseChange (b : Basis ι R A) : Basis ι B (A ⊗[R] B) where
     comm.symm.trans π |>.trans finite.symm
 
 @[simp]
-lemma Basis.rightBaseChange_repr (b : Basis ι R A) (i) (x : B) :
+lemma Basis.rightBaseChange_repr [DecidableEq ι] (b : Basis ι R A) (i) (x : B) :
     (b.rightBaseChange A).repr (b i ⊗ₜ x) = Finsupp.single i x := by
-  letI : DecidableEq ι := Classical.typeDecidableEq ι
   have : ∑ (j : ι), (Pi.single i (1 : R) : ι → R) j • (b j) = b i := by
     conv =>
       lhs
@@ -43,7 +41,7 @@ lemma Basis.rightBaseChange_repr (b : Basis ι R A) (i) (x : B) :
   simp [rightBaseChange, this]
 
 @[simp]
-lemma Basis.rightBaseChange_apply (b : Basis ι R A) (i) :
+lemma Basis.rightBaseChange_apply [DecidableEq ι] (b : Basis ι R A) (i) :
     b.rightBaseChange A i = b i ⊗ₜ (1 : B) := by
   rw [apply_eq_iff]
   exact rightBaseChange_repr A b i 1

--- a/FLT/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/FLT/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -17,5 +17,6 @@ def ContinuousLinearEquiv.restrictScalars (R : Type*) {S M M₂ : Type*}
     [TopologicalSpace M₂] (f : M ≃L[S] M₂) :
     M ≃L[R] M₂ where
   __ := f.toLinearEquiv.restrictScalars R
+  invFun := f.symm
   continuous_toFun := f.continuous_toFun
   continuous_invFun := f.continuous_invFun

--- a/FLT/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
+++ b/FLT/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
@@ -243,11 +243,13 @@ over a complete thing so I don't think there can be any other possibility
 (the argument is weak here)
 -/
 
+@[simps!]
 def continuousLinearEquiv {A B R : Type*} [TopologicalSpace A]
     [TopologicalSpace B] [TopologicalSpace R] [Semiring R] [AddCommMonoid A] [AddCommMonoid B]
     [Module R A] [Module R B] [IsModuleTopology R A] [IsModuleTopology R B]
     (e : A ≃ₗ[R] B) :
     A ≃L[R] B where
+  toFun := e
   __ := e
   continuous_toFun :=
     letI := IsModuleTopology.toContinuousAdd
@@ -255,20 +257,6 @@ def continuousLinearEquiv {A B R : Type*} [TopologicalSpace A]
   continuous_invFun :=
     letI := IsModuleTopology.toContinuousAdd
     IsModuleTopology.continuous_of_linearMap e.symm.toLinearMap
-
-@[simp]
-def continuousLinearEquiv_apply {A B R : Type*} [TopologicalSpace A]
-    [TopologicalSpace B] [TopologicalSpace R] [Semiring R] [AddCommMonoid A] [AddCommMonoid B]
-    [Module R A] [Module R B] [IsModuleTopology R A] [IsModuleTopology R B]
-    (e : A ≃ₗ[R] B) ( a : A ) : continuousLinearEquiv e a = e a :=
-  rfl
-
-@[simp]
-def symmContinuousLinearEquiv_apply {A B R : Type*} [TopologicalSpace A]
-    [TopologicalSpace B] [TopologicalSpace R] [Semiring R] [AddCommMonoid A] [AddCommMonoid B]
-    [Module R A] [Module R B] [IsModuleTopology R A] [IsModuleTopology R B]
-    (e : A ≃ₗ[R] B) ( b : B ) : (continuousLinearEquiv e).symm b = e.symm b :=
-  rfl
 
 /--
 Given the following

--- a/FLT/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
+++ b/FLT/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
@@ -256,6 +256,20 @@ def continuousLinearEquiv {A B R : Type*} [TopologicalSpace A]
     letI := IsModuleTopology.toContinuousAdd
     IsModuleTopology.continuous_of_linearMap e.symm.toLinearMap
 
+@[simp]
+def continuousLinearEquiv_apply {A B R : Type*} [TopologicalSpace A]
+    [TopologicalSpace B] [TopologicalSpace R] [Semiring R] [AddCommMonoid A] [AddCommMonoid B]
+    [Module R A] [Module R B] [IsModuleTopology R A] [IsModuleTopology R B]
+    (e : A ≃ₗ[R] B) ( a : A ) : continuousLinearEquiv e a = e a :=
+  rfl
+
+@[simp]
+def symmContinuousLinearEquiv_apply {A B R : Type*} [TopologicalSpace A]
+    [TopologicalSpace B] [TopologicalSpace R] [Semiring R] [AddCommMonoid A] [AddCommMonoid B]
+    [Module R A] [Module R B] [IsModuleTopology R A] [IsModuleTopology R B]
+    (e : A ≃ₗ[R] B) ( b : B ) : (continuousLinearEquiv e).symm b = e.symm b :=
+  rfl
+
 /--
 Given the following
 ```

--- a/FLT/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/FLT/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -9,7 +9,7 @@ lemma Valued.isUnit_valuationSubring_iff {Γ₀ : Type*} [LinearOrderedCommGroup
   convert Valuation.Integers.isUnit_iff_valuation_eq_one _
   exact Valuation.integer.integers _
 
-/-- The unit ball of a valued ring is open. -/
+/-- The unit ball of a valued ring is closed. -/
 theorem Valued.integer_isClosed ( R : Type* ) {Γ₀ : Type*} [Ring R]
     [LinearOrderedCommGroupWithZero Γ₀] [_i : Valued R Γ₀] : IsClosed (_i.v.integer : Set R) := by
   rw [← Subring.coe_toAddSubgroup]

--- a/FLT/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/FLT/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -11,10 +11,9 @@ lemma Valued.isUnit_valuationSubring_iff {Γ₀ : Type*} [LinearOrderedCommGroup
 
 /-- The unit ball of a valued ring is closed. -/
 theorem Valued.integer_isClosed ( R : Type* ) {Γ₀ : Type*} [Ring R]
-    [LinearOrderedCommGroupWithZero Γ₀] [_i : Valued R Γ₀] : IsClosed (_i.v.integer : Set R) := by
+    [LinearOrderedCommGroupWithZero Γ₀] [i : Valued R Γ₀] : IsClosed (i.v.integer : Set R) := by
   rw [← Subring.coe_toAddSubgroup]
-  apply AddSubgroup.isClosed_of_isOpen
-  apply integer_isOpen
+  exact AddSubgroup.isClosed_of_isOpen _ (integer_isOpen _)
 
 /-- The valuation subring of a valued field is closed. -/
 theorem Valued.valuationSubring_isClosed {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]

--- a/FLT/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/FLT/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -8,3 +8,16 @@ lemma Valued.isUnit_valuationSubring_iff {Γ₀ : Type*} [LinearOrderedCommGroup
     IsUnit x ↔ Valued.v (x.val : F) = 1 := by
   convert Valuation.Integers.isUnit_iff_valuation_eq_one _
   exact Valuation.integer.integers _
+
+/-- The unit ball of a valued ring is open. -/
+theorem Valued.integer_isClosed ( R : Type* ) {Γ₀ : Type*} [Ring R]
+    [LinearOrderedCommGroupWithZero Γ₀] [_i : Valued R Γ₀] : IsClosed (_i.v.integer : Set R) := by
+  rw [← Subring.coe_toAddSubgroup]
+  apply AddSubgroup.isClosed_of_isOpen
+  apply integer_isOpen
+
+/-- The valuation subring of a valued field is closed. -/
+theorem Valued.valuationSubring_isClosed {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
+    [hv : Valued F Γ₀] :
+    IsClosed (hv.v.valuationSubring : Set F) :=
+  integer_isClosed F

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -106,7 +106,7 @@ theorem piEquiv_apply_of_algebraMap
   simp only [← funext h, ContinuousLinearEquiv.trans_apply,
     ContinuousLinearEquiv.restrictScalars_symm_apply, AlgEquiv.toAlgHom_eq_coe,
     AlgHom.toRingHom_eq_coe, AlgEquiv.toLinearEquiv_symm,
-    ContinuousLinearEquiv.restrictScalars_apply, IsModuleTopology.continuousLinearEquiv]
+    ContinuousLinearEquiv.restrictScalars_apply, IsModuleTopology.continuousLinearEquiv_symm_apply]
   rw [LinearEquiv.trans_symm, LinearEquiv.trans_apply, finiteEquivPi_symm_apply]
   simp [AlgEquiv.extendScalars, ContinuousAlgEquiv.toContinuousLinearEquiv_apply,
     baseChangeEquiv_tsum_apply_right]


### PR DESCRIPTION
Not the proof in the blueprint to avoid having to work with discriminants and to avoid bases as much as possible.
This also doesn't need the finite set of exceptions.
Still needs some work, but the proofs probably won't change too much now.
