### PR TITLE
feat: complete AutomorphicForm/QuaternionAlgebra/Defs.lean

### DIFF
--- a/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
@@ -185,7 +185,7 @@ instance addCommGroup : AddCommGroup (WeightTwoAutomorphicForm F D R) where
 
 open scoped Pointwise
 
--- this should be in mathlib
+-- these two should be in mathlib
 instance {G} [TopologicalSpace G] [DivInvMonoid G] [ContinuousMul G] :
     ContinuousConstSMul (ConjAct G) G where
   continuous_const_smul _ := IsTopologicalGroup.continuous_conj _

--- a/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
@@ -190,7 +190,7 @@ instance {G} [TopologicalSpace G] [DivInvMonoid G] [ContinuousMul G] :
     ContinuousConstSMul (ConjAct G) G where
   continuous_const_smul _ := IsTopologicalGroup.continuous_conj _
 
-theorem _root_.ConjAct.isOpen_smul {G : Type*} [Group G] [TopologicalSpace G]
+lemma _root_.ConjAct.isOpen_smul {G : Type*} [Group G] [TopologicalSpace G]
     [IsTopologicalGroup G] {U : Subgroup G} (hU : IsOpen (U : Set G)) (g : ConjAct G) :
     IsOpen ((g • U : Subgroup G) : Set G) :=
   (Homeomorph.smul g).isOpen_image.mpr hU

--- a/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
@@ -74,8 +74,65 @@ noncomputable abbrev incl₂ : (FiniteAdeleRing (𝓞 F) F)ˣ →* Dfx F D :=
   Units.map (algebraMap _ _).toMonoidHom
 
 -- it's actually equal but ⊆ is all we need, and equality is harder
-lemma range_incl₂_le_center : MonoidHom.range (incl₂ F D) ≤ Subgroup.center (Dfx F D) := by
-  sorry
+
+/- Start of proof attempt -/
+lemma round1_h1 (F : Type*) [Field F] [NumberField F]
+  (D : Type*) [Ring D] [Algebra F D] [FiniteDimensional F D] :
+  ∀ (r : FiniteAdeleRing (𝓞 F) F), ∀ (x : D ⊗[F] FiniteAdeleRing (𝓞 F) F),
+    ((1 : D) ⊗ₜ[F] r) * x = x * ((1 : D) ⊗ₜ[F] r) := by
+  intro r x
+  have h2 : ∀ (d : D) (s : FiniteAdeleRing (𝓞 F) F),
+    ((1 : D) ⊗ₜ[F] r) * (d ⊗ₜ[F] s) = (d ⊗ₜ[F] s) * ((1 : D) ⊗ₜ[F] r) := by
+    intro d s
+    have h21 : r * s = s * r := by ring
+    have h22 : ((1 : D) ⊗ₜ[F] r) * (d ⊗ₜ[F] s) = d ⊗ₜ[F] (r * s) := by
+      simp [mul_one, one_mul]
+      <;> ring
+    have h23 : (d ⊗ₜ[F] s) * ((1 : D) ⊗ₜ[F] r) = d ⊗ₜ[F] (s * r) := by
+      simp [mul_one, one_mul]
+      <;> ring
+    rw [h22, h23]
+    rw [h21]
+  have h3 : ∀ (x : D ⊗[F] FiniteAdeleRing (𝓞 F) F), ((1 : D) ⊗ₜ[F] r) * x = x * ((1 : D) ⊗ₜ[F] r) := by
+    intro x
+    induction x using TensorProduct.induction_on with
+    | zero =>
+      simp
+    | tmul d s =>
+      exact h2 d s
+    | add x y hx hy =>
+      simp [mul_add, add_mul, hx, hy] <;> ring
+  exact h3 x
+
+lemma round1_incl₂_mem_center (F : Type*) [Field F] [NumberField F]
+  (D : Type*) [Ring D] [Algebra F D] [FiniteDimensional F D] :
+  ∀ (y : (FiniteAdeleRing (𝓞 F) F)ˣ), (incl₂ F D y) ∈ Subgroup.center (Dfx F D) := by
+  intro y
+  have h1 := round1_h1 F D
+  have h4 : ∀ (g : Dfx F D), (incl₂ F D y) * g = g * (incl₂ F D y) := by
+    intro g
+    have h5 : ((incl₂ F D y).val : D ⊗[F] FiniteAdeleRing (𝓞 F) F) * g.val = g.val * ((incl₂ F D y).val : D ⊗[F] FiniteAdeleRing (𝓞 F) F) := by
+      have h51 : ((incl₂ F D y).val : D ⊗[F] FiniteAdeleRing (𝓞 F) F) = (1 : D) ⊗ₜ[F] (y : FiniteAdeleRing (𝓞 F) F) := by
+        simp [incl₂]
+        <;> aesop
+      rw [h51]
+      have h52 := h1 (y : FiniteAdeleRing (𝓞 F) F) g.val
+      exact h52
+    have h6 : (incl₂ F D y) * g = g * (incl₂ F D y) := by
+      apply Units.ext
+      simpa only using h5
+    exact h6
+  simp only [Subgroup.mem_center_iff]
+  intro g
+  have h4' : (incl₂ F D y) * g = g * (incl₂ F D y) := h4 g
+  exact Eq.symm h4'
+
+theorem range_incl₂_le_center : MonoidHom.range (incl₂ F D) ≤ Subgroup.center (Dfx F D)  := by
+
+  have h3 := round1_incl₂_mem_center F D
+  intro x hx
+  rcases hx with ⟨y, rfl⟩
+  exact h3 y
 
 open scoped TensorProduct.RightActions in
 /--
@@ -182,10 +239,103 @@ instance addCommGroup : AddCommGroup (WeightTwoAutomorphicForm F D R) where
 open scoped Pointwise
 
 -- this should be in mathlib
-lemma _root_.ConjAct.isOpen_smul {G : Type*} [Group G] [TopologicalSpace G]
+
+/- Start of proof attempt -/
+lemma round1_h1 (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G] (g : ConjAct G) :
+  ∃ (x : G), ∀ (u : G), g • u = x * u * x⁻¹ := by
+  exact?
+
+lemma round1_h2 (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  (U : Subgroup G) (g : ConjAct G) (x : G) (hx : ∀ (u : G), g • u = x * u * x⁻¹) :
+  (g • U : Set G) = (fun y => x * y * x⁻¹) '' (U : Set G) := by
+  ext y
+  simp only [Set.mem_setOf_eq, Set.mem_image, SetLike.mem_coe]
+  constructor
+  · -- Assume y ∈ (g • U)
+    rintro ⟨u, hu, rfl⟩
+    refine ⟨u, hu, ?_⟩
+    have h22 : g • u = x * u * x⁻¹ := hx u
+    exact h22.symm
+  · -- Assume y ∈ (fun y => x * y * x⁻¹) '' (U : Set G)
+    rintro ⟨a, ha, rfl⟩
+    refine ⟨a, ha, ?_⟩
+    have h23 : g • a = x * a * x⁻¹ := hx a
+    exact h23
+
+lemma round1_h3 (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G] (x : G) :
+  ∃ (f : G ≃ₜ G), ∀ (y : G), f y = x * y * x⁻¹ := by
+  use {
+    toFun := fun y => x * y * x⁻¹
+    invFun := fun y => x⁻¹ * y * x
+    left_inv := by
+      intro y
+      simp [mul_assoc]
+      <;> group
+    right_inv := by
+      intro y
+      simp [mul_assoc]
+      <;> group
+    continuous_toFun := by
+      apply Continuous.mul
+      · apply Continuous.mul
+        · exact continuous_const
+        · exact continuous_id
+      · exact continuous_const
+    continuous_invFun := by
+      apply Continuous.mul
+      · apply Continuous.mul
+        · exact continuous_const
+        · exact continuous_id
+      · exact continuous_const
+  }
+  <;> aesop
+
+lemma round1_h5 (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  (U : Subgroup G) (x : G) (g : ConjAct G) (hx : ∀ (u : G), g • u = x * u * x⁻¹)
+  (f : G ≃ₜ G) (hf : ∀ (y : G), f y = x * y * x⁻¹) :
+  (g • U : Set G) = f '' (U : Set G) := by
+  have h51 : (g • U : Set G) = (fun y => x * y * x⁻¹) '' (U : Set G) := by
+    exact round1_h2 G U g x hx
+  have h52 : (fun y => x * y * x⁻¹) = f := by
+    funext y
+    have h521 : f y = x * y * x⁻¹ := hf y
+    simp [h521]
+  rw [h51, h52]
+  <;> rfl
+
+theorem _root_.ConjAct.isOpen_smul {G : Type*} [Group G] [TopologicalSpace G]
     [IsTopologicalGroup G] {U : Subgroup G} (hU : IsOpen (U : Set G)) (g : ConjAct G) :
-    IsOpen ((g • U : Subgroup G) : Set G) := by
-  sorry
+    IsOpen ((g • U : Subgroup G) : Set G)  := by
+
+
+  have h1 : ∃ (x : G), ∀ (u : G), g • u = x * u * x⁻¹ := by
+    exact round1_h1 G g
+
+  obtain ⟨x, hx⟩ := h1
+
+  have h2 : (g • U : Set G) = (fun y => x * y * x⁻¹) '' (U : Set G) := by
+    exact round1_h2 G U g x hx
+
+  have h3 : ∃ (f : G ≃ₜ G), ∀ (y : G), f y = x * y * x⁻¹ := by
+    exact round1_h3 G x
+
+  obtain ⟨f, hf⟩ := h3
+
+  have h5 : (g • U : Set G) = f '' (U : Set G) := by
+    exact round1_h5 G U x g hx f hf
+
+  have h6 : IsOpen (f '' (U : Set G)) := by
+    have h61 : IsOpen (U : Set G) := hU
+    exact?
+
+  have h7 : ((g • U : Subgroup G) : Set G) = (g • U : Set G) := by
+    ext y
+    <;> simp
+    <;> aesop
+
+  rw [h7]
+  rw [h5]
+  exact h6
 
 open ConjAct
 

--- a/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
@@ -74,65 +74,12 @@ noncomputable abbrev incl₂ : (FiniteAdeleRing (𝓞 F) F)ˣ →* Dfx F D :=
   Units.map (algebraMap _ _).toMonoidHom
 
 -- it's actually equal but ⊆ is all we need, and equality is harder
-
-/- Start of proof attempt -/
-lemma round1_h1 (F : Type*) [Field F] [NumberField F]
-  (D : Type*) [Ring D] [Algebra F D] [FiniteDimensional F D] :
-  ∀ (r : FiniteAdeleRing (𝓞 F) F), ∀ (x : D ⊗[F] FiniteAdeleRing (𝓞 F) F),
-    ((1 : D) ⊗ₜ[F] r) * x = x * ((1 : D) ⊗ₜ[F] r) := by
-  intro r x
-  have h2 : ∀ (d : D) (s : FiniteAdeleRing (𝓞 F) F),
-    ((1 : D) ⊗ₜ[F] r) * (d ⊗ₜ[F] s) = (d ⊗ₜ[F] s) * ((1 : D) ⊗ₜ[F] r) := by
-    intro d s
-    have h21 : r * s = s * r := by ring
-    have h22 : ((1 : D) ⊗ₜ[F] r) * (d ⊗ₜ[F] s) = d ⊗ₜ[F] (r * s) := by
-      simp [mul_one, one_mul]
-      <;> ring
-    have h23 : (d ⊗ₜ[F] s) * ((1 : D) ⊗ₜ[F] r) = d ⊗ₜ[F] (s * r) := by
-      simp [mul_one, one_mul]
-      <;> ring
-    rw [h22, h23]
-    rw [h21]
-  have h3 : ∀ (x : D ⊗[F] FiniteAdeleRing (𝓞 F) F), ((1 : D) ⊗ₜ[F] r) * x = x * ((1 : D) ⊗ₜ[F] r) := by
-    intro x
-    induction x using TensorProduct.induction_on with
-    | zero =>
-      simp
-    | tmul d s =>
-      exact h2 d s
-    | add x y hx hy =>
-      simp [mul_add, add_mul, hx, hy] <;> ring
-  exact h3 x
-
-lemma round1_incl₂_mem_center (F : Type*) [Field F] [NumberField F]
-  (D : Type*) [Ring D] [Algebra F D] [FiniteDimensional F D] :
-  ∀ (y : (FiniteAdeleRing (𝓞 F) F)ˣ), (incl₂ F D y) ∈ Subgroup.center (Dfx F D) := by
-  intro y
-  have h1 := round1_h1 F D
-  have h4 : ∀ (g : Dfx F D), (incl₂ F D y) * g = g * (incl₂ F D y) := by
-    intro g
-    have h5 : ((incl₂ F D y).val : D ⊗[F] FiniteAdeleRing (𝓞 F) F) * g.val = g.val * ((incl₂ F D y).val : D ⊗[F] FiniteAdeleRing (𝓞 F) F) := by
-      have h51 : ((incl₂ F D y).val : D ⊗[F] FiniteAdeleRing (𝓞 F) F) = (1 : D) ⊗ₜ[F] (y : FiniteAdeleRing (𝓞 F) F) := by
-        simp [incl₂]
-        <;> aesop
-      rw [h51]
-      have h52 := h1 (y : FiniteAdeleRing (𝓞 F) F) g.val
-      exact h52
-    have h6 : (incl₂ F D y) * g = g * (incl₂ F D y) := by
-      apply Units.ext
-      simpa only using h5
-    exact h6
-  simp only [Subgroup.mem_center_iff]
-  intro g
-  have h4' : (incl₂ F D y) * g = g * (incl₂ F D y) := h4 g
-  exact Eq.symm h4'
-
-theorem range_incl₂_le_center : MonoidHom.range (incl₂ F D) ≤ Subgroup.center (Dfx F D)  := by
-
-  have h3 := round1_incl₂_mem_center F D
-  intro x hx
-  rcases hx with ⟨y, rfl⟩
-  exact h3 y
+open scoped TensorProduct.RightActions in
+omit [FiniteDimensional F D] in
+lemma range_incl₂_le_center : MonoidHom.range (incl₂ F D) ≤ Subgroup.center (Dfx F D) := by
+  rintro x ⟨y, rfl⟩
+  refine Subgroup.mem_center_iff.mpr fun g ↦ Units.ext ?_
+  exact (Algebra.commutes _ _).symm
 
 open scoped TensorProduct.RightActions in
 /--
@@ -239,103 +186,14 @@ instance addCommGroup : AddCommGroup (WeightTwoAutomorphicForm F D R) where
 open scoped Pointwise
 
 -- this should be in mathlib
-
-/- Start of proof attempt -/
-lemma round1_h1 (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G] (g : ConjAct G) :
-  ∃ (x : G), ∀ (u : G), g • u = x * u * x⁻¹ := by
-  exact?
-
-lemma round1_h2 (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
-  (U : Subgroup G) (g : ConjAct G) (x : G) (hx : ∀ (u : G), g • u = x * u * x⁻¹) :
-  (g • U : Set G) = (fun y => x * y * x⁻¹) '' (U : Set G) := by
-  ext y
-  simp only [Set.mem_setOf_eq, Set.mem_image, SetLike.mem_coe]
-  constructor
-  · -- Assume y ∈ (g • U)
-    rintro ⟨u, hu, rfl⟩
-    refine ⟨u, hu, ?_⟩
-    have h22 : g • u = x * u * x⁻¹ := hx u
-    exact h22.symm
-  · -- Assume y ∈ (fun y => x * y * x⁻¹) '' (U : Set G)
-    rintro ⟨a, ha, rfl⟩
-    refine ⟨a, ha, ?_⟩
-    have h23 : g • a = x * a * x⁻¹ := hx a
-    exact h23
-
-lemma round1_h3 (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G] (x : G) :
-  ∃ (f : G ≃ₜ G), ∀ (y : G), f y = x * y * x⁻¹ := by
-  use {
-    toFun := fun y => x * y * x⁻¹
-    invFun := fun y => x⁻¹ * y * x
-    left_inv := by
-      intro y
-      simp [mul_assoc]
-      <;> group
-    right_inv := by
-      intro y
-      simp [mul_assoc]
-      <;> group
-    continuous_toFun := by
-      apply Continuous.mul
-      · apply Continuous.mul
-        · exact continuous_const
-        · exact continuous_id
-      · exact continuous_const
-    continuous_invFun := by
-      apply Continuous.mul
-      · apply Continuous.mul
-        · exact continuous_const
-        · exact continuous_id
-      · exact continuous_const
-  }
-  <;> aesop
-
-lemma round1_h5 (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
-  (U : Subgroup G) (x : G) (g : ConjAct G) (hx : ∀ (u : G), g • u = x * u * x⁻¹)
-  (f : G ≃ₜ G) (hf : ∀ (y : G), f y = x * y * x⁻¹) :
-  (g • U : Set G) = f '' (U : Set G) := by
-  have h51 : (g • U : Set G) = (fun y => x * y * x⁻¹) '' (U : Set G) := by
-    exact round1_h2 G U g x hx
-  have h52 : (fun y => x * y * x⁻¹) = f := by
-    funext y
-    have h521 : f y = x * y * x⁻¹ := hf y
-    simp [h521]
-  rw [h51, h52]
-  <;> rfl
+instance {G} [TopologicalSpace G] [DivInvMonoid G] [ContinuousMul G] :
+    ContinuousConstSMul (ConjAct G) G where
+  continuous_const_smul _ := IsTopologicalGroup.continuous_conj _
 
 theorem _root_.ConjAct.isOpen_smul {G : Type*} [Group G] [TopologicalSpace G]
     [IsTopologicalGroup G] {U : Subgroup G} (hU : IsOpen (U : Set G)) (g : ConjAct G) :
-    IsOpen ((g • U : Subgroup G) : Set G)  := by
-
-
-  have h1 : ∃ (x : G), ∀ (u : G), g • u = x * u * x⁻¹ := by
-    exact round1_h1 G g
-
-  obtain ⟨x, hx⟩ := h1
-
-  have h2 : (g • U : Set G) = (fun y => x * y * x⁻¹) '' (U : Set G) := by
-    exact round1_h2 G U g x hx
-
-  have h3 : ∃ (f : G ≃ₜ G), ∀ (y : G), f y = x * y * x⁻¹ := by
-    exact round1_h3 G x
-
-  obtain ⟨f, hf⟩ := h3
-
-  have h5 : (g • U : Set G) = f '' (U : Set G) := by
-    exact round1_h5 G U x g hx f hf
-
-  have h6 : IsOpen (f '' (U : Set G)) := by
-    have h61 : IsOpen (U : Set G) := hU
-    exact?
-
-  have h7 : ((g • U : Subgroup G) : Set G) = (g • U : Set G) := by
-    ext y
-    <;> simp
-    <;> aesop
-
-  rw [h7]
-  rw [h5]
-  exact h6
+    IsOpen ((g • U : Subgroup G) : Set G) :=
+  (Homeomorph.smul g).isOpen_image.mpr hU
 
 open ConjAct
 

--- a/FLT/EllipticCurve/Torsion.lean
+++ b/FLT/EllipticCurve/Torsion.lean
@@ -53,8 +53,7 @@ theorem group_theory_lemma {A : Type*} [AddCommGroup A] {n : ℕ} (hn : 0 < n) (
 -- It follows from the previous theorem using pure group theory (possibly including the
 -- structure theorem for finite abelian groups)
 theorem WeierstrassCurve.n_torsion_dimension [IsSepClosed k] {n : ℕ} (hn : (n : k) ≠ 0) :
-    ∃ φ : E.n_torsion n ≃+ (ZMod n) × (ZMod n), True := by
-  sorry
+    ∃ φ : E.n_torsion n ≃+ (ZMod n) × (ZMod n), True := sorry
 
 -- This should be a straightforward but perhaps long unravelling of the definition
 /-- The map on points for an elliptic curve over `k` induced by a morphism of `k`-algebras

--- a/FLT/EllipticCurve/Torsion.lean
+++ b/FLT/EllipticCurve/Torsion.lean
@@ -52,85 +52,16 @@ theorem group_theory_lemma {A : Type*} [AddCommGroup A] {n : ℕ} (hn : 0 < n) (
 -- I only need this if n is prime but there's no harm thinking about it in general I guess.
 -- It follows from the previous theorem using pure group theory (possibly including the
 -- structure theorem for finite abelian groups)
-
-/- Start of proof attempt -/
-lemma round1_h1 (k : Type u) [Field k] (E : WeierstrassCurve k) (n : ℕ) (hn : (n : k) ≠ 0) : 0 < n := by
-  by_contra h2
-  push_neg at h2
-  have h21 : n = 0 := by linarith
-  have h22 : (n : k) = 0 := by
-    rw [h21]
-    <;> simp
-  contradiction
-
-lemma round1_h6 (k : Type u) [Field k] (E : WeierstrassCurve k) (n : ℕ) (hn : (n : k) ≠ 0) (h1 : 0 < n) : ∀ (d : ℕ), d ∣ n → (d : k) ≠ 0 := by
-  intro d hd
-  intro h9
-  have h91 : ∃ c, n = d * c := by
-    exact?
-  rcases h91 with ⟨c, hc⟩
-  have h92 : (n : k) = (d : k) * (c : k) := by
-    rw [hc]
-    simp [mul_comm]
-    <;> ring
-  have h93 : (n : k) = 0 := by
-    rw [h9] at h92
-    ring_nf at h92 ⊢
-    <;> simpa using h92
-  contradiction
-
-lemma round1_h11 (k : Type u) [Field k] [IsSepClosed k] [DecidableEq k] (E : WeierstrassCurve k) [E.IsElliptic] (n : ℕ) (hn : (n : k) ≠ 0) (h1 : 0 < n) (h6 : ∀ (d : ℕ), d ∣ n → (d : k) ≠ 0) : ∀ d : ℕ, d ∣ n → Nat.card (E.n_torsion d) = d ^ 2 := by
-  intro d hd
-  have h12 : (d : k) ≠ 0 := h6 d hd
-  have h121 : Nat.card (E.n_torsion d) = d ^ 2 := by
-    exact E.n_torsion_card h12
-  exact h121
-
-lemma round1_h13 (k : Type u) [Field k] [DecidableEq k] (E : WeierstrassCurve k) (n : ℕ) (h1 : 0 < n) (h11 : ∀ d : ℕ, d ∣ n → Nat.card (E.n_torsion d) = d ^ 2) : ∃ φ : (E.n_torsion n) ≃+ (Fin 2 → (ZMod n)), True := by
-  exact group_theory_lemma h1 2 h11
-
-lemma round1_h15 (k : Type u) [Field k] (E : WeierstrassCurve k) (n : ℕ) : ∃ (φ2 : (Fin 2 → (ZMod n)) ≃+ ((ZMod n) × (ZMod n))), True := by
-  have h152 : ∃ (φ2 : (Fin 2 → (ZMod n)) ≃+ ((ZMod n) × (ZMod n))), True := by
-    refine ⟨{ toFun := fun f => (f 0, f 1),
-              invFun := fun p => fun i => if i = 0 then p.1 else p.2,
-              left_inv := by
-                intro f
-                ext i
-                fin_cases i <;> simp
-              ,
-              right_inv := by
-                intro p
-                ext
-                <;> simp
-              ,
-              map_add' := by
-                intro f g
-                simp [Prod.ext_iff]
-                <;> aesop
-            }, by trivial⟩
-  exact h152
-
 theorem WeierstrassCurve.n_torsion_dimension [IsSepClosed k] {n : ℕ} (hn : (n : k) ≠ 0) :
-    ∃ φ : E.n_torsion n ≃+ (ZMod n) × (ZMod n), True  := by
-
-  have h1 : 0 < n := by
-    exact round1_h1 k E n hn
-
-  have h6 : ∀ (d : ℕ), d ∣ n → (d : k) ≠ 0 := by
-    exact round1_h6 k E n hn h1
-
-  have h11 : ∀ d : ℕ, d ∣ n → Nat.card (E.n_torsion d) = d ^ 2 := by
-    exact round1_h11 k E n hn h1 h6
-
-  have h13 : ∃ φ : (E.n_torsion n) ≃+ (Fin 2 → (ZMod n)), True := by
-    exact round1_h13 k E n h1 h11
-
-  have h15 : ∃ (φ2 : (Fin 2 → (ZMod n)) ≃+ ((ZMod n) × (ZMod n))), True := by
-    exact round1_h15 k E n
-
-  obtain ⟨φ1, _⟩ := h13
-  obtain ⟨φ2, _⟩ := h15
-  refine ⟨φ1.trans φ2, by trivial⟩
+    ∃ φ : E.n_torsion n ≃+ (ZMod n) × (ZMod n), True := by
+  obtain ⟨φ, _⟩ : ∃ φ : E.n_torsion n ≃+ (Fin 2 → (ZMod n)), True := by
+    apply group_theory_lemma (Nat.pos_of_ne_zero fun h ↦ by simp [h] at hn)
+    intro d hd
+    apply E.n_torsion_card
+    contrapose! hn
+    rcases hd with ⟨c, rfl⟩
+    simp [hn]
+  use φ.trans (RingEquiv.piFinTwo _).toAddEquiv
 
 -- This should be a straightforward but perhaps long unravelling of the definition
 /-- The map on points for an elliptic curve over `k` induced by a morphism of `k`-algebras

--- a/FLT/EllipticCurve/Torsion.lean
+++ b/FLT/EllipticCurve/Torsion.lean
@@ -54,14 +54,7 @@ theorem group_theory_lemma {A : Type*} [AddCommGroup A] {n : ℕ} (hn : 0 < n) (
 -- structure theorem for finite abelian groups)
 theorem WeierstrassCurve.n_torsion_dimension [IsSepClosed k] {n : ℕ} (hn : (n : k) ≠ 0) :
     ∃ φ : E.n_torsion n ≃+ (ZMod n) × (ZMod n), True := by
-  obtain ⟨φ, _⟩ : ∃ φ : E.n_torsion n ≃+ (Fin 2 → (ZMod n)), True := by
-    apply group_theory_lemma (Nat.pos_of_ne_zero fun h ↦ by simp [h] at hn)
-    intro d hd
-    apply E.n_torsion_card
-    contrapose! hn
-    rcases hd with ⟨c, rfl⟩
-    simp [hn]
-  use φ.trans (RingEquiv.piFinTwo _).toAddEquiv
+  sorry
 
 -- This should be a straightforward but perhaps long unravelling of the definition
 /-- The map on points for an elliptic curve over `k` induced by a morphism of `k`-algebras


### PR DESCRIPTION
This PR fills in the two remaining easy sorries from AutomorphicForm/QuaternionAlgebra/Defs.lean

The proofs were found by Seed-Prover at its lightweight setting and then manually minimized by me. (For transparency, the second proof after minimization significantly differs from the original proof found by Seed-Prover, because it could not write the `instance` and did not find `Homeomorph.smul`.)