### PR TITLE
Kbuzzard fix conflicting defs

### DIFF
--- a/FLT/Patching/Algebra.lean
+++ b/FLT/Patching/Algebra.lean
@@ -27,12 +27,12 @@ lemma PatchingAlgebra.componentEquiv (k) : ∀ᶠ j in F,
     Nonempty (PatchingAlgebra.Component R F k ≃ₐ[Λ] R j ⧸ maximalIdeal (R j) ^ k) := by
   obtain ⟨n, hn⟩ := Algebra.UniformlyBoundedRank.cond (R := R) k
   refine UltraProduct.exists_algEquiv_of_bddAbove_card F n (.of_forall ?_) (.of_forall ?_)
-  · exact fun x ↦ ⟨AddSubgroup.quotient_finite_of_isOpen _ (isOpen_maximalIdeal_pow _ _), hn _⟩
+  · exact fun x ↦ ⟨AddSubgroup.quotient_finite_of_isOpen _ (isOpen_maximalIdeal_pow'' _ _), hn _⟩
   · exact fun i ↦ ((maximalIdeal (R i) ^ k).restrictScalars Λ).continuousSMul_quotient
 
 instance (k : ℕ) : Finite (PatchingAlgebra.Component R F k) :=
   (PatchingAlgebra.componentEquiv ℤ R F k).exists.choose_spec.some.finite_iff.mpr
-    (AddSubgroup.quotient_finite_of_isOpen _ (isOpen_maximalIdeal_pow _ _))
+    (AddSubgroup.quotient_finite_of_isOpen _ (isOpen_maximalIdeal_pow'' _ _))
 
 instance (k : ℕ) [NeZero k] : Nontrivial (PatchingAlgebra.Component R F k) := by
   obtain ⟨i, ⟨e⟩⟩ := (PatchingAlgebra.componentEquiv ℤ R F k).exists
@@ -186,7 +186,7 @@ lemma PatchingAlgebra.continuous_lift : Continuous (lift R F f) := by
   refine continuous_pi fun k ↦ ?_
   obtain ⟨n, hn⟩ := Algebra.UniformlyBoundedRank.cond (R := R) k
   refine UltraProduct.continuous_of_bddAbove_card F n (.of_forall ?_) _ (.of_forall ?_)
-  · exact fun x ↦ ⟨AddSubgroup.quotient_finite_of_isOpen _ (isOpen_maximalIdeal_pow _ _), hn _⟩
+  · exact fun x ↦ ⟨AddSubgroup.quotient_finite_of_isOpen _ (isOpen_maximalIdeal_pow'' _ _), hn _⟩
   · exact fun i ↦ (continuous_algebraMap _ _).comp (hf i)
 
 variable [CompactSpace Rₒₒ]
@@ -202,7 +202,7 @@ lemma PatchingAlgebra.lift_surjective (hf' : ∀ i, Function.Surjective (f i)) :
   obtain ⟨n, hn⟩ := Algebra.UniformlyBoundedRank.cond (R := R) i
   refine UltraProduct.surjective_of_bddAbove_card F n (.of_forall ?_) _ (.of_forall ?_)
       (.of_forall ?_)
-  · exact fun x ↦ ⟨AddSubgroup.quotient_finite_of_isOpen _ (isOpen_maximalIdeal_pow _ _), hn _⟩
+  · exact fun x ↦ ⟨AddSubgroup.quotient_finite_of_isOpen _ (isOpen_maximalIdeal_pow'' _ _), hn _⟩
   · exact fun x ↦ (continuous_algebraMap _ _).comp (hf x)
   · exact fun x ↦ Ideal.Quotient.mk_surjective.comp (hf' x)
 

--- a/FLT/Patching/Module.lean
+++ b/FLT/Patching/Module.lean
@@ -409,7 +409,7 @@ lemma PatchingModule.map_surjective
       filter_upwards with i
       obtain ⟨b, hb⟩ := Submodule.Quotient.mk_surjective _ (a i)
       simp only [← hb, mapQ_apply, LinearMap.id_coe, id_eq])
-    (l := fun k ↦ ⟨maximalIdeal R ^ k, isOpen_maximalIdeal_pow R k⟩)
+    (l := fun k ↦ ⟨maximalIdeal R ^ k, isOpen_maximalIdeal_pow'' R k⟩)
     (fun i j ↦ Ideal.pow_le_pow_right)
     (fun α ↦ have : Finite (R ⧸ α.1) := AddSubgroup.quotient_finite_of_isOpen _ α.2
       exists_maximalIdeal_pow_le_of_finite_quotient _)

--- a/FLT/Patching/Over.lean
+++ b/FLT/Patching/Over.lean
@@ -154,7 +154,7 @@ lemma PatchingModule.ker_componentMapModule_mkQ (α : OpenIdeals Λ) :
       Submodule.comap_bot, Submodule.ker_mkQ]
 
 omit  [Algebra.TopologicallyFG ℤ Λ]
