### PR TITLE
ci: Use docgen-action to build the website.

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Lint project
         run: env LEAN_ABORT_ON_PANIC=1 ~/.elan/bin/lake exe runLinter FLT
 
-      - uses: leanprover-community/docgen-action@main
+      - uses: leanprover-community/docgen-action@b210116d3e6096c0c7146f7a96a6d56b6884fef5 # 2025-06-12
         with:
           blueprint: true
           homepage: docs

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -1,5 +1,4 @@
 name: Build project
-
 on:
   push:
     branches:
@@ -77,81 +76,7 @@ jobs:
       - name: Lint project
         run: env LEAN_ABORT_ON_PANIC=1 ~/.elan/bin/lake exe runLinter FLT
 
-      - name: Cache Mathlib docs
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - uses: leanprover-community/docgen-action@main
         with:
-          path: |
-            docbuild/.lake/build/doc/Aesop
-            docbuild/.lake/build/doc/Batteries
-            docbuild/.lake/build/doc/find
-            docbuild/.lake/build/doc/Init
-            docbuild/.lake/build/doc/Lake
-            docbuild/.lake/build/doc/Lean
-            docbuild/.lake/build/doc/Mathlib
-            docbuild/.lake/build/doc/Std
-          key: Docs-${{ hashFiles('lake-manifest.json') }}
-
-      - name: Check for `docs` folder # this is meant to detect a Jekyll-based website
-        id: check_docs
-        run: |
-          if [ -d docs ]; then
-            echo "The 'docs' folder exists in the repository."
-            echo "DOCS_EXISTS=true" >> $GITHUB_ENV
-          else
-            echo "The 'docs' folder does not exist in the repository."
-            echo "DOCS_EXISTS=false" >> $GITHUB_ENV
-          fi
-
-      - name: Build blueprint and copy to `docs/blueprint`
-        uses: xu-cheng/texlive-action@f886de8159e5952a131848a5fa9c3196a2132b5d # v2
-        with:
-          docker_image: ghcr.io/xu-cheng/texlive-full:20250401
-          run: |
-            # Install necessary dependencies and build the blueprint
-            apk update
-            apk add --update make py3-pip git pkgconfig graphviz graphviz-dev gcc musl-dev
-            git config --global --add safe.directory $GITHUB_WORKSPACE
-            git config --global --add safe.directory `pwd`
-            python3 -m venv env
-            source env/bin/activate
-            pip install --upgrade pip requests wheel
-            pip install pygraphviz --global-option=build_ext --global-option="-L/usr/lib/graphviz/" --global-option="-R/usr/lib/graphviz/"
-            pip install leanblueprint
-            leanblueprint pdf
-            mkdir -p docs
-            cp blueprint/print/print.pdf docs/blueprint.pdf
-            leanblueprint web
-            cp -r blueprint/web docs/blueprint
-
-      - name: Check declarations mentioned in the blueprint exist in Lean code
-        run: ~/.elan/bin/lake exe checkdecls blueprint/lean_decls
-
-      - name: Build project API documentation
-        if: github.ref == 'refs/heads/main'
-        run: scripts/build_docs.sh
-
-      - name: Bundle dependencies
-        if: github.ref == 'refs/heads/main'
-        uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
-        with:
-          working-directory: docs
-          ruby-version: "3.1"  # Specify Ruby version
-          bundler-cache: true  # Enable caching for bundler
-
-      - name: Build website using Jekyll
-        if: github.ref == 'refs/heads/main' && env.DOCS_EXISTS == 'true'
-        working-directory: docs
-        env:
-            JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: JEKYLL_ENV=production bundle exec jekyll build  # Note this will also copy the blueprint and API doc into docs/_site
-
-      - name: "Upload website (API documentation, blueprint and any home page)"
-        if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
-        with:
-          path: ${{ env.DOCS_EXISTS == 'true' && 'docs/_site' || 'docs/' }}
-
-      - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main'
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+          blueprint: true
+          homepage: docs


### PR DESCRIPTION
This PR replaces the docgen and blueprint steps of the workflow with [a single doc-gen action](https://github.com/leanprover-community/docgen-action). This should help in making the CI steps more consistent and easy to maintain across downstream projects. From the outside, everything should function exactly the same as before. Please see https://vierkantor.github.io/FLT for a test build of the site.