### PR TITLE
CI: checkout project during lint style

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -45,6 +45,11 @@ jobs:
     name: Lint style
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout project
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # Fetch all history for all branches and tags
+
       - name: Don't 'import Mathlib', use precise imports
         if: always()
         run: |


### PR DESCRIPTION
Otherwise, this does nothing!

Also fix the CI error that should have previously been caught.