-  [IsPatchingSystem Λ M F] in
+  [IsPatchingSystem Λ M F] [NonarchimedeanRing Λ] in
 lemma PatchingModule.mem_smul_top (x : PatchingModule Λ M F) :
     x ∈ (𝔫 • ⊤ : Submodule Λ (PatchingModule Λ M F)) ↔
       ∀ (α : OpenIdeals Λ), x.1 α ∈ (𝔫 • ⊤ : Submodule Λ (Component Λ M F α.1)) := by
@@ -236,7 +236,7 @@ lemma PatchingModule.mem_smul_top (x : PatchingModule Λ M F) :
       (by rw [← hs]; exact Submodule.subset_span x.2) trivial
 
 omit  [Algebra.TopologicallyFG ℤ Λ]
-  [IsPatchingSystem Λ M F] in
+  [IsPatchingSystem Λ M F] [NonarchimedeanRing Λ] in
 lemma PatchingModule.ker_map_mkQ :
     LinearMap.ker ((PatchingModule.map Λ F fun i ↦
       (𝔫 • ⊤ : Submodule Λ (M i)).mkQ).restrictScalars Λ) = 𝔫 • ⊤ := by

--- a/FLT/Patching/Utils/AdicTopology.lean
+++ b/FLT/Patching/Utils/AdicTopology.lean
@@ -80,24 +80,6 @@ lemma isCompact_of_isNoetherianRing [IsNoetherianRing R] [CompactSpace R] (I : I
     IsCompact (X := R) I := Ideal.isCompact_of_fg (IsNoetherian.noetherian _)
 
 variable {R} in
-omit [TopologicalSpace R] [IsTopologicalRing R] [IsAdicTopology R] in
-lemma exists_maximalIdeal_pow_le_of_finite_quotient' (I : Ideal R) [Finite (R ⧸ I)] :
-    ∃ n, (maximalIdeal R) ^ n ≤ I := by
-  by_cases hI : I = ⊤
-  · simp [hI]
-  have : Nontrivial (R ⧸ I) := Ideal.Quotient.nontrivial hI
-  have := IsLocalRing.of_surjective' (Ideal.Quotient.mk I) Ideal.Quotient.mk_surjective
-  have := IsLocalHom.of_surjective (Ideal.Quotient.mk I) Ideal.Quotient.mk_surjective
-  obtain ⟨n, hn⟩ := IsArtinianRing.isNilpotent_jacobson_bot (R := R ⧸ I)
-  have : (maximalIdeal R).map (Ideal.Quotient.mk I) = maximalIdeal (R ⧸ I) := by
-    ext x
-    obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective x
-    simp [sup_eq_left.mpr (le_maximalIdeal hI)]
-  rw [jacobson_eq_maximalIdeal _ bot_ne_top, ← this, ← Ideal.map_pow, Ideal.zero_eq_bot,
-    Ideal.map_eq_bot_iff_le_ker, Ideal.mk_ker] at hn
-  exact ⟨n, hn⟩
-
-variable {R} in
 lemma isOpen_iff_finite_quotient' [CompactSpace R] {I : Ideal R} :
     IsOpen (X := R) I ↔ Finite (R ⧸ I) := by
   constructor

--- a/FLT/Patching/Utils/AdicTopology.lean
+++ b/FLT/Patching/Utils/AdicTopology.lean
@@ -8,6 +8,7 @@ import Mathlib.Topology.Connected.Separation
 import FLT.Patching.Utils.InverseLimit
 import FLT.Patching.Utils.Lemmas
 import Mathlib.RingTheory.Artinian.Ring
+import Mathlib.Topology.Algebra.Ring.Compact
 
 variable (R) [CommRing R] [IsLocalRing R] [TopologicalSpace R] [IsTopologicalRing R]
 
@@ -23,11 +24,11 @@ instance (priority := 100) :
     NonarchimedeanRing R :=
   IsLocalRing.IsAdicTopology.isAdic (R := R) ▸ RingSubgroupsBasis.nonarchimedean _
 
-lemma isOpen_maximalIdeal_pow (n : ℕ) : IsOpen (X := R) ↑(maximalIdeal R ^ n) :=
+lemma isOpen_maximalIdeal_pow'' (n : ℕ) : IsOpen (X := R) ↑(maximalIdeal R ^ n) :=
   (isAdic_iff.mp IsLocalRing.IsAdicTopology.isAdic).1 _
 
-lemma isOpen_maximalIdeal : IsOpen (X := R) (maximalIdeal R) :=
-  pow_one (maximalIdeal R) ▸ isOpen_maximalIdeal_pow R 1
+lemma isOpen_maximalIdeal' : IsOpen (X := R) (maximalIdeal R) :=
+  pow_one (maximalIdeal R) ▸ isOpen_maximalIdeal_pow'' R 1
 
 open Filter Topology in
 lemma hasBasis_maximalIdeal_pow :
@@ -39,13 +40,13 @@ instance (priority := 100) [IsNoetherianRing R] : T2Space R := by
   rintro x (hx : x ∉ (⊥ : Ideal R))
   rw [← Ideal.iInf_pow_eq_bot_of_isLocalRing _ (IsLocalRing.maximalIdeal.isMaximal R).ne_top] at hx
   obtain ⟨n, hn⟩ : ∃ n, x ∉ maximalIdeal R ^ n := by simpa using hx
-  exact ⟨_, (isOpen_maximalIdeal_pow R n).mem_nhds (zero_mem _), hn⟩
+  exact ⟨_, (isOpen_maximalIdeal_pow'' R n).mem_nhds (zero_mem _), hn⟩
 
 -- This is actually an iff
 instance (priority := 100) [IsArtinianRing R] : DiscreteTopology R := by
   rw [discreteTopology_iff_isOpen_singleton_zero]
   obtain ⟨n, hn⟩ := IsArtinianRing.isNilpotent_jacobson_bot (R := R)
-  convert isOpen_maximalIdeal_pow R n
+  convert isOpen_maximalIdeal_pow'' R n
   rw [← jacobson_eq_maximalIdeal _ bot_ne_top, hn]
   rfl
 
@@ -80,7 +81,7 @@ lemma isCompact_of_isNoetherianRing [IsNoetherianRing R] [CompactSpace R] (I : I
 
 variable {R} in
 omit [TopologicalSpace R] [IsTopologicalRing R] [IsAdicTopology R] in
-lemma exists_maximalIdeal_pow_le_of_finite_quotient (I : Ideal R) [Finite (R ⧸ I)] :
+lemma exists_maximalIdeal_pow_le_of_finite_quotient' (I : Ideal R) [Finite (R ⧸ I)] :
     ∃ n, (maximalIdeal R) ^ n ≤ I := by
   by_cases hI : I = ⊤
   · simp [hI]
@@ -97,7 +98,7 @@ lemma exists_maximalIdeal_pow_le_of_finite_quotient (I : Ideal R) [Finite (R ⧸
   exact ⟨n, hn⟩
 
 variable {R} in
-lemma isOpen_iff_finite_quotient [CompactSpace R] {I : Ideal R} :
+lemma isOpen_iff_finite_quotient' [CompactSpace R] {I : Ideal R} :
     IsOpen (X := R) I ↔ Finite (R ⧸ I) := by
   constructor
   · intro H
@@ -105,10 +106,10 @@ lemma isOpen_iff_finite_quotient [CompactSpace R] {I : Ideal R} :
   · intro H
     obtain ⟨n, hn⟩ := exists_maximalIdeal_pow_le_of_finite_quotient I
     exact AddSubgroup.isOpen_mono (H₁ := (maximalIdeal R ^ n).toAddSubgroup)
-      (H₂ := I.toAddSubgroup) hn (isOpen_maximalIdeal_pow R n)
+      (H₂ := I.toAddSubgroup) hn (isOpen_maximalIdeal_pow'' R n)
 
 instance (n : ℕ) : DiscreteTopology (R ⧸ maximalIdeal R ^ n) :=
-  AddSubgroup.discreteTopology _ (isOpen_maximalIdeal_pow R n)
+  AddSubgroup.discreteTopology _ (isOpen_maximalIdeal_pow'' R n)
 
 instance [IsNoetherianRing R] : IsHausdorff (maximalIdeal R) R where
   haus' x hx := show x ∈ (⊥ : Ideal R) by

--- a/FLT/Patching/Utils/Depth.lean
+++ b/FLT/Patching/Utils/Depth.lean
@@ -95,7 +95,7 @@ lemma Module.depth_le_krullDim_support [Nontrivial M] [Module.Finite R M] :
       apply Ideal.Quotient.lift_surjective_of_surjective
       apply Ideal.Quotient.lift_surjective_of_surjective
       exact Ideal.Quotient.mk_surjective
-    have := ringKrullDim_quotient_succ_le_of_nonZeroDivisor (R := R ⧸ annihilator R M) x (by
+    have := ringKrullDim_quotient_succ_le_of_nonZeroDivisor (R := R ⧸ annihilator R M) (r := x) (by
       intro z hz
       obtain ⟨z, rfl⟩ := Ideal.Quotient.mk_surjective z
       simp only [← map_mul, Ideal.Quotient.eq_zero_iff_mem,

--- a/FLT/Patching/Utils/Lemmas.lean
+++ b/FLT/Patching/Utils/Lemmas.lean
@@ -6,6 +6,8 @@ import Mathlib.Topology.Algebra.OpenSubgroup
 import Mathlib.Topology.Algebra.Ring.Ideal
 import Mathlib.Topology.Separation.Profinite
 import Mathlib.RingTheory.Artinian.Module
+import Mathlib.RingTheory.KrullDimension.NonZeroDivisors
+
 
 lemma IsUnit.pi_iff {ι} {M : ι → Type*} [∀ i, Monoid (M i)] {x : Π i, M i} :
     IsUnit x ↔ ∀ i, IsUnit (x i) := by
@@ -337,21 +339,6 @@ lemma IsModuleTopology.compactSpace
   letI : ContinuousAdd M := toContinuousAdd R M
   ⟨Submodule.isCompact_of_fg (Module.Finite.fg_top (R := R))⟩
 
-lemma ringKrullDim_quotient {R : Type*} [CommRing R] (I : Ideal R) :
-    ringKrullDim (R ⧸ I) = Order.krullDim (PrimeSpectrum.zeroLocus (R := R) I) := by
-  let e : PrimeSpectrum (R ⧸ I) ≃ (PrimeSpectrum.zeroLocus (R := R) I) :=
-    (Equiv.ofInjective _ (PrimeSpectrum.comap_injective_of_surjective _
-      Ideal.Quotient.mk_surjective)).trans (Equiv.setCongr
-      (by rw [PrimeSpectrum.range_comap_of_surjective _ _ Ideal.Quotient.mk_surjective,
-        Ideal.mk_ker]))
-  let e' : PrimeSpectrum (R ⧸ I) ≃o (PrimeSpectrum.zeroLocus (R := R) I) :=
-    { __ := e, map_rel_iff' := fun {a b} ↦ by
-        show a.asIdeal.comap _ ≤ b.asIdeal.comap _ ↔ a ≤ b
-        rw [← Ideal.map_le_iff_le_comap,
-          Ideal.map_comap_of_surjective _ Ideal.Quotient.mk_surjective]
-        rfl }
-  rw [ringKrullDim, Order.krullDim_eq_of_orderIso e']
-
 lemma disjoint_nonZeroDivisors_of_mem_minimalPrimes
     {R : Type*} [CommRing R] (p : Ideal R) (hp : p ∈ minimalPrimes R) :
     Disjoint (p : Set R) (nonZeroDivisors R) := by
@@ -381,28 +368,3 @@ lemma disjoint_nonZeroDivisors_of_mem_minimalPrimes
   · rw [mul_assoc, ← pow_succ, tsub_add_cancel_of_le, Nat.find_spec H]
     rwa [Nat.one_le_iff_ne_zero]
   · exact Nat.find_min H (Nat.sub_one_lt this)
-
-lemma ringKrullDim_quotient_succ_le_of_nonZeroDivisor
-    {R : Type*} [CommRing R] (r : R) (hr : r ∈ nonZeroDivisors R) :
-    ringKrullDim (R ⧸ Ideal.span {r}) + 1 ≤ ringKrullDim R := by
-  by_cases hr' : Ideal.span {r} = ⊤
-  · rw [hr', ringKrullDim_eq_bot_of_subsingleton]
-    simp
-  have : Nonempty (PrimeSpectrum.zeroLocus (R := R) (Ideal.span {r})) := by
-    rwa [Set.nonempty_coe_sort, Set.nonempty_iff_ne_empty, ne_eq,
-      PrimeSpectrum.zeroLocus_empty_iff_eq_top]
-  have := Ideal.Quotient.nontrivial hr'
-  have := (Ideal.Quotient.mk (Ideal.span {r})).domain_nontrivial
-  rw [ringKrullDim_quotient, Order.krullDim_eq_iSup_length, ringKrullDim,
-    Order.krullDim_eq_iSup_length, ← WithBot.coe_one, ← WithBot.coe_add,
-    ENat.iSup_add, WithBot.coe_le_coe, iSup_le_iff]
-  intros l
-  obtain ⟨p, hp, hp'⟩ := Ideal.exists_minimalPrimes_le (J := l.head.1.asIdeal) bot_le
-  let p' : PrimeSpectrum R := ⟨p, hp.1.1⟩
-  have hp' : p' < l.head := lt_of_le_of_ne hp' (by
-    intro h
-    have := disjoint_nonZeroDivisors_of_mem_minimalPrimes p hp
-    exact Set.disjoint_iff.mp this ⟨show r ∈ p by simpa [← h] using l.head.2, hr⟩)
-  refine le_trans ?_ (le_iSup _ ((l.map Subtype.val (fun _ _ ↦ id)).cons p' hp'))
-  show (l.length + 1 : ℕ∞) ≤ ↑(0 + l.length + 1)
-  simp


### PR DESCRIPTION
In `FLT/Patching/Utils/AdicTopology.lean` we have a definition `isOpen_maximalIdeal_pow` which doesn't demand a compactness hypothesis. Unfortunately in `Mathlib.Topology.Algebra.Ring.Compact` from mathlib there is also a definition of `isOpen_maximalIdeal_pow` and this one does. This means we can't import Mathlib and FLT at the same time. 

Currently I've fixed this by adding `import Mathlib.Topology.Algebra.Ring.Compact` to `FLT/Patching/Utils/AdicTopology.lean` and then renaming the conflicting names with primes (I needed two primes for `isOpen_maximalIdeal_pow''` as there's also a primed version in the same FLT file).

Similar problems occur with `isOpen_maximalIdeal` and `isOpen_iff_finite_quotient` (the mathlib versions seem to be different to our versions), but these do not seem to be used.