### PR TITLE
chore: add some docstrings for auto forms on quat algs

### DIFF
--- a/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
@@ -26,12 +26,17 @@ open scoped TensorProduct NumberField
 
 open IsDedekindDomain
 
+/-- `Dfx` is an abbreviation for $(D\otimes_F\mathbb{A}_F^\infty)^\times.$ -/
 abbrev Dfx := (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ
 
+/-- incl₁ is an abbreviation for the inclusion
+$D^\times\to(D\otimes_F\mathbb{A}_F^\infty)^\times.$ Remark: I wrote the `incl₁`
+docstring in LaTeX and the `incl₂` one in unicode. Which is better?-/
 noncomputable abbrev incl₁ : Dˣ →* Dfx F D :=
   Units.map Algebra.TensorProduct.includeLeftRingHom.toMonoidHom
 
-/-- The inclusion 𝔸_F^∞ˣ → (D ⊗ 𝔸_F^∞ˣ) -/
+/-- `incl₂` is he inclusion `𝔸_F^∞ˣ → (D ⊗ 𝔸_F^∞ˣ)`. Remark: I wrote the `incl₁`
+docstring in LaTeX and the `incl₂` one in unicode. Which is better? -/
 noncomputable abbrev incl₂ : (FiniteAdeleRing (𝓞 F) F)ˣ →* Dfx F D :=
   Units.map Algebra.TensorProduct.rightAlgebra.algebraMap.toMonoidHom
 
@@ -56,15 +61,15 @@ variable [IsQuaternionAlgebra F D] in
 attribute [local instance] Algebra.TensorProduct.rightAlgebra in
 instance : IsTopologicalRing (D ⊗[F] (FiniteAdeleRing (𝓞 F) F)) :=
   IsModuleTopology.isTopologicalRing (FiniteAdeleRing (𝓞 F) F) _
-/-!
+/--
 This definition is made in mathlib-generality but is *not* the definition of a
-weight 2 automorphic form unless Dˣ is compact mod centre at infinity.
+weight 2 automorphic form unless `Dˣ` is compact mod centre at infinity.
 This hypothesis will be true if `D` is a totally definite quaternion algebra.
 -/
 structure WeightTwoAutomorphicForm
   -- defined over R
   (R : Type*) [AddCommMonoid R] where
-  -- definition
+  /-- The function underlying an automorphic form. -/
   toFun : (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ → R
   left_invt : ∀ (δ : Dˣ) (g : (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ),
     toFun (incl₁ F D δ * g) = (toFun g)
@@ -94,6 +99,7 @@ attribute [coe] WeightTwoAutomorphicForm.toFun
 theorem ext (φ ψ : WeightTwoAutomorphicForm F D R) (h : ∀ x, φ x = ψ x) : φ = ψ := by
   cases φ; cases ψ; simp only [mk.injEq]; ext; apply h
 
+/-- The zero automorphic form for a totally definite quaterion algebra. -/
 def zero : (WeightTwoAutomorphicForm F D R) where
   toFun := 0
   left_invt δ _ := by simp
@@ -110,6 +116,7 @@ instance : Zero (WeightTwoAutomorphicForm F D R) where
 theorem zero_apply (x : (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ) :
     (0 : WeightTwoAutomorphicForm F D R) x = 0 := rfl
 
+/-- Negation on the space of automorphic forms over a totally definite quaternion algebra. -/
 def neg (φ : WeightTwoAutomorphicForm F D R) : WeightTwoAutomorphicForm F D R where
   toFun x := - φ x
   left_invt δ g := by simp [left_invt]
@@ -125,6 +132,7 @@ instance : Neg (WeightTwoAutomorphicForm F D R) where
 theorem neg_apply (φ : WeightTwoAutomorphicForm F D R) (x : (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ) :
     (-φ : WeightTwoAutomorphicForm F D R) x = -(φ x) := rfl
 
+/-- Addition on the space of automorphic forms over a totally definite quaternion algebra. -/
 def add (φ ψ : WeightTwoAutomorphicForm F D R) : WeightTwoAutomorphicForm F D R where
   toFun x := φ x + ψ x
   left_invt := by simp [left_invt]
@@ -166,6 +174,8 @@ open ConjAct
 
 variable [IsQuaternionAlgebra F D]
 
+/-- The adelic group action on the space of automorphic forms over a totally definite
+quaternion algebra. -/
 def group_smul (g : (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ) (φ : WeightTwoAutomorphicForm F D R) :
     WeightTwoAutomorphicForm F D R where
   toFun x := φ (x * g)
@@ -210,6 +220,8 @@ section comm_ring
 
 variable {R : Type*} [CommRing R]
 
+/-- The scalar action on the space of weight 2 automorphic forms on a totally definite
+quaternion algebra. -/
 def ring_smul (r : R) (φ : WeightTwoAutomorphicForm F D R) :
     WeightTwoAutomorphicForm F D R where
       toFun g := r • φ g
@@ -251,6 +263,9 @@ section finite_level
 
 variable [IsQuaternionAlgebra F D]
 
+/-- An auxiliary definition: weight 2 automorphic forms of a fixed level, but given as
+a submodule of the space of all weight 2 automorphic forms. For the type, see
+`TotallyDefiniteQuaternionAlgebra.WeightTwoAutomorphicFormOfLevel`. -/
 def WeightTwoAutomorphicFormOfLevel_aux (U : Subgroup (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ)
     (R : Type*) [CommRing R] : Submodule R (WeightTwoAutomorphicForm F D R) where
   carrier := {φ | ∀ u ∈ U, u • φ = φ}
@@ -258,6 +273,10 @@ def WeightTwoAutomorphicFormOfLevel_aux (U : Subgroup (D ⊗[F] (FiniteAdeleRing
   zero_mem' := by simp_all
   smul_mem' c {x} hx := by simp_all [smul_comm]
 
+/--
+Weight 2 automorphic forms of a fixed level for a totally definite quaternion algebra
+over a totally real field.
+-/
 def WeightTwoAutomorphicFormOfLevel (U : Subgroup (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ)
     (R : Type*) [CommRing R] : Type _ := WeightTwoAutomorphicFormOfLevel_aux U R
 


### PR DESCRIPTION
`FLT.AutomorphicForm.QuaternionAlgebra.Defs` now lints.