### PR TITLE
t2_of_finite_free

### DIFF
--- a/FLT/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
+++ b/FLT/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
@@ -424,7 +424,7 @@ def continuousAlgEquivOfAlgEquiv {A B R : Type*} [TopologicalSpace A]
 
 /-- A free module with the module topology over a `T2Space` ring is a `T2Space`.
 -/
-theorem t2Space {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M] [Module.Free R M]
+theorem t2Space {R M : Type*} [Semiring R] [AddCommGroup M] [Module R M] [Module.Free R M]
     [TopologicalSpace R] [TopologicalSpace M] [T2Space R]
     [ContinuousAdd R] [ContinuousMul R] [IsModuleTopology R M]
     : T2Space M := by


### PR DESCRIPTION
The proposed theorem  `t2_of_finite_free` is a special case of the existing theorem `t2Space` in  `ModuleTopology`, e.g. `t2_of_finite_free` can be proven from `t2Space` by  `apply t2Space (R := R)` . 
 
In theorem `t2Space`, I have replaced the assumption `CommRing R`  with  `Semiring R`. 

Closes #651