### PR TITLE
feat: add table of contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ blueprint/lean_decls
 *.fdb_latexmk
 *.synctex.gz
 docbuild/*
+*.toc

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -1,3 +1,7 @@
+% Add table of contents
+
+\tableofcontents
+
 % Add chapters of the blueprint here
 
 \input{chapter/ch01introduction}
@@ -5,9 +9,9 @@
 \input{chapter/ch03frey}
 \input{chapter/ch04overview}
 \input{chapter/ch05automorphicformexample}
-%\input{chapter/ch06automorphicrepresentations} -- all in mathlib or on the way.
+\input{chapter/ch06automorphicrepresentations}
 \input{chapter/ch07exampleGLn}
-\input{chapter/FrobeniusProject}
+%\input{chapter/FrobeniusProject} -- all in mathlib or on the way.
 \input{chapter/AdeleMiniproject}
 \input{chapter/HaarCharacterProject}
 \input{chapter/FujisakiProject}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -1,7 +1,3 @@
-% Add table of contents
-
-\tableofcontents
-
 % Add chapters of the blueprint here
 
 \input{chapter/ch01introduction}

--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -36,5 +36,6 @@
 
 \begin{document}
 \maketitle
+\tableofcontents
 \input{content}
 \end{document}


### PR DESCRIPTION
I'd like a table of contents for the print version of the blueprint to help me navigate it more easily. Hopefully this achieves it.