### PR TITLE
modified:   lakefile.toml (Cache Mathlib builds until invalidation)

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -21,3 +21,6 @@ git = "https://github.com/PatrickMassot/checkdecls.git"
 [[lean_lib]]
 name = "FLT"
 globs = ["FLT", "FermatsLastTheorem"]
+
+[[dependancies.FLT]]
+path="FLT"


### PR DESCRIPTION
Cache Mathlib builds, until invalidation. This reduces Mathlib incremental builds from a span of hours, to only a few minutes. 