### PR TITLE
chore: bump texlive-full distribution for docker image

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build blueprint and copy to `docs/blueprint`
         uses: xu-cheng/texlive-action@f886de8159e5952a131848a5fa9c3196a2132b5d # v2
         with:
-          docker_image: ghcr.io/xu-cheng/texlive-full:20231201
+          docker_image: ghcr.io/xu-cheng/texlive-full:20250401
           run: |
             # Install necessary dependencies and build the blueprint
             apk update


### PR DESCRIPTION
This PR simply bumps the TeX-Live distribution of the docker image we use to compile the blueprint. 