### PR TITLE
chore(Padics): assume that `s` is a compact subgroup when computing `[xs : s]`

### DIFF
--- a/FLT/HaarMeasure/DistribHaarChar/Padic.lean
+++ b/FLT/HaarMeasure/DistribHaarChar/Padic.lean
@@ -34,7 +34,7 @@ variable {p : ℕ} [Fact p.Prime]
 private lemma distribHaarChar_padic_padicInt (x : ℤ_[p]⁰) :
     distribHaarChar ℚ_[p] (x : ℚ_[p]ˣ) = ‖(x : ℚ_[p])‖₊ := by
   -- Let `K` be the copy of `ℤ_[p]` inside `ℚ_[p]` and `H` be `xK`.
-  let K : AddSubgroup ℚ_[p] := (1 : Submodule ℤ_[p] ℚ_[p]).toAddSubgroup
+  set K : AddSubgroup ℚ_[p] := (1 : Submodule ℤ_[p] ℚ_[p]).toAddSubgroup with hK
   let H := (x : ℚ_[p]) • K
   -- We compute that `volume H = ‖x‖₊ * volume K`.
   refine distribHaarChar_eq_of_measure_smul_eq_mul (s := K) (μ := volume) (G := ℚ_[p]ˣ)
@@ -45,10 +45,13 @@ private lemma distribHaarChar_padic_padicInt (x : ℤ_[p]⁰) :
   have hHK : H ≤ K := by
     simpa [H, K, -Submodule.smul_le_self_of_tower]
       using (1 : Submodule ℤ_[p] ℚ_[p]).smul_le_self_of_tower (x : ℤ_[p])
+  have isCompact_K : IsCompact (K : Set ℚ_[p]) := by
+    rw [hK, Submodule.one_eq_range]; exact isCompact_range PadicInt.isEmbedding_coe.continuous
   have : H.FiniteRelIndex K :=
-    PadicInt.smul_submodule_finiteRelIndex (p := p) (mem_nonZeroDivisors_iff_ne_zero.1 x.2) 1
+    PadicInt.smul_submodule_finiteRelIndex (p := p) (mem_nonZeroDivisors_iff_ne_zero.1 x.2)
+      isCompact_K
   have H_relindex_Z : (H.relindex K : ℝ≥0∞) = ‖(x : ℚ_[p])‖₊⁻¹ :=
-    congr(ENNReal.ofNNReal $(PadicInt.smul_submodule_relindex (p := p) x 1))
+    congr(ENNReal.ofNNReal $(PadicInt.smul_submodule_relindex (p := p) isCompact_K x))
   rw [← index_mul_addHaar_addSubgroup_eq_addHaar_addSubgroup hHK, H_relindex_Z, ENNReal.coe_inv,
     ENNReal.mul_inv_cancel_left]
   · simp

--- a/FLT/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/FLT/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -55,8 +55,8 @@ noncomputable instance : Coe ℤ_[p]ˣ ℚ_[p]ˣ where coe := Units.map Coe.ring
 
 Note that `s` is of the form `yℤ_[p]` for some `y : ℚ_[p]`, but this is syntactically less
 general. -/
-lemma smul_submodule_relindex (x : ℤ_[p]) (s : Submodule ℤ_[p] ℚ_[p]) :
-    (x • s.toAddSubgroup).relindex s.toAddSubgroup = ‖x‖₊⁻¹ :=
+lemma smul_submodule_relindex {s : Submodule ℤ_[p] ℚ_[p]} (hs : IsCompact (s : Set ℚ_[p]))
+    (x : ℤ_[p]) : (x • s.toAddSubgroup).relindex s.toAddSubgroup = ‖x‖₊⁻¹ :=
   -- https://github.com/ImperialCollegeLondon/FLT/issues/279
   -- Note: You might need to prove `smul_submoduleSpan_finiteRelIndex_submoduleSpan` first
   sorry
@@ -65,9 +65,10 @@ lemma smul_submodule_relindex (x : ℤ_[p]) (s : Submodule ℤ_[p] ℚ_[p]) :
 
 Note that `s` is the form `yℤ_[p]` for some `y : ℚ_[p]`, but this is syntactically less
 general. -/
-lemma smul_submodule_finiteRelIndex (hx : x ≠ 0) (s : Submodule ℤ_[p] ℚ_[p]) :
+lemma smul_submodule_finiteRelIndex (hx : x ≠ 0) {s : Submodule ℤ_[p] ℚ_[p]}
+    (hs : IsCompact (s : Set ℚ_[p])) :
     (x • s.toAddSubgroup).FiniteRelIndex s.toAddSubgroup where
-  relIndex_ne_zero := by simpa [← Nat.cast_ne_zero (R := ℝ≥0), smul_submodule_relindex]
+  relIndex_ne_zero := by simpa [← Nat.cast_ne_zero (R := ℝ≥0), smul_submodule_relindex, hs]
 
 -- Yaël: Do we really want this as a coercion?
 noncomputable instance : Coe ℤ_[p]⁰ ℚ_[p]ˣ where
@@ -85,6 +86,9 @@ lemma closure_nonZeroDivisors_padicInt :
     (subset_closure <| Set.mem_range_self ⟨z, hz⟩) using 1
   ext
   simpa using hyzx.symm
+
+lemma isEmbedding_coe : IsEmbedding ((↑) : ℤ_[p] → ℚ_[p]) := by
+  sorry
 
 end PadicInt
 


### PR DESCRIPTION
Otherwise it doesn't hold, as noted in https://github.com/ImperialCollegeLondon/FLT/issues/279#issuecomment-2799015518.