### PR TITLE
Adjust the actions on PR comments to also add the ability to mark a PR as awaiting-author 

### DIFF
--- a/.github/workflows/05-pr-comment.yml
+++ b/.github/workflows/05-pr-comment.yml
@@ -5,16 +5,32 @@ on:
     types: [created]
 
 jobs:
+  awaiting_author:
+    if: github.event.issue.pull_request != null && contains(github.event.comment.body, 'awaiting-author')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add 'awaiting-author; and remove any 'awaiting-review'
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { owner, repo, number: issue_number } = context.issue;
+          await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['awaiting-author'] });
+          await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'awaiting-review' }).catch(() => {});
+
   awaiting_review:
     if: github.event.issue.pull_request != null && contains(github.event.comment.body, 'awaiting-review')
     runs-on: ubuntu-latest
 
     steps:
-    - name: Add "awaiting-review" label to the PR
-      run: |
-        curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-        -d '{"labels":["awaiting-review"]}' \
-        https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels
+    - name: Add 'awaiting-review; and remove any 'awaiting-author'
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { owner, repo, number: issue_number } = context.issue;
+          await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['awaiting-review'] });
+          await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'awaiting-author' }).catch(() => {});
 
     - name: Retrieve project ID
       id: get_project_id

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Once you are assigned to an issue, begin working on the corresponding task. You 
 ### 6. Review Process
 
 - After finishing the task and ensuring your PR is ready for review, comment `awaiting-review` on the PR. This will add the `awaiting-review` label to your PR and move the task from `In Progress` to the `In Review` column of the dashboard.
-- The project maintainers will review the PR. They may request changes, approve the PR, or provide feedback. If they comment `awaiting-author` this will add the `awaiting-author` label to your PR. When you've responded comment `awaiting-review` again.
+- The project maintainers will review the PR. They may request changes, approve the PR, or provide feedback. If they comment `awaiting-author` this will add the `awaiting-author` label to your PR. When you've responded comment `awaiting-review` again to remove it and add the `awaiting-review` tag agian.
 
 ### 7. Task Completion
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Once you are assigned to an issue, begin working on the corresponding task. You 
 ### 6. Review Process
 
 - After finishing the task and ensuring your PR is ready for review, comment `awaiting-review` on the PR. This will add the `awaiting-review` label to your PR and move the task from `In Progress` to the `In Review` column of the dashboard.
-- The project maintainers will review the PR. They may request changes, approve the PR, or provide feedback. If they comment `awaiting-author` this will add the `awaiting-author` label to your PR.
+- The project maintainers will review the PR. They may request changes, approve the PR, or provide feedback. If they comment `awaiting-author` this will add the `awaiting-author` label to your PR. When you've responded comment `awaiting-review` again.
 
 ### 7. Task Completion
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,8 @@ Once you are assigned to an issue, begin working on the corresponding task. You 
 ### 6. Review Process
 
 - After finishing the task and ensuring your PR is ready for review, comment `awaiting-review` on the PR. This will add the `awaiting-review` label to your PR and move the task from `In Progress` to the `In Review` column of the dashboard.
-- The project maintainers will review the PR. They may request changes, approve the PR, or provide feedback. If they comment `awaiting-author` this will add the `awaiting-author` label to your PR. When you've responded comment `awaiting-review` again to remove it and add the `awaiting-review` tag agian.
+ The project maintainers will review the PR. They may request changes, approve the PR, or provide feedback. If they comment `awaiting-author`, this will add the `awaiting-author` label to your PR.
+ When you've responded, comment `awaiting-review` again to remove it and add the `awaiting-review` tag again.
 
 ### 7. Task Completion
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Once you are assigned to an issue, begin working on the corresponding task. You 
 ### 6. Review Process
 
 - After finishing the task and ensuring your PR is ready for review, comment `awaiting-review` on the PR. This will add the `awaiting-review` label to your PR and move the task from `In Progress` to the `In Review` column of the dashboard.
-- The project maintainers will review the PR. They may request changes, approve the PR, or provide feedback.
+- The project maintainers will review the PR. They may request changes, approve the PR, or provide feedback. If they comment `awaiting-author` this will add the `awaiting-author` label to your PR.
 
 ### 7. Task Completion
 


### PR DESCRIPTION
Also renamed file as not just about awaiting-review and updated contributing.md to advertise this change

Also used the javascript mechanism for doing this rather than CURL 

This addresses most of the issue #619 but possible we want to also move the tasks between columns as well

Feel free to play with this here https://github.com/Shiney/FLT/pull/2 to see if it's doing what you expect