### PR TITLE
Prove unitsrat_join_unitszHat

### DIFF
--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -615,7 +615,6 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       apply Int.eq_zero_of_dvd_of_nonneg_of_lt (n := g) (Int.natCast_nonneg _)
       · exact Int.lt_of_toNat_lt (ZMod.val_lt (X N))
       exact ⟨a, by rw [mul_comm, ← smul_eq_mul, ha]⟩
-    exact hgx
 
 end multiplicative_structure_of_QHat
 

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -548,7 +548,19 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       simp only [← hX, AddMonoidHom.coe_coe, Algebra.TensorProduct.includeRight_apply,
         Algebra.TensorProduct.tmul_mul_tmul, mul_one, I, J] at this
       simp only [Algebra.TensorProduct.includeRight_apply, this, map_natCast, I, J]
-
+    let IdealJ : Ideal ℤ := by -- make this construction into a lemma?
+      refine ⟨⟨⟨J, ?_⟩, ?_⟩, ?_⟩
+      intro a b
+      simp only [Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, Int.cast_add, J]
+      exact Ideal.add_mem I
+      simp only [Int.coe_castRingHom, Set.mem_preimage, Int.cast_zero, SetLike.mem_coe,
+        Submodule.zero_mem, J, I]
+      simp only [smul_eq_mul, I, J, Set.mem_preimage, Int.coe_castRingHom, Int.cast_mul]
+      intro c x
+      apply Ideal.mul_mem_left I
+    -- #check EuclideanDomain.to_principal_ideal_domain (R := ℤ)
+    -- #check IsPrincipalIdealRing.principal (R := ℤ) IdealJ
+    -- #check Submodule.IsPrincipal.principal IdealJ
     sorry
 
 end multiplicative_structure_of_QHat

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -528,11 +528,12 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
     -- now the harder part which uses that ℤ is a PID
     intro x hx
     rcases lowestTerms (x⁻¹.val) with ⟨⟨M, y, cop, hxinv⟩, unique⟩
+    clear cop unique
     have : x * (i₂ y) = M := by
-      have h : (M : QHat) = (M : ℚ) ⊗ₜ[ℤ] 1 := by
-        rw [← Algebra.TensorProduct.includeLeft_apply (S := ℚ) (M : ℚ), map_natCast]
       rw [← one_mul (M : QHat), ← Units.val_one, ← mul_inv_cancel x, Units.val_mul, mul_assoc]
       congr!
+      have h : (M : QHat) = (M : ℚ) ⊗ₜ[ℤ] 1 := by
+        rw [← Algebra.TensorProduct.includeLeft_apply (S := ℚ) (M : ℚ), map_natCast]
       rw [hxinv, h, Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_div, inv_mul_cancel₀,
         Algebra.TensorProduct.includeRight_apply]
       simp only [ne_eq, Rat.natCast_eq_zero, PNat.ne_zero, not_false_eq_true]
@@ -543,11 +544,10 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       simp only [Int.coe_castRingHom, Set.mem_preimage, Int.cast_natCast, SetLike.mem_coe, J, I]
       rw [Ideal.mem_span_singleton']
       use y
-      rw [mul_comm]
       apply injective_zHat
-      simp only [← hX, AddMonoidHom.coe_coe, Algebra.TensorProduct.includeRight_apply,
+      simp only [mul_comm, ← hX, AddMonoidHom.coe_coe, Algebra.TensorProduct.includeRight_apply,
         Algebra.TensorProduct.tmul_mul_tmul, mul_one, I, J] at this
-      simp only [Algebra.TensorProduct.includeRight_apply, this, map_natCast, I, J]
+      rw [Algebra.TensorProduct.includeRight_apply, this, map_natCast]
     let IdealJ : Ideal ℤ := by -- make this construction into a lemma?
       refine ⟨⟨⟨J, ?_⟩, ?_⟩, ?_⟩
       intro a b
@@ -558,9 +558,19 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       simp only [smul_eq_mul, I, J, Set.mem_preimage, Int.coe_castRingHom, Int.cast_mul]
       intro c x
       apply Ideal.mul_mem_left I
-    -- #check EuclideanDomain.to_principal_ideal_domain (R := ℤ)
-    -- #check IsPrincipalIdealRing.principal (R := ℤ) IdealJ
-    -- #check Submodule.IsPrincipal.principal IdealJ
+    obtain ⟨g, hg⟩ : Submodule.IsPrincipal IdealJ := by
+      exact IsPrincipalIdealRing.principal (R := ℤ) IdealJ
+    wlog gpos : 0 < g with H
+    · specialize H x M y hxinv this X hX Jnonzero (-g)
+      apply H (by rw [← Set.neg_singleton, Submodule.span_neg, ← hg])
+      rw [Int.neg_pos, Int.lt_iff_le_and_ne, ← Int.not_gt_eq]
+      refine ⟨gpos, ?_⟩
+      intro h
+      rw [h, Submodule.span_zero_singleton, Submodule.eq_bot_iff] at hg
+      specialize hg (M : ℤ) Jnonzero
+      simp only [Int.natCast_eq_zero, PNat.ne_zero] at hg
+    suffices h : Ideal.span {X} = Ideal.span {(g : ZHat)} by
+      sorry
     sorry
 
 end multiplicative_structure_of_QHat

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -583,9 +583,8 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       have : y * z = 1 := by
         rw [mul_comm, ← sub_right_inj (a := (1 : ZHat)), sub_self]
         apply ZHat.eq_zero_of_mul_eq_zero N
-        simp only [PNat.mk_coe, N]
+        simp only [N, PNat.mk_coe]
         rwa [← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos)]
-      let Z : ZHatˣ := ⟨z, y, by rw[mul_comm]; exact this, this⟩
       simp only [Subgroup.mem_sup, MonoidHom.mem_range, exists_exists_eq_and]
       set G : ℚ := 1 / g with G_def
       have gG : g * G = 1 := by
@@ -596,6 +595,7 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
         exact gpos
       let gunit : ℚˣ := ⟨(g : ℚ), G, gG, by rw [mul_comm]; exact gG⟩
       use gunit
+      let Z : ZHatˣ := ⟨z, y, by rw[mul_comm]; exact this, this⟩
       use Z
       simp only [← Units.eq_iff, ← hX, Units.map_mk, MonoidHom.coe_coe, map_intCast,
         Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.includeRight_apply,
@@ -614,15 +614,13 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       exact huh
     apply le_antisymm
     · suffices h : X N = 0 by
-        rw [Ideal.span_singleton_le_span_singleton, dvd_def]
         rcases (ZHat.multiples N X).2 h with ⟨y, hy⟩
+        rw [Ideal.span_singleton_le_span_singleton]
         use y
         rw [← hy]
         congr
-        simp only [PNat.mk_coe, N]
+        simp only [N, PNat.mk_coe]
         rw [← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos)]
-      apply not_not.1
-      intro hxN
       let xg := (X N).val
       have : (xg - X) N = 0 := by
         simp only [ZHat, ZMod.castHom_apply, ZHat.instDFunLikePNatZModVal,
@@ -635,7 +633,7 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
         · apply hgx
           rw [Ideal.mem_span_singleton', ← hy]
           use y
-          simp only [PNat.mk_coe, N]
+          simp only [N, PNat.mk_coe]
           rw [← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos), mul_comm]
         apply Ideal.mem_span_singleton_self
       have hxg : (xg : ℤ) ∈ IdealJ := by
@@ -644,8 +642,15 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
           J, I, xg, N]
       rw [hg, Submodule.mem_span_singleton] at hxg
       rcases hxg with ⟨a, ha⟩
-      rw [smul_eq_mul] at ha
-      sorry
+      simp only [smul_eq_mul, xg] at ha
+      rw [← ZMod.val_eq_zero, ← Int.natCast_eq_zero]
+      apply Int.eq_zero_of_dvd_of_nonneg_of_lt (n := g)
+      · apply Int.natCast_nonneg
+      · apply Int.lt_of_toNat_lt
+        rw [Int.toNat_natCast]
+        apply ZMod.val_lt (X N)
+      use a
+      rw [mul_comm, ha]
     exact hgx
 
 end multiplicative_structure_of_QHat

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -511,17 +511,14 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       let q : ℚˣ := ⟨v / N, N / v, by field_simp, by field_simp⟩
       use ((Units.map ↑i₁) q)
       simp only [MonoidHom.mem_range, exists_exists_eq_and]
-      constructor
-      use q
-      use t
+      refine ⟨⟨q, rfl⟩, t, ?_⟩
       simp only [← Units.eq_iff, hy, ht, Units.map_mk, MonoidHom.coe_coe,
         Algebra.TensorProduct.includeLeft_apply, Units.val_mul, one_div, q, xunit]
       rw [← mul_one (N⁻¹ : ℚ), ← one_mul x, ← Algebra.TensorProduct.tmul_mul_tmul, div_eq_mul_inv,
         mul_comm (v : ℚ), ← mul_one 1, ← Algebra.TensorProduct.tmul_mul_tmul, mul_assoc, mul_one]
       congr
-      simp only [← hv, ← Units.eq_iff, Units.val_mul, Units.coe_map, MonoidHom.coe_coe,
-        Algebra.TensorProduct.includeLeft_apply, xunit, q] at wzx
-      exact wzx
+      simpa only [← hv, ← Units.eq_iff, Units.val_mul, Units.coe_map, MonoidHom.coe_coe,
+        Algebra.TensorProduct.includeLeft_apply, xunit, q] using wzx
     clear * -
     intro x hx
     rcases canonicalForm (x⁻¹.val) with ⟨M, y, hxinv⟩
@@ -545,8 +542,8 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       rw [Algebra.TensorProduct.includeRight_apply, this, map_natCast]
     let IdealJ : Ideal ℤ := by -- make this construction into a function (for Mathlib)?
       refine ⟨⟨⟨J, ?_⟩, ?_⟩, ?_⟩
-      simp only [Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, Int.cast_add, J]
-      exact (fun {a b} ↦ Ideal.add_mem I)
+      · simp only [Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, Int.cast_add, J]
+        exact (fun {a b} ↦ Ideal.add_mem I)
       simp only [Int.coe_castRingHom, Set.mem_preimage, Int.cast_zero, SetLike.mem_coe,
         Submodule.zero_mem, J, I]
       simp only [smul_eq_mul, I, J, Set.mem_preimage, Int.coe_castRingHom, Int.cast_mul]
@@ -564,7 +561,8 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
     clear this hxinv y Jnonzero M
     let N : ℕ+ := ⟨g.toNat, Int.pos_iff_toNat_pos.1 gpos⟩
     suffices h : Ideal.span {X} = Ideal.span {(g : ZHat)} by
-      obtain ⟨y,hy⟩ : ∃ y,y*X=g := by rw [← Ideal.mem_span_singleton',h,Ideal.mem_span_singleton]
+      obtain ⟨y, hy⟩ : ∃ y, y * X = g := by 
+        rw [← Ideal.mem_span_singleton',h,Ideal.mem_span_singleton]
       obtain ⟨z,hz⟩ : ∃ z,z*g=X := by rw [← Ideal.mem_span_singleton',← h,Ideal.mem_span_singleton]
       have : y * z = 1 := by
         rw [mul_comm, ← sub_right_inj (a := (1 : ZHat)), sub_self]
@@ -576,7 +574,7 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       have gG : g * G = 1 := by
         rw [G_def, one_div, mul_inv_cancel₀]
         simp only [ne_eq, Rat.intCast_eq_zero, Int.ne_of_gt gpos, not_false_eq_true]
-      use ⟨g, G, gG, by rw [mul_comm]; exact gG⟩
+      use ⟨g, G, gG, mul_comm _ G ▸ gG⟩ 
       use ⟨z, y, by rw[mul_comm]; exact this, this⟩
       simp only [← Units.eq_iff, ← hX, Units.map_mk, MonoidHom.coe_coe, map_intCast,
         Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.includeRight_apply,
@@ -590,7 +588,7 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       simp only [Submodule.mem_mk, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk,
         Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, J, IdealJ, I] at this
       exact (Ideal.span_singleton_le_iff_mem _).2 this
-    apply le_antisymm
+    refine le_antisymm ?_ hgx
     · suffices h : X N = 0 by
         rcases (ZHat.multiples N X).2 h with ⟨y, hy⟩
         rw [Ideal.span_singleton_le_span_singleton, ← hy, PNat.mk_coe]

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -602,19 +602,51 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
         Units.val_mul, AddMonoidHom.coe_coe, gunit, Z]
       rw [← hz, ← mul_one 1, ← Algebra.TensorProduct.tmul_mul_tmul, mul_one, mul_comm,
         Algebra.TensorProduct.one_tmul_intCast]
+    have hgx : Ideal.span {(g : ZHat)} ≤ Ideal.span {X} := by
+      rw [Ideal.span_singleton_le_iff_mem]
+      have : g ∈ IdealJ := by
+        rw [hg, Ideal.submodule_span_eq]
+        apply Ideal.mem_span_singleton_self
+      have huh : g ∈ J := by
+        simp only [Submodule.mem_mk, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk, IdealJ] at this
+        exact this
+      simp only [Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, J, IdealJ, I] at huh
+      exact huh
     apply le_antisymm
     · suffices h : X N = 0 by
-        sorry
+        rw [Ideal.span_singleton_le_span_singleton, dvd_def]
+        rcases (ZHat.multiples N X).2 h with ⟨y, hy⟩
+        use y
+        rw [← hy]
+        congr
+        simp only [PNat.mk_coe, N]
+        rw [← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos)]
+      apply not_not.1
+      intro hxN
+      let xg := (X N).val
+      have : (xg - X) N = 0 := by
+        simp only [ZHat, ZMod.castHom_apply, ZHat.instDFunLikePNatZModVal,
+          AddSubgroupClass.coe_sub, SubringClass.coe_natCast, Pi.sub_apply, Pi.natCast_apply, xg]
+        simp only [ZMod.natCast_val, ZMod.cast_id', id_eq, sub_self]
+      rcases (ZHat.multiples N _).2 this with ⟨y, hy⟩
+      have : (xg : ZHat) ∈ Ideal.span {X} := by
+        rw [← sub_add_cancel (xg : ZHat) X]
+        apply Ideal.add_mem
+        · apply hgx
+          rw [Ideal.mem_span_singleton', ← hy]
+          use y
+          simp only [PNat.mk_coe, N]
+          rw [← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos), mul_comm]
+        apply Ideal.mem_span_singleton_self
+      have hxg : (xg : ℤ) ∈ IdealJ := by
+        simp only [Int.coe_castRingHom, Submodule.mem_mk, AddSubmonoid.mem_mk,
+          AddSubsemigroup.mem_mk, Set.mem_preimage, Int.cast_natCast, SetLike.mem_coe, this, IdealJ,
+          J, I, xg, N]
+      rw [hg, Submodule.mem_span_singleton] at hxg
+      rcases hxg with ⟨a, ha⟩
+      rw [smul_eq_mul] at ha
       sorry
-    rw [Ideal.span_singleton_le_iff_mem]
-    have : g ∈ IdealJ := by
-      rw [hg, Ideal.submodule_span_eq]
-      apply Ideal.mem_span_singleton_self
-    have huh : g ∈ J := by
-      simp only [Submodule.mem_mk, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk, IdealJ] at this
-      exact this
-    simp only [Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, J, IdealJ, I] at huh
-    exact huh
+    exact hgx
 
 end multiplicative_structure_of_QHat
 

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -489,27 +489,28 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
     exact Subgroup.mem_top x
   · intro y _
     -- use lowestTerms for y = x/N
-    rcases lowestTerms y with ⟨⟨N, x, cop, hy⟩, unique_y⟩
+    rcases lowestTerms y with ⟨⟨N, x, _, hy⟩, _⟩
     -- show x is invertible
-    let yinv := y⁻¹
-    rcases lowestTerms yinv with ⟨⟨N2, x2, cop2, hy2⟩, _⟩
+    rcases lowestTerms (y⁻¹.val) with ⟨⟨N2, x2, _, hy2⟩, _⟩
     -- we need to show that x is in QHatˣ
     let xinv := (1 / (N * N2) : ℚ) ⊗ₜ[ℤ] x2
     have : (i₂ x) * xinv = 1 := by
       unfold xinv
       rw [Algebra.TensorProduct.includeRight_apply, one_div, mul_inv_rev,
         Algebra.TensorProduct.tmul_mul_tmul, one_mul, mul_comm,
-        ← Algebra.TensorProduct.tmul_mul_tmul, ← one_div, ← one_div, ← hy, ← hy2]
-      unfold yinv
-      rw [← Units.val_mul, mul_inv_cancel, Units.val_one]
+        ← Algebra.TensorProduct.tmul_mul_tmul, ← one_div, ← one_div, ← hy, ← hy2,
+        ← Units.val_mul, mul_inv_cancel, Units.val_one]
     let xunit : QHatˣ := ⟨i₂ x, xinv, this, by rw [mul_comm]; exact this⟩
     -- show that it suffices to prove it for x
-    suffices h : xunit ∈ unitsratsub ⊔ unitszHatsub by
+    suffices h : ∀ (u : QHatˣ), (u : QHat) ∈ zHatsub → u ∈ unitsratsub ⊔ unitszHatsub by
       have : y = xunit * (i₁ (1 / N : ℚ)) := by
         unfold xunit
         simp only [Algebra.TensorProduct.includeRight_apply, one_mul, mul_one, hy,
           Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.tmul_mul_tmul]
       rw [Subgroup.mem_sup] at *
+      specialize h xunit
+      simp only [Algebra.TensorProduct.includeRight_apply, AddMonoidHom.mem_range,
+        AddMonoidHom.coe_coe, exists_apply_eq_apply, forall_const, Subgroup.mem_sup, xunit] at h
       rcases h with ⟨w, wh, z, zh, wzx⟩
       rw [MonoidHom.mem_range] at wh
       rcases wh with ⟨v, hv⟩
@@ -524,8 +525,18 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       rw [hv, ht, div_eq_mul_inv, mul_comm w, mul_assoc, wzx, mul_comm,
         ← Units.eq_iff, Units.val_mul, this]
       congr
-
+    clear * -
     -- now the harder part which uses that ℤ is a PID
+    intro x hx
+    rcases lowestTerms (x⁻¹.val) with ⟨⟨M, y, cop, hxinv⟩, unique⟩
+    have : x * (i₂ y) = M := by
+      have h : (M : QHat) = (M : ℚ) ⊗ₜ[ℤ] 1 := by
+        rw [← Algebra.TensorProduct.includeLeft_apply (S := ℚ) (M : ℚ), map_natCast]
+      rw [← one_mul (M : QHat), ← Units.val_one, ← mul_inv_cancel x, Units.val_mul, mul_assoc]
+      congr!
+      rw [hxinv, h, Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_div, inv_mul_cancel₀,
+        Algebra.TensorProduct.includeRight_apply]
+      simp only [ne_eq, Rat.natCast_eq_zero, PNat.ne_zero, not_false_eq_true]
     sorry
 
 end multiplicative_structure_of_QHat

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -489,30 +489,43 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
     exact Subgroup.mem_top x
   · intro y _
     -- use lowestTerms for y = x/N
-    obtain ⟨⟨N, x, cop, hy⟩, unique_y⟩ := lowestTerms y
+    rcases lowestTerms y with ⟨⟨N, x, cop, hy⟩, unique_y⟩
     -- show x is invertible
     let yinv := y⁻¹
-    obtain ⟨⟨N2, x2, cop2, hy2⟩, _⟩ := lowestTerms yinv
-    have h : 1 = (1 / N * (1 / N2) : ℚ) ⊗ₜ[ℤ] (x * x2) := by
-      rw [← Units.val_one, ← mul_inv_cancel y, Units.val_mul, hy, hy2]
-      dsimp
-    have : x * x2 = 1 := by
-      rw [Algebra.TensorProduct.one_def] at h
-      specialize unique_y 1 (N * N2) 1 (x * x2)
-      simp only [PNat.val_ofNat, Nat.cast_one, ne_eq, one_ne_zero, not_false_eq_true, div_self,
-        PNat.mul_coe, Nat.cast_mul, one_div, mul_inv_rev, and_imp] at unique_y
-      specialize unique_y (by simp only [IsCoprime, PNat.val_ofNat, isUnit_of_subsingleton])
-      nth_rewrite 3 [mul_comm] at unique_y
-      rw [← one_div, ← one_div] at unique_y
-      symm
-      apply And.right
-      refine unique_y ?_ h
-      unfold IsCoprime IsUnit
-      -- proving the wrong thing?
-      sorry
+    rcases lowestTerms yinv with ⟨⟨N2, x2, cop2, hy2⟩, _⟩
     -- we need to show that x is in QHatˣ
+    let xinv := (1 / (N * N2) : ℚ) ⊗ₜ[ℤ] x2
+    have : (i₂ x) * xinv = 1 := by
+      unfold xinv
+      rw [Algebra.TensorProduct.includeRight_apply, one_div, mul_inv_rev,
+        Algebra.TensorProduct.tmul_mul_tmul, one_mul, mul_comm,
+        ← Algebra.TensorProduct.tmul_mul_tmul, ← one_div, ← one_div, ← hy, ← hy2]
+      unfold yinv
+      rw [← Units.val_mul, mul_inv_cancel, Units.val_one]
+    let xunit : QHatˣ := ⟨i₂ x, xinv, this, by rw [mul_comm]; exact this⟩
     -- show that it suffices to prove it for x
+    suffices h : xunit ∈ unitsratsub ⊔ unitszHatsub by
+      have : y = xunit * (i₁ (1 / N : ℚ)) := by
+        unfold xunit
+        simp only [Algebra.TensorProduct.includeRight_apply, one_mul, mul_one, hy,
+          Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.tmul_mul_tmul]
+      rw [Subgroup.mem_sup] at *
+      rcases h with ⟨w, wh, z, zh, wzx⟩
+      rw [MonoidHom.mem_range] at wh
+      rcases wh with ⟨v, hv⟩
+      let n : ℚˣ := ⟨(N : ℚ), (1 / N : ℚ), by field_simp, by field_simp⟩
+      use ((Units.map ↑i₁) (v / n))
+      simp only [map_div, MonoidHom.mem_range, exists_exists_eq_and]
+      constructor
+      use (v / n)
+      rw [map_div]
+      rcases zh with ⟨t, ht⟩
+      use t
+      rw [hv, ht, div_eq_mul_inv, mul_comm w, mul_assoc, wzx, mul_comm,
+        ← Units.eq_iff, Units.val_mul, this]
+      congr
 
+    -- now the harder part which uses that ℤ is a PID
     sorry
 
 end multiplicative_structure_of_QHat

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -504,8 +504,7 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
     -- show that it suffices to prove it for x
     suffices h : ∀ (u : QHatˣ), (u : QHat) ∈ zHatsub → u ∈ unitsratsub ⊔ unitszHatsub by
       have : y = xunit * (i₁ (1 / N : ℚ)) := by
-        unfold xunit
-        simp only [Algebra.TensorProduct.includeRight_apply, one_mul, mul_one, hy,
+        simp only [xunit, Algebra.TensorProduct.includeRight_apply, one_mul, mul_one, hy,
           Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.tmul_mul_tmul]
       rw [Subgroup.mem_sup] at *
       specialize h xunit
@@ -537,6 +536,19 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       rw [hxinv, h, Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_div, inv_mul_cancel₀,
         Algebra.TensorProduct.includeRight_apply]
       simp only [ne_eq, Rat.natCast_eq_zero, PNat.ne_zero, not_false_eq_true]
+    rcases hx with ⟨X, hX⟩
+    let I := Ideal.span {X}
+    let J : Set ℤ := (Int.castRingHom ZHat) ⁻¹' I -- this needs to be an ideal
+    have Jnonzero : (M : ℤ) ∈ J := by
+      simp only [Int.coe_castRingHom, Set.mem_preimage, Int.cast_natCast, SetLike.mem_coe, J, I]
+      rw [Ideal.mem_span_singleton']
+      use y
+      rw [mul_comm]
+      apply injective_zHat
+      simp only [← hX, AddMonoidHom.coe_coe, Algebra.TensorProduct.includeRight_apply,
+        Algebra.TensorProduct.tmul_mul_tmul, mul_one, I, J] at this
+      simp only [Algebra.TensorProduct.includeRight_apply, this, map_natCast, I, J]
+
     sorry
 
 end multiplicative_structure_of_QHat

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -512,9 +512,8 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       constructor
       use q
       use t
-      rw [← Units.eq_iff, hy, ht]
-      simp only [Units.map_mk, MonoidHom.coe_coe, Algebra.TensorProduct.includeLeft_apply,
-        Units.val_mul, one_div, q, xunit]
+      simp only [← Units.eq_iff, hy, ht, Units.map_mk, MonoidHom.coe_coe,
+        Algebra.TensorProduct.includeLeft_apply, Units.val_mul, one_div, q, xunit]
       rw [← mul_one (N⁻¹ : ℚ), ← one_mul x, ← Algebra.TensorProduct.tmul_mul_tmul, div_eq_mul_inv,
         mul_comm (v : ℚ), ← mul_one 1, ← Algebra.TensorProduct.tmul_mul_tmul, mul_assoc, mul_one]
       congr
@@ -529,9 +528,9 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       rw [← one_mul (M : QHat), ← Units.val_one, ← mul_inv_cancel x, Units.val_mul, mul_assoc]
       congr!
       have h : (M : QHat) = (M : ℚ) ⊗ₜ[ℤ] 1 := by
-        rw [← Algebra.TensorProduct.includeLeft_apply (S := ℚ) (M : ℚ), map_natCast]
-      rw [hxinv, h, Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_div, inv_mul_cancel₀,
-        Algebra.TensorProduct.includeRight_apply]
+        rw [← Algebra.TensorProduct.includeLeft_apply (S := ℚ) (M : ℚ), map_natCast ]
+      rw [Algebra.TensorProduct.includeRight_apply, hxinv, h, Algebra.TensorProduct.tmul_mul_tmul,
+        mul_one, one_div, inv_mul_cancel₀]
       simp only [ne_eq, Rat.natCast_eq_zero, PNat.ne_zero, not_false_eq_true]
     rcases hx with ⟨X, hX⟩
     let I := Ideal.span {X}
@@ -565,8 +564,34 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       rw [h, Submodule.span_zero_singleton, Submodule.eq_bot_iff] at hg
       specialize hg (M : ℤ) Jnonzero
       simp only [Int.natCast_eq_zero, PNat.ne_zero] at hg
+    clear this hxinv y
     suffices h : Ideal.span {X} = Ideal.span {(g : ZHat)} by
-      sorry
+      --#check Ideal.mem_span_singleton'.1 (Ideal.mem_span_singleton_self X)
+      have hy : ∃ y, y * X = g := by rw [← Ideal.mem_span_singleton', h, Ideal.mem_span_singleton]
+      have hz : ∃ z, z * g = X := by rw [← Ideal.mem_span_singleton', ← h, Ideal.mem_span_singleton]
+      rcases hy with ⟨y, hy⟩
+      rcases hz with ⟨z, hz⟩
+      rw [← hz, ← mul_assoc, mul_comm, mul_comm y, ← sub_right_inj (a := (g : ZHat) * 1), ← mul_sub,
+        mul_one, sub_self] at hy
+      have : y * z = 1 := by
+        sorry
+      let Z : ZHatˣ := ⟨z, y, by rw[mul_comm]; exact this, this⟩
+      simp only [Subgroup.mem_sup, MonoidHom.mem_range, exists_exists_eq_and]
+      set G : ℚ := 1 / g with G_def
+      have gG : g * G = 1 := by
+        rw [G_def, one_div, mul_inv_cancel₀]
+        rw [ne_eq, Rat.intCast_eq_zero]
+        intro h
+        rw [h, lt_self_iff_false] at gpos
+        exact gpos
+      let gunit : ℚˣ := ⟨(g : ℚ), G, gG, by rw [mul_comm]; exact gG⟩
+      use gunit
+      use Z
+      simp only [← Units.eq_iff, ← hX, Units.map_mk, MonoidHom.coe_coe, map_intCast,
+        Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.includeRight_apply,
+        Units.val_mul, AddMonoidHom.coe_coe, gunit, Z]
+      rw [← hz, ← mul_one 1, ← Algebra.TensorProduct.tmul_mul_tmul, mul_one, mul_comm,
+        Algebra.TensorProduct.one_tmul_intCast]
     sorry
 
 end multiplicative_structure_of_QHat

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -482,6 +482,13 @@ lemma unitsrat_meet_unitszHat : unitsratsub ⊓ unitszHatsub = unitszsub := by
         Algebra.TensorProduct.includeRight_apply, Algebra.TensorProduct.one_tmul_intCast]
       simp
 
+@[simp]
+lemma _root_.Algebra.TensorProduct.intCast_tmul_one {R : Type*} {A : Type*} {B : Type*}
+    [CommRing R] [Ring A] [Algebra R A] [Ring B] [Algebra R B] {z : ℤ} :
+    (z : A) ⊗ₜ[R] (1 : B) = (z : TensorProduct R A B) := by
+  rw [← map_intCast (F := A →ₐ[R] TensorProduct R A B),
+    Algebra.TensorProduct.includeLeft_apply]
+
 -- this needs that ℤ is a PID.
 lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
   apply le_antisymm
@@ -528,7 +535,7 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       rw [← one_mul (M : QHat), ← Units.val_one, ← mul_inv_cancel x, Units.val_mul, mul_assoc]
       congr!
       have h : (M : QHat) = (M : ℚ) ⊗ₜ[ℤ] 1 := by
-        rw [← Algebra.TensorProduct.includeLeft_apply (S := ℚ) (M : ℚ), map_natCast ]
+        rw [← Algebra.TensorProduct.includeLeft_apply (S := ℚ) (M : ℚ), map_natCast]
       rw [Algebra.TensorProduct.includeRight_apply, hxinv, h, Algebra.TensorProduct.tmul_mul_tmul,
         mul_one, one_div, inv_mul_cancel₀]
       simp only [ne_eq, Rat.natCast_eq_zero, PNat.ne_zero, not_false_eq_true]
@@ -565,8 +572,8 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       specialize hg (M : ℤ) Jnonzero
       simp only [Int.natCast_eq_zero, PNat.ne_zero] at hg
     clear this hxinv y
+    let N : ℕ+ := ⟨g.toNat, Int.pos_iff_toNat_pos.1 gpos⟩
     suffices h : Ideal.span {X} = Ideal.span {(g : ZHat)} by
-      --#check Ideal.mem_span_singleton'.1 (Ideal.mem_span_singleton_self X)
       have hy : ∃ y, y * X = g := by rw [← Ideal.mem_span_singleton', h, Ideal.mem_span_singleton]
       have hz : ∃ z, z * g = X := by rw [← Ideal.mem_span_singleton', ← h, Ideal.mem_span_singleton]
       rcases hy with ⟨y, hy⟩
@@ -574,7 +581,10 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       rw [← hz, ← mul_assoc, mul_comm, mul_comm y, ← sub_right_inj (a := (g : ZHat) * 1), ← mul_sub,
         mul_one, sub_self] at hy
       have : y * z = 1 := by
-        sorry
+        rw [mul_comm, ← sub_right_inj (a := (1 : ZHat)), sub_self]
+        apply ZHat.eq_zero_of_mul_eq_zero N
+        simp only [PNat.mk_coe, N]
+        rwa [← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos)]
       let Z : ZHatˣ := ⟨z, y, by rw[mul_comm]; exact this, this⟩
       simp only [Subgroup.mem_sup, MonoidHom.mem_range, exists_exists_eq_and]
       set G : ℚ := 1 / g with G_def
@@ -592,7 +602,19 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
         Units.val_mul, AddMonoidHom.coe_coe, gunit, Z]
       rw [← hz, ← mul_one 1, ← Algebra.TensorProduct.tmul_mul_tmul, mul_one, mul_comm,
         Algebra.TensorProduct.one_tmul_intCast]
-    sorry
+    apply le_antisymm
+    · suffices h : X N = 0 by
+        sorry
+      sorry
+    rw [Ideal.span_singleton_le_iff_mem]
+    have : g ∈ IdealJ := by
+      rw [hg, Ideal.submodule_span_eq]
+      apply Ideal.mem_span_singleton_self
+    have huh : g ∈ J := by
+      simp only [Submodule.mem_mk, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk, IdealJ] at this
+      exact this
+    simp only [Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, J, IdealJ, I] at huh
+    exact huh
 
 end multiplicative_structure_of_QHat
 

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -491,9 +491,8 @@ lemma _root_.Algebra.TensorProduct.intCast_tmul_one {R : Type*} {A : Type*} {B :
 
 -- this needs that ℤ is a PID.
 lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
-  apply le_antisymm
-  · apply le_top
-  · intro y _
+  rw [eq_top_iff]
+  rintro y -
     rcases canonicalForm y.val with ⟨N, x, hy⟩
     rcases canonicalForm (y⁻¹.val) with ⟨N2, x2, hy2⟩
     set xinv := (1 / (N * N2) : ℚ) ⊗ₜ[ℤ] x2 with xinv_def
@@ -506,7 +505,7 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       specialize h xunit
       simp only [Algebra.TensorProduct.includeRight_apply, AddMonoidHom.mem_range,
         AddMonoidHom.coe_coe, exists_apply_eq_apply, forall_const, Subgroup.mem_sup, xunit] at h
-      rcases h with ⟨w, ⟨v, hv⟩, z, ⟨t, ht⟩, wzx⟩
+      rcases h with ⟨w, ⟨v, rfl⟩, z, ⟨t, rfl⟩, wzx⟩
       rw [Subgroup.mem_sup]
       let q : ℚˣ := ⟨v / N, N / v, by field_simp, by field_simp⟩
       use ((Units.map ↑i₁) q)

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -483,7 +483,37 @@ lemma unitsrat_meet_unitszHat : unitsratsub ⊓ unitszHatsub = unitszsub := by
       simp
 
 -- this needs that ℤ is a PID.
-lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := sorry
+lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
+  apply le_antisymm
+  · intro x _
+    exact Subgroup.mem_top x
+  · intro y _
+    -- use lowestTerms for y = x/N
+    obtain ⟨⟨N, x, cop, hy⟩, unique_y⟩ := lowestTerms y
+    -- show x is invertible
+    let yinv := y⁻¹
+    obtain ⟨⟨N2, x2, cop2, hy2⟩, _⟩ := lowestTerms yinv
+    have h : 1 = (1 / N * (1 / N2) : ℚ) ⊗ₜ[ℤ] (x * x2) := by
+      rw [← Units.val_one, ← mul_inv_cancel y, Units.val_mul, hy, hy2]
+      dsimp
+    have : x * x2 = 1 := by
+      rw [Algebra.TensorProduct.one_def] at h
+      specialize unique_y 1 (N * N2) 1 (x * x2)
+      simp only [PNat.val_ofNat, Nat.cast_one, ne_eq, one_ne_zero, not_false_eq_true, div_self,
+        PNat.mul_coe, Nat.cast_mul, one_div, mul_inv_rev, and_imp] at unique_y
+      specialize unique_y (by simp only [IsCoprime, PNat.val_ofNat, isUnit_of_subsingleton])
+      nth_rewrite 3 [mul_comm] at unique_y
+      rw [← one_div, ← one_div] at unique_y
+      symm
+      apply And.right
+      refine unique_y ?_ h
+      unfold IsCoprime IsUnit
+      -- proving the wrong thing?
+      sorry
+    -- we need to show that x is in QHatˣ
+    -- show that it suffices to prove it for x
+
+    sorry
 
 end multiplicative_structure_of_QHat
 

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -488,11 +488,9 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
   · intro x _
     exact Subgroup.mem_top x
   · intro y _
-    -- use lowestTerms for y = x/N
-    rcases lowestTerms y with ⟨⟨N, x, _, hy⟩, _⟩
-    -- show x is invertible
-    rcases lowestTerms (y⁻¹.val) with ⟨⟨N2, x2, _, hy2⟩, _⟩
-    -- we need to show that x is in QHatˣ
+    rcases canonicalForm y.val with ⟨N, x, hy⟩
+    rcases canonicalForm (y⁻¹.val) with ⟨N2, x2, hy2⟩
+    -- we need to show that x is invertible in QHat
     let xinv := (1 / (N * N2) : ℚ) ⊗ₜ[ℤ] x2
     have : (i₂ x) * xinv = 1 := by
       unfold xinv
@@ -503,32 +501,30 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
     let xunit : QHatˣ := ⟨i₂ x, xinv, this, by rw [mul_comm]; exact this⟩
     -- show that it suffices to prove it for x
     suffices h : ∀ (u : QHatˣ), (u : QHat) ∈ zHatsub → u ∈ unitsratsub ⊔ unitszHatsub by
-      have : y = xunit * (i₁ (1 / N : ℚ)) := by
-        simp only [xunit, Algebra.TensorProduct.includeRight_apply, one_mul, mul_one, hy,
-          Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.tmul_mul_tmul]
-      rw [Subgroup.mem_sup] at *
       specialize h xunit
       simp only [Algebra.TensorProduct.includeRight_apply, AddMonoidHom.mem_range,
         AddMonoidHom.coe_coe, exists_apply_eq_apply, forall_const, Subgroup.mem_sup, xunit] at h
-      rcases h with ⟨w, wh, z, zh, wzx⟩
-      rw [MonoidHom.mem_range] at wh
-      rcases wh with ⟨v, hv⟩
-      let n : ℚˣ := ⟨(N : ℚ), (1 / N : ℚ), by field_simp, by field_simp⟩
-      use ((Units.map ↑i₁) (v / n))
-      simp only [map_div, MonoidHom.mem_range, exists_exists_eq_and]
+      rcases h with ⟨w, ⟨v, hv⟩, z, ⟨t, ht⟩, wzx⟩
+      rw [Subgroup.mem_sup]
+      let q : ℚˣ := ⟨(v / N : ℚ), (N / v : ℚ), by field_simp, by field_simp⟩
+      use ((Units.map ↑i₁) q)
+      simp only [MonoidHom.mem_range, exists_exists_eq_and]
       constructor
-      use (v / n)
-      rw [map_div]
-      rcases zh with ⟨t, ht⟩
+      use q
       use t
-      rw [hv, ht, div_eq_mul_inv, mul_comm w, mul_assoc, wzx, mul_comm,
-        ← Units.eq_iff, Units.val_mul, this]
+      rw [← Units.eq_iff, hy, ht]
+      simp only [Units.map_mk, MonoidHom.coe_coe, Algebra.TensorProduct.includeLeft_apply,
+        Units.val_mul, one_div, q, xunit]
+      rw [← mul_one (N⁻¹ : ℚ), ← one_mul x, ← Algebra.TensorProduct.tmul_mul_tmul, div_eq_mul_inv,
+        mul_comm (v : ℚ), ← mul_one 1, ← Algebra.TensorProduct.tmul_mul_tmul, mul_assoc, mul_one]
       congr
+      simp only [← hv, ← Units.eq_iff, Units.val_mul, Units.coe_map, MonoidHom.coe_coe,
+        Algebra.TensorProduct.includeLeft_apply, xunit, q] at wzx
+      exact wzx
     clear * -
     -- now the harder part which uses that ℤ is a PID
     intro x hx
-    rcases lowestTerms (x⁻¹.val) with ⟨⟨M, y, cop, hxinv⟩, unique⟩
-    clear cop unique
+    rcases canonicalForm (x⁻¹.val) with ⟨M, y, hxinv⟩
     have : x * (i₂ y) = M := by
       rw [← one_mul (M : QHat), ← Units.val_one, ← mul_inv_cancel x, Units.val_mul, mul_assoc]
       congr!

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -489,131 +489,132 @@ lemma _root_.Algebra.TensorProduct.intCast_tmul_one {R : Type*} {A : Type*} {B :
   rw [← map_intCast (F := A →ₐ[R] TensorProduct R A B),
     Algebra.TensorProduct.includeLeft_apply]
 
+@[simp]
+lemma _root_.Algebra.TensorProduct.one_tmul_natCast {R : Type*} {A : Type*} {B : Type*}
+    [CommRing R] [Ring A] [Algebra R A] [Ring B] [Algebra R B] {n : ℕ} :
+    (1 : A) ⊗ₜ[R] (n : B) = (n : TensorProduct R A B) := by
+  rw [← map_natCast (F := B →ₐ[R] TensorProduct R A B),
+    Algebra.TensorProduct.includeRight_apply]
+
 -- this needs that ℤ is a PID.
 lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
   rw [eq_top_iff]
   rintro y -
-    rcases canonicalForm y.val with ⟨N, x, hy⟩
-    rcases canonicalForm (y⁻¹.val) with ⟨N2, x2, hy2⟩
-    set xinv := (1 / (N * N2) : ℚ) ⊗ₜ[ℤ] x2 with xinv_def
-    have : (i₂ x) * xinv = 1 := by
-      rw [xinv_def, Algebra.TensorProduct.includeRight_apply, one_div, mul_inv_rev,
-        Algebra.TensorProduct.tmul_mul_tmul,one_mul,mul_comm,← Algebra.TensorProduct.tmul_mul_tmul,
-        ← one_div, ← one_div, ← hy, ← hy2, ← Units.val_mul, mul_inv_cancel, Units.val_one]
-    let xunit : QHatˣ := ⟨i₂ x, xinv, this, by rw [mul_comm]; exact this⟩
-    suffices h : ∀ (u : QHatˣ), (u : QHat) ∈ zHatsub → u ∈ unitsratsub ⊔ unitszHatsub by
-      specialize h xunit
-      simp only [Algebra.TensorProduct.includeRight_apply, AddMonoidHom.mem_range,
-        AddMonoidHom.coe_coe, exists_apply_eq_apply, forall_const, Subgroup.mem_sup, xunit] at h
-      rcases h with ⟨w, ⟨v, rfl⟩, z, ⟨t, rfl⟩, wzx⟩
-      rw [Subgroup.mem_sup]
-      let q : ℚˣ := ⟨v / N, N / v, by field_simp, by field_simp⟩
-      use ((Units.map ↑i₁) q)
-      simp only [MonoidHom.mem_range, exists_exists_eq_and]
-      refine ⟨⟨q, rfl⟩, t, ?_⟩
-      simp only [← Units.eq_iff, hy, ht, Units.map_mk, MonoidHom.coe_coe,
-        Algebra.TensorProduct.includeLeft_apply, Units.val_mul, one_div, q, xunit]
-      rw [← mul_one (N⁻¹ : ℚ), ← one_mul x, ← Algebra.TensorProduct.tmul_mul_tmul, div_eq_mul_inv,
-        mul_comm (v : ℚ), ← mul_one 1, ← Algebra.TensorProduct.tmul_mul_tmul, mul_assoc, mul_one]
-      congr
-      simpa only [← hv, ← Units.eq_iff, Units.val_mul, Units.coe_map, MonoidHom.coe_coe,
-        Algebra.TensorProduct.includeLeft_apply, xunit, q] using wzx
-    clear * -
-    intro x hx
-    rcases canonicalForm (x⁻¹.val) with ⟨M, y, hxinv⟩
-    have : x * (i₂ y) = M := by
-      rw [← one_mul (M : QHat), ← Units.val_one, ← mul_inv_cancel x, Units.val_mul, mul_assoc]
-      congr!
-      have h : (M : QHat) = (M : ℚ) ⊗ₜ[ℤ] 1 := by norm_cast
-      rw [Algebra.TensorProduct.includeRight_apply, hxinv, h, Algebra.TensorProduct.tmul_mul_tmul,
-        mul_one, one_div, inv_mul_cancel₀]
-      simp only [ne_eq, Rat.natCast_eq_zero, PNat.ne_zero, not_false_eq_true]
-    rcases hx with ⟨X, hX⟩
-    let I := Ideal.span {X}
-    let J := (Int.castRingHom ZHat) ⁻¹' I -- this needs to be an ideal
-    have Jnonzero : (M : ℤ) ∈ J := by
-      simp only [Int.coe_castRingHom, Set.mem_preimage, Int.cast_natCast, SetLike.mem_coe, J, I]
-      rw [Ideal.mem_span_singleton']
-      use y
-      apply injective_zHat
-      simp only [mul_comm, ← hX, AddMonoidHom.coe_coe, Algebra.TensorProduct.includeRight_apply,
-        Algebra.TensorProduct.tmul_mul_tmul, mul_one, I, J] at this
-      rw [Algebra.TensorProduct.includeRight_apply, this, map_natCast]
-    let IdealJ : Ideal ℤ := by -- make this construction into a function (for Mathlib)?
-      refine ⟨⟨⟨J, ?_⟩, ?_⟩, ?_⟩
-      · simp only [Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, Int.cast_add, J]
-        exact (fun {a b} ↦ Ideal.add_mem I)
-      · simp only [Int.coe_castRingHom, Set.mem_preimage, Int.cast_zero, SetLike.mem_coe,
-          Submodule.zero_mem, J, I]
-      · simp only [smul_eq_mul, I, J, Set.mem_preimage, Int.coe_castRingHom, Int.cast_mul]
-        exact (fun c {x} ↦ by apply Ideal.mul_mem_left I)
-    obtain ⟨g, hg⟩ := IsPrincipalIdealRing.principal (R := ℤ) IdealJ
-    wlog gpos : 0 < g with H
-    · specialize H x M y hxinv this X hX Jnonzero (-g)
-      apply H (by rw [← Set.neg_singleton, Submodule.span_neg, ← hg])
-      rw [Int.neg_pos, Int.lt_iff_le_and_ne, ← Int.not_gt_eq]
-      refine ⟨gpos, ?_⟩
-      rintro rfl
-      rw [Submodule.span_zero_singleton, Submodule.eq_bot_iff] at hg
-      specialize hg (M : ℤ) Jnonzero
-      simp only [Int.natCast_eq_zero, PNat.ne_zero] at hg
-    clear this hxinv y Jnonzero M
-    let N : ℕ+ := ⟨g.toNat, Int.pos_iff_toNat_pos.1 gpos⟩
-    suffices h : Ideal.span {X} = Ideal.span {(g : ZHat)} by
-      obtain ⟨y, hy⟩ : ∃ y, y * X = g := by 
-        rw [← Ideal.mem_span_singleton',h,Ideal.mem_span_singleton]
-      obtain ⟨z,hz⟩ : ∃ z,z*g=X := by rw [← Ideal.mem_span_singleton',← h,Ideal.mem_span_singleton]
-      have : y * z = 1 := by
-        rw [mul_comm, ← sub_right_inj (a := (1 : ZHat)), sub_self]
-        apply ZHat.eq_zero_of_mul_eq_zero N
-        rw [PNat.mk_coe, ← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos), mul_sub,
-          mul_one, sub_eq_zero, ← mul_assoc, mul_comm _ z, hz, mul_comm, hy]
-      simp only [Subgroup.mem_sup, MonoidHom.mem_range, exists_exists_eq_and]
-      set G : ℚ := 1 / g with G_def
-      have gG : g * G = 1 := by
-        rw [G_def, one_div, mul_inv_cancel₀]
-        simp only [ne_eq, Rat.intCast_eq_zero, Int.ne_of_gt gpos, not_false_eq_true]
-      use ⟨g, G, gG, mul_comm _ G ▸ gG⟩ 
-      use ⟨z, y, by rw[mul_comm]; exact this, this⟩
-      simp only [← Units.eq_iff, ← hX, Units.map_mk, MonoidHom.coe_coe, map_intCast,
-        Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.includeRight_apply,
-        Units.val_mul, AddMonoidHom.coe_coe]
-      rw [← hz, ← mul_one 1, ← Algebra.TensorProduct.tmul_mul_tmul, mul_one, mul_comm,
-        Algebra.TensorProduct.one_tmul_intCast]
-    have hgx : Ideal.span {(g : ZHat)} ≤ Ideal.span {X} := by
-      have : g ∈ IdealJ := by
-        rw [hg, Ideal.submodule_span_eq]
-        apply Ideal.mem_span_singleton_self
-      simp only [Submodule.mem_mk, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk,
-        Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, J, IdealJ, I] at this
-      exact (Ideal.span_singleton_le_iff_mem _).2 this
-    refine le_antisymm ?_ hgx
-    · suffices h : X N = 0 by
-        rcases (ZHat.multiples N X).2 h with ⟨y, hy⟩
-        rw [Ideal.span_singleton_le_span_singleton, ← hy, PNat.mk_coe]
-        exact ⟨y, by rw [← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos)]⟩
-      let xg := (X N).val
-      have : (xg - X) N = 0 := by
-        simp only [ZHat, ZMod.castHom_apply, ZHat.instDFunLikePNatZModVal,
-          AddSubgroupClass.coe_sub, SubringClass.coe_natCast, Pi.sub_apply, Pi.natCast_apply, xg]
-        simp only [ZMod.natCast_val, ZMod.cast_id', id_eq, sub_self]
-      rcases (ZHat.multiples N _).2 this with ⟨y, hy⟩
-      have : (xg : ZHat) ∈ Ideal.span {X} := by
-        rw [← sub_add_cancel (xg : ZHat) X]
-        apply Ideal.add_mem
-        · apply hgx
-          rw [Ideal.mem_span_singleton', ← hy, mul_comm, PNat.mk_coe]
-          exact ⟨y, by rw [← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos)]⟩
-        apply Ideal.mem_span_singleton_self
-      have hxg : (xg : ℤ) ∈ IdealJ := by
-        simp only [Int.coe_castRingHom, Submodule.mem_mk, AddSubmonoid.mem_mk, Set.mem_preimage,
-          AddSubsemigroup.mem_mk, Int.cast_natCast, SetLike.mem_coe, this, IdealJ, J, I, xg, N]
-      rw [hg, Submodule.mem_span_singleton] at hxg
-      rcases hxg with ⟨a, ha⟩
-      rw [← ZMod.val_eq_zero, ← Int.natCast_eq_zero]
-      apply Int.eq_zero_of_dvd_of_nonneg_of_lt (n := g) (Int.natCast_nonneg _)
-      · exact Int.lt_of_toNat_lt (ZMod.val_lt (X N))
-      exact ⟨a, by rw [mul_comm, ← smul_eq_mul, ha]⟩
+  rcases canonicalForm y.val with ⟨N, x, hy⟩
+  rcases canonicalForm (y⁻¹.val) with ⟨N2, x2, hy2⟩
+  set xinv := (1 / (N * N2) : ℚ) ⊗ₜ[ℤ] x2 with xinv_def
+  have : (i₂ x) * xinv = 1 := by
+    rw [xinv_def, Algebra.TensorProduct.includeRight_apply, one_div, mul_inv_rev,
+      Algebra.TensorProduct.tmul_mul_tmul,one_mul,mul_comm,← Algebra.TensorProduct.tmul_mul_tmul,
+      ← one_div, ← one_div, ← hy, ← hy2, ← Units.val_mul, mul_inv_cancel, Units.val_one]
+  let xunit : QHatˣ := ⟨i₂ x, xinv, this, by rw [mul_comm]; exact this⟩
+  suffices h : ∀ (u : QHatˣ), (u : QHat) ∈ zHatsub → u ∈ unitsratsub ⊔ unitszHatsub by
+    specialize h xunit
+    simp only [Algebra.TensorProduct.includeRight_apply, AddMonoidHom.mem_range,
+      AddMonoidHom.coe_coe, exists_apply_eq_apply, forall_const, Subgroup.mem_sup, xunit] at h
+    rcases h with ⟨w, ⟨v, rfl⟩, z, ⟨t, rfl⟩, wzx⟩
+    rw [Subgroup.mem_sup]
+    let q : ℚˣ := ⟨v / N, N / v, by field_simp, by field_simp⟩
+    use ((Units.map ↑i₁) q)
+    simp only [MonoidHom.mem_range, exists_exists_eq_and]
+    refine ⟨⟨q, rfl⟩, t, ?_⟩
+    simp only [← Units.eq_iff, hy, Units.map_mk, MonoidHom.coe_coe,
+      Algebra.TensorProduct.includeLeft_apply, Units.val_mul, one_div, q, xunit]
+    rw [← mul_one (N⁻¹ : ℚ), ← one_mul x, ← Algebra.TensorProduct.tmul_mul_tmul, div_eq_mul_inv,
+      mul_comm (v : ℚ), ← mul_one 1, ← Algebra.TensorProduct.tmul_mul_tmul, mul_assoc, mul_one]
+    congr
+    simpa only [← Units.eq_iff, Units.val_mul, Units.coe_map, MonoidHom.coe_coe,
+      Algebra.TensorProduct.includeLeft_apply, xunit, q] using wzx
+  clear * -
+  intro x hx
+  rcases canonicalForm (x⁻¹.val) with ⟨M, y, hxinv⟩
+  have : x * (i₂ y) = M := by
+    rw [← one_mul (M : QHat), ← Units.val_one, ← mul_inv_cancel x, Units.val_mul, mul_assoc]
+    congr!
+    have h : (M : QHat) = (M : ℚ) ⊗ₜ[ℤ] 1 := by norm_cast
+    rw [Algebra.TensorProduct.includeRight_apply, hxinv, h, Algebra.TensorProduct.tmul_mul_tmul,
+      mul_one, one_div, inv_mul_cancel₀]
+    simp only [ne_eq, Rat.natCast_eq_zero, PNat.ne_zero, not_false_eq_true]
+  rcases hx with ⟨X, hX⟩
+  let I := Ideal.span {X}
+  let J := I.comap (Int.castRingHom ZHat)
+  have Jnonzero : (M : ℤ) ∈ J := by
+    simp only [J, I, Ideal.mem_comap]
+    rw [Ideal.mem_span_singleton']
+    use y
+    apply injective_zHat
+    simp only [mul_comm, ← hX, AddMonoidHom.coe_coe, Algebra.TensorProduct.includeRight_apply,
+      Algebra.TensorProduct.tmul_mul_tmul, mul_one] at this
+    rw [Algebra.TensorProduct.includeRight_apply, this, map_natCast,
+      Algebra.TensorProduct.includeRight_apply, Algebra.TensorProduct.one_tmul_natCast]
+  obtain ⟨g, hg⟩ := IsPrincipalIdealRing.principal (R := ℤ) J
+  wlog gpos : 0 < g with H
+  · specialize H x M y hxinv this X hX Jnonzero (-g)
+    apply H (by rw [← Set.neg_singleton, Submodule.span_neg, ← hg])
+    rw [Int.neg_pos, Int.lt_iff_le_and_ne, ← Int.not_gt_eq]
+    refine ⟨gpos, ?_⟩
+    rintro rfl
+    rw [Submodule.span_zero_singleton, Submodule.eq_bot_iff] at hg
+    specialize hg (M : ℤ) Jnonzero
+    simp only [Int.natCast_eq_zero, PNat.ne_zero] at hg
+  clear this hxinv y Jnonzero M
+  let N : ℕ+ := ⟨g.toNat, Int.pos_iff_toNat_pos.1 gpos⟩
+  suffices h : Ideal.span {X} = Ideal.span {(g : ZHat)} by
+    obtain ⟨y, hy⟩ : ∃ y, y * X = g := by 
+      rw [← Ideal.mem_span_singleton', h, Ideal.mem_span_singleton]
+    obtain ⟨z, hz⟩ : ∃ z, z * g = X := by
+      rw [← Ideal.mem_span_singleton', ← h, Ideal.mem_span_singleton]
+    have : y * z = 1 := by
+      rw [mul_comm, ← sub_right_inj (a := (1 : ZHat)), sub_self]
+      apply ZHat.eq_zero_of_mul_eq_zero N
+      rw [PNat.mk_coe, ← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos), mul_sub,
+        mul_one, sub_eq_zero, ← mul_assoc, mul_comm _ z, hz, mul_comm, hy]
+    simp only [Subgroup.mem_sup, MonoidHom.mem_range, exists_exists_eq_and]
+    set G : ℚ := 1 / g with G_def
+    have gG : g * G = 1 := by
+      rw [G_def, one_div, mul_inv_cancel₀]
+      simp only [ne_eq, Rat.intCast_eq_zero, Int.ne_of_gt gpos, not_false_eq_true]
+    use ⟨g, G, gG, mul_comm _ G ▸ gG⟩
+    use ⟨z, y, by rw[mul_comm]; exact this, this⟩
+    simp only [← Units.eq_iff, ← hX, Units.map_mk, MonoidHom.coe_coe, map_intCast,
+      Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.includeRight_apply,
+      Units.val_mul, AddMonoidHom.coe_coe]
+    rw [← hz, ← mul_one 1, ← Algebra.TensorProduct.tmul_mul_tmul, mul_one, mul_comm,
+      Algebra.TensorProduct.one_tmul_intCast]
+  have hgx : Ideal.span {(g : ZHat)} ≤ Ideal.span {X} := by
+    have : g ∈ J := by
+      rw [hg, Ideal.submodule_span_eq]
+      apply Ideal.mem_span_singleton_self
+    simp only [Submodule.mem_mk, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk,
+      Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, J, I] at this
+    exact (Ideal.span_singleton_le_iff_mem _).2 this
+  refine le_antisymm ?_ hgx
+  suffices h : X N = 0 by
+    rcases (ZHat.multiples N X).2 h with ⟨y, hy⟩
+    rw [Ideal.span_singleton_le_span_singleton, ← hy, PNat.mk_coe]
+    exact ⟨y, by rw [← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos)]⟩
+  let xg := (X N).val
+  have : (xg - X) N = 0 := by
+    simp only [ZHat, ZMod.castHom_apply, ZHat.instDFunLikePNatZModVal,
+      AddSubgroupClass.coe_sub, SubringClass.coe_natCast, Pi.sub_apply, Pi.natCast_apply, xg]
+    simp only [ZMod.natCast_val, ZMod.cast_id', id_eq, sub_self]
+  rcases (ZHat.multiples N _).2 this with ⟨y, hy⟩
+  have : (xg : ZHat) ∈ Ideal.span {X} := by
+    rw [← sub_add_cancel (xg : ZHat) X]
+    apply Ideal.add_mem
+    · apply hgx
+      rw [Ideal.mem_span_singleton', ← hy, mul_comm, PNat.mk_coe]
+      exact ⟨y, by rw [← Int.cast_natCast, Int.natCast_toNat_eq_self.2 (le_of_lt gpos)]⟩
+    apply Ideal.mem_span_singleton_self
+  have hxg : (xg : ℤ) ∈ J := by
+    rw [Ideal.mem_comap]
+    simp only [Int.coe_castRingHom, Int.cast_natCast, I, this]
+  rw [hg, Submodule.mem_span_singleton] at hxg
+  rcases hxg with ⟨a, ha⟩
+  rw [← ZMod.val_eq_zero, ← Int.natCast_eq_zero]
+  apply Int.eq_zero_of_dvd_of_nonneg_of_lt (n := g) (Int.natCast_nonneg _)
+  · exact Int.lt_of_toNat_lt (ZMod.val_lt (X N))
+  exact ⟨a, by rw [mul_comm, ← smul_eq_mul, ha]⟩
 
 end multiplicative_structure_of_QHat
 

--- a/FLT/AutomorphicRepresentation/Example.lean
+++ b/FLT/AutomorphicRepresentation/Example.lean
@@ -544,10 +544,10 @@ lemma unitsrat_join_unitszHat : unitsratsub ⊔ unitszHatsub = ⊤ := by
       refine ⟨⟨⟨J, ?_⟩, ?_⟩, ?_⟩
       · simp only [Int.coe_castRingHom, Set.mem_preimage, SetLike.mem_coe, Int.cast_add, J]
         exact (fun {a b} ↦ Ideal.add_mem I)
-      simp only [Int.coe_castRingHom, Set.mem_preimage, Int.cast_zero, SetLike.mem_coe,
-        Submodule.zero_mem, J, I]
-      simp only [smul_eq_mul, I, J, Set.mem_preimage, Int.coe_castRingHom, Int.cast_mul]
-      exact (fun c {x} ↦ by apply Ideal.mul_mem_left I)
+      · simp only [Int.coe_castRingHom, Set.mem_preimage, Int.cast_zero, SetLike.mem_coe,
+          Submodule.zero_mem, J, I]
+      · simp only [smul_eq_mul, I, J, Set.mem_preimage, Int.coe_castRingHom, Int.cast_mul]
+        exact (fun c {x} ↦ by apply Ideal.mul_mem_left I)
     obtain ⟨g, hg⟩ := IsPrincipalIdealRing.principal (R := ℤ) IdealJ
     wlog gpos : 0 < g with H
     · specialize H x M y hxinv this X hX Jnonzero (-g)

--- a/blueprint/src/chapter/ch05automorphicformexample.tex
+++ b/blueprint/src/chapter/ch05automorphicformexample.tex
@@ -511,7 +511,8 @@ subgroups $\Q^\times$, $\Z^\times$ and $\Zhat^\times$.
 \end{lemma}
 Note that by the previous lemma, this representation will be unique up to sign.
 \begin{proof}
-    \uses{QHat.lowestTerms}
+    \uses{ZHat.multiples,ZHat.eq_zero_of_mul_eq_zero,QHat.canonicalForm}
+    \leanok
   We already know that a general element of $\Qhat^\times$ can be written as $x/N$ with $N$
   positive, so this reduces us to proving that a general element $x\in\Zhat$ which is invertible
   in $\Qhat^\times$ can be written as $qz$ with $q\in\Q^\times$ and $z\in\Zhat^\times$.


### PR DESCRIPTION
This pr fills in the proof of unitsrat_join_unitszHat and adds the corresponding `leanok` and dependency tags to the blueprint.