### PR TITLE
chore: replace Subtype.map_ne

### DIFF
--- a/FLT/Mathlib/Data/Subtype.lean
+++ b/FLT/Mathlib/Data/Subtype.lean
@@ -1,8 +1,7 @@
 import Mathlib.Data.Subtype
 
-theorem Subtype.map_ne {α β : Sort*} {p : α → Prop} {q : β → Prop} (f g : α → β)
-    (h₁ : ∀ (a : α), p a → q (f a)) (h₂ : ∀ (a : α), p a → q (g a))
-    (h₃ : ∀ (a₁ a₂ : α), p a₁ → p a₂ → f a₁ ≠ g a₂) :
-    ∀ x y, Subtype.map f h₁ x ≠ Subtype.map g h₂ y := by
-  simp only [Subtype.map_def, ne_eq, Subtype.mk.injEq]
-  exact fun x y => h₃ _ _ x.2 y.2
+theorem Subtype.map_ne {α β : Sort*} {p : α → Prop} {q : β → Prop} {f g : α → β}
+    (h₁ : ∀ a : α, p a → q (f a)) (h₂ : ∀ a : α, p a → q (g a))
+    (x y : Subtype p) :
+    map f h₁ x ≠ map g h₂ y ↔ f x ≠ g y :=
+  .not ⟨congr_arg Subtype.val, (Subtype.ext ·)⟩

--- a/FLT/NumberField/InfinitePlace/Dimension.lean
+++ b/FLT/NumberField/InfinitePlace/Dimension.lean
@@ -113,9 +113,9 @@ def toIsMixedExtension (w : v.RamifiedExtension L ⊕ v.RamifiedExtension L) :
 theorem toIsMixedExtension_injective : (toIsMixedExtension L v).Injective := by
   apply Subtype.map_injective _ (embedding_injective _) |>.sumElim
     (Subtype.map_injective _ (conjugate_embedding_injective _))
-  exact Subtype.map_ne _ _ (fun w h => isMixedExtension ⟨w, h⟩)
-    (fun w h => isMixedExtension_conjugate ⟨w, h⟩)
-    (fun _ _ _ h₂ => h₂.2.ne_conjugate)
+  intro a b
+  rw [Subtype.map_ne]
+  exact b.prop.2.ne_conjugate
 
 theorem toIsMixedExtension_surjective : (toIsMixedExtension L v).Surjective := by
   intro ⟨ψ, h⟩


### PR DESCRIPTION
As suggested by Jireh in https://github.com/leanprover-community/mathlib4/pull/27012