### PR TITLE
chore: try to stop CI randomly taking an hour

### DIFF
--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -39,7 +39,11 @@ sed -i s/TOOLCHAIN/`grep -oP 'v4\..*' lean-toolchain`/ docbuild/lakefile.toml
 cd docbuild
 
 # Disable an error message due to a non-blocking bug. See Zulip
-MATHLIB_NO_CACHE_ON_UPDATE=1 ~/.elan/bin/lake update FLT
+# (note added by kmb : no idea what that "See Zulip" is referring to but Bhavik
+# suggests that we should be updating doc-gen4 rather than FLT here in order to prevent
+# the "build project API documentation" step of CI from taking 42 minutes on
+# e.g. PR 523 despite not bumping mathlib)
+MATHLIB_NO_CACHE_ON_UPDATE=1 ~/.elan/bin/lake update doc-gen4
 
 # Build the docs
 ~/.elan/bin/lake build FLT:docs


### PR DESCRIPTION
#523 took nearly an hour in CI and I don't know why. More precisely https://github.com/ImperialCollegeLondon/FLT/actions/runs/15141983212/job/42568200037 shows that it spent 42 minutes building API docs, even though we didn't bump mathlib. Bhavik suggests that this PR might fix this.

@pitmonticone what do you think? I guess we're still figuring out how to run doc-gen in the preferred way. 