### PR TITLE
chore: get the module topology file linting.

### DIFF
--- a/FLT/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
+++ b/FLT/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
@@ -122,7 +122,7 @@ theorem continuous_mul'
   Module.continuous_bilinear_of_finite (LinearMap.mul R D)
 
 include R in
-lemma topologicalSemiring [Module.Free R D] : IsTopologicalSemiring D where
+lemma topologicalSemiring : IsTopologicalSemiring D where
   continuous_add := (toContinuousAdd R D).1
   continuous_mul := continuous_mul' R D
 
@@ -244,6 +244,9 @@ over a complete thing so I don't think there can be any other possibility
 (the argument is weak here)
 -/
 
+/-- Given a linear isomorphism between two topological modules with the module topology,
+upgrades it to a continuous linear isomorphism using the fact that linear maps between modules
+with the module topology are automatically continuous. -/
 @[simps!]
 def continuousLinearEquiv {A B R : Type*} [TopologicalSpace A]
     [TopologicalSpace B] [TopologicalSpace R] [Semiring R] [AddCommMonoid A] [AddCommMonoid B]
@@ -312,3 +315,4 @@ def continuousAlgEquiv {A B : Type*} (R S₁ : Type*) {S₂ : Type*} [Topologica
     rw [ModuleTopology.eq_coinduced_of_surjective this]
     -- and the underlying functions are the same
     congr
+#lint


### PR DESCRIPTION
There was an unused argument. Also add a docstring, so the file lints.