### PR TITLE
CI: don't build docs on non-`main` branches for real

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -117,7 +117,7 @@ jobs:
         run: scripts/build_docs.sh
 
       - name: Bundle dependencies
-        if: github.event_name == 'push'
+        if: github.ref == 'refs/heads/main'
         uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # v1.237.0
         with:
           working-directory: docs
@@ -125,19 +125,19 @@ jobs:
           bundler-cache: true  # Enable caching for bundler
 
       - name: Build website using Jekyll
-        if: github.event_name == 'push' && env.DOCS_EXISTS == 'true'
+        if: github.ref == 'refs/heads/main' && env.DOCS_EXISTS == 'true'
         working-directory: docs
         env:
             JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: JEKYLL_ENV=production bundle exec jekyll build  # Note this will also copy the blueprint and API doc into docs/_site
 
       - name: "Upload website (API documentation, blueprint and any home page)"
-        if: github.event_name == 'push'
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ${{ env.DOCS_EXISTS == 'true' && 'docs/_site' || 'docs/' }}
 
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
+        if: github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -12,6 +12,15 @@ on:
       - 'lakefile.toml'
       - 'lake-manifest.json'
   pull_request:
+    paths:
+      - '**/*.lean'
+      - '**/blueprint.yml'
+      - 'blueprint/**'
+      - 'docs/**'
+      - 'scripts/**'
+      - 'lean-toolchain'
+      - 'lakefile.toml'
+      - 'lake-manifest.json'
   workflow_dispatch: # Allow manual triggering of the workflow from the GitHub Actions interface
 
 # We do not cancel CI on main so as to keep all commits green (cancelling CI on a commit makes it

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -11,6 +11,7 @@ on:
       - 'lean-toolchain'
       - 'lakefile.toml'
       - 'lake-manifest.json'
+  pull_request:
   workflow_dispatch: # Allow manual triggering of the workflow from the GitHub Actions interface
 
 # We do not cancel CI on main so as to keep all commits green (cancelling CI on a commit makes it

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -113,7 +113,7 @@ jobs:
         run: ~/.elan/bin/lake exe checkdecls blueprint/lean_decls
 
       - name: Build project API documentation
-        if: github.event_name == 'push'
+        if: github.ref == 'refs/heads/main'
         run: scripts/build_docs.sh
 
       - name: Bundle dependencies


### PR DESCRIPTION
The condition was wrong, as the workflow is triggered by push even when on non-`main` branches.