### PR TITLE
chore: simplify subproject setup

### DIFF
--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -7,9 +7,11 @@ set -euo pipefail
 # Build HTML documentation for FLT
 # The output will be located in docs/docs
 
+# Create a temporary docbuild folder
+mkdir -p docbuild
+
 # Template lakefile.toml
-template() {
-  cat <<EOF
+cat << EOF > docbuild/lakefile.toml
 name = "docbuild"
 reservoir = false
 version = "0.1.0"
@@ -22,18 +24,8 @@ path = "../"
 [[require]]
 scope = "leanprover"
 name = "doc-gen4"
-rev = "TOOLCHAIN"
+rev = "$(< lean-toolchain cut -f 2 -d: )"
 EOF
-}
-
-# Create a temporary docbuild folder
-mkdir -p docbuild
-
-# Equip docbuild with the template lakefile.toml
-template > docbuild/lakefile.toml
-
-# Substitute the toolchain from lean-toolchain into docbuild/lakefile.toml
-sed -i s/TOOLCHAIN/`grep -oP 'v4\..*' lean-toolchain`/ docbuild/lakefile.toml
 
 # Initialise docbuild as a Lean project
 cd docbuild


### PR DESCRIPTION
This PR adjusts the `lakefile.toml` setup in the subproject created for doc-gen in the following way. Previously, it did:
- make the file with a dummy string
- find the toolchain
- use sed to edit the toolchain into the file
whereas the new version does:
- find the toolchain
- make the correct file

This should not have any significant performance improvement (and certainly no performance loss).
This script has been tested in at least four other projects and has worked for (cumulatively) several months.