### PR TITLE
chore: shake

### DIFF
--- a/FLT/HaarMeasure/HaarChar/AddEquiv.lean
+++ b/FLT/HaarMeasure/HaarChar/AddEquiv.lean
@@ -1,4 +1,4 @@
-import Mathlib.MeasureTheory.Measure.Haar.DistribChar
+import Mathlib.MeasureTheory.Measure.Haar.Unique
 
 open MeasureTheory.Measure
 open scoped NNReal Pointwise ENNReal

--- a/FLT/HaarMeasure/HaarChar/Ring.lean
+++ b/FLT/HaarMeasure/HaarChar/Ring.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard
 -/
 import FLT.HaarMeasure.HaarChar.AddEquiv
-import Mathlib
 
 open scoped NNReal Pointwise ENNReal
 


### PR DESCRIPTION
I accidentally pushed an `import Mathlib` and suddenly docs took 45 minutes to build aargh.

@YaelDillies you have a solution for this right?

Would another solution be "get CI to shake"? This might be preferred (mathlib does this, right?) Is this easy?