### PR TITLE
Mostly finish showing that adele base change map is an isomorphism

### DIFF
--- a/FLT.lean
+++ b/FLT.lean
@@ -11,6 +11,7 @@ import FLT.DedekindDomain.Completion.BaseChange
 import FLT.DedekindDomain.FiniteAdeleRing.BaseChange
 import FLT.DedekindDomain.FiniteAdeleRing.LocalUnits
 import FLT.DedekindDomain.FiniteAdeleRing.TensorPi
+import FLT.DedekindDomain.FiniteAdeleRing.TensorRestrictedProduct
 import FLT.DedekindDomain.IntegralClosure
 import FLT.Deformations.Algebra.InverseLimit.Basic
 import FLT.Deformations.Algebra.InverseLimit.Topology

--- a/FLT/DedekindDomain/Completion/BaseChange.lean
+++ b/FLT/DedekindDomain/Completion/BaseChange.lean
@@ -22,6 +22,7 @@ import Mathlib.Topology.Algebra.Algebra.Equiv
 import Mathlib.Topology.Algebra.Module.ModuleTopology
 import Mathlib.Topology.Algebra.Valued.NormedValued
 import Mathlib.RingTheory.Valuation.RankOne
+import Mathlib.RingTheory.Flat.Basic
 import Mathlib.Topology.Algebra.Module.FiniteDimension
 import FLT.DedekindDomain.AdicValuation
 import FLT.DedekindDomain.IntegralClosure
@@ -232,10 +233,10 @@ noncomputable def tensorAdicCompletionComapAlgHom (v : HeightOneSpectrum A) :
   SemialgHom.baseChange_of_algebraMap (adicCompletionComapSemialgHom' A K L B v)
 
 omit [IsIntegralClosure B A L] [FiniteDimensional K L] in
-lemma tensorAdicCompletionComapAlgHom_tmul_apply (v : HeightOneSpectrum A) (x y i) :
-  tensorAdicCompletionComapAlgHom A K L B v (x ⊗ₜ y) i =
-    x • adicCompletionComapSemialgHom A K L B v i.1 i.2 y := by
-  simp_rw [Algebra.smul_def]
+lemma tensorAdicCompletionComapAlgHom_tmul_apply (v : HeightOneSpectrum A) (x y w) :
+  letI := comap_algebra A K L B w.prop
+  tensorAdicCompletionComapAlgHom A K L B v (x ⊗ₜ y) w =
+    (algebraMap _ (w.1.adicCompletion L) x) * (algebraMap _ (w.1.adicCompletion L) y) := by
   rfl
 
 open scoped TensorProduct.RightActions in
@@ -420,6 +421,14 @@ noncomputable def tensorAdicCompletionIntegersTo (v : HeightOneSpectrum A) :
     ((Algebra.TensorProduct.includeRight.restrictScalars A).comp (IsScalarTower.toAlgHom _ _ _))
     (fun _ _ ↦ .all _ _)
 
+omit [IsIntegralClosure B A L] [FiniteDimensional K L] [Algebra.IsIntegral A B]
+  [IsDedekindDomain B] [IsFractionRing B L] in
+@[simp]
+lemma tensorAdicCompletionIntegersTo_tmul (v : HeightOneSpectrum A) (b : B)
+    (x : v.adicCompletionIntegers K) : tensorAdicCompletionIntegersTo A K L B v (b ⊗ₜ x) =
+      (algebraMap B L b) ⊗ₜ x.val := by
+  simp [tensorAdicCompletionIntegersTo]
+
 omit [IsIntegralClosure B A L]
     [Algebra.IsIntegral A B] [IsDedekindDomain B]
     [IsFractionRing B L] in
@@ -514,9 +523,6 @@ lemma tensorAdicCompletionIsClopenRange :
       intro i
       apply IsIntegralClosure.isIntegral_iff.mp (hb i)
     choose f hf_prop using hf
-    have hf_prop' : ∀ (i : ι), (algebraMap B (L ⊗[K] adicCompletion K v) (f i)) = (b i) ⊗ₜ 1 := by
-      intro i
-      rw [Algebra.TensorProduct.algebraMap_apply, hf_prop]
     use ∑ (i : ι), (f i) ⊗ₜ ⟨g i, hg i trivial⟩
     let _ : NonAssocSemiring (B ⊗[A] (adicCompletionIntegers K v)) :=
       Algebra.TensorProduct.instNonAssocSemiring
@@ -531,8 +537,7 @@ lemma tensorAdicCompletionIsClopenRange :
     apply Finset.sum_congr rfl
     intro x
     have : (algebraMap _ (L ⊗[K] adicCompletion K v)) (g x) = 1 ⊗ₜ[K] (g x) := rfl
-    simp [Algebra.smul_def, Algebra.ofId_apply, tensorAdicCompletionIntegersTo, hf_prop',
-        b', this]
+    simp [Algebra.smul_def, tensorAdicCompletionIntegersTo_tmul, hf_prop, b', this]
   · rw [ContinuousLinearEquiv.image_symm_eq_preimage]
     apply IsOpen.preimage equiv.continuous
     apply isOpen_set_pi Set.finite_univ
@@ -665,12 +670,10 @@ noncomputable def tensorAdicCompletionIntegersToLinearMap :
       (L ⊗[K] adicCompletion K v) where
   __ := tensorAdicCompletionIntegersTo A K L B v
   map_smul' x y := by
-    simp only [tensorAdicCompletionIntegersTo, Algebra.comp_ofId, AlgHom.toRingHom_eq_coe,
+    simp only [tensorAdicCompletionIntegersTo_tmul, AlgHom.toRingHom_eq_coe,
       RingHom.toMonoidHom_eq_coe, AlgHom.toRingHom_toMonoidHom, Algebra.smul_def,
       TensorProduct.RightActions.algebraMap_eval, OneHom.toFun_eq_coe, MonoidHom.toOneHom_coe,
-      MonoidHom.coe_coe, map_mul, Algebra.TensorProduct.lift_tmul, map_one, AlgHom.coe_comp,
-      AlgHom.coe_restrictScalars', IsScalarTower.coe_toAlgHom', RingHom.algebraMap_toAlgebra,
-      Function.comp_apply, Algebra.TensorProduct.includeRight_apply, one_mul, RingHom.id_apply]
+      MonoidHom.coe_coe, map_mul, map_one, RingHom.id_apply]
     rw [Subsemiring.smul_def, Algebra.smul_def]
     rfl
 
@@ -766,43 +769,6 @@ theorem comap_integer_algebra_finite [Module.Finite A B] (v : HeightOneSpectrum 
 end ModuleTopology
 
 section RamificationInertia
-
-/-- There are only finitely many nonzero primes of B above a nonzero prime of A. -/
-noncomputable def Extension.fintype : Fintype (Extension B v) :=
-  have := Extension.finite A K L B v
-  Fintype.ofFinite <| Extension B v
-
-omit [IsIntegralClosure B A L] [FiniteDimensional K L] in
-/-- `Ideal.sum_ramification_inertia`, rewritten as a sum over extensions. -/
-lemma _root_.Ideal.sum_ramification_inertia_extensions [Module.Finite A B] :
-    letI := Extension.fintype A K L B v
-    ∑ (w : Extension B v), Ideal.ramificationIdx (algebraMap A B) (v.asIdeal) (w.val.asIdeal)
-      * (v.asIdeal).inertiaDeg (w.val.asIdeal) = Module.finrank K L := by
-  have := v.isMaximal
-  have := noZeroSMulDivisors A K L B
-  -- Use Ideal.sum_ramification_inertia to make this an equivalence of two sums.
-  rw [← Ideal.sum_ramification_inertia B v.asIdeal K L v.ne_bot]
-  -- Check that the sums are equal via a bijection
-  apply Finset.sum_nbij (fun w ↦ w.val.asIdeal)
-  · rintro ⟨a, rfl⟩ -
-    rw [← Finset.mem_coe, coe_primesOverFinset (comap A a).ne_bot]
-    exact ⟨a.isPrime, ⟨rfl⟩⟩
-  · apply Function.Injective.injOn
-    exact fun _ _ hw ↦ Subtype.ext <| HeightOneSpectrum.ext hw
-  · intro y hy
-    rw [coe_primesOverFinset v.ne_bot B] at hy
-    obtain ⟨hprime, ⟨hyover⟩⟩ := hy
-    have hybot : y ≠ ⊥ := by
-      rw [Ideal.under_def] at hyover
-      intro hbot
-      apply v.ne_bot
-      rw [hyover, hbot]
-      exact Ideal.comap_bot_of_injective _ (FaithfulSMul.algebraMap_injective _ _)
-    let w' : HeightOneSpectrum B := ⟨y, hprime, hybot⟩
-    have wcomap : comap A w' = v := HeightOneSpectrum.ext hyover.symm
-    let w : Extension B v := ⟨w', wcomap⟩
-    exact ⟨w, by simp, rfl⟩
-  · exact fun _ _ ↦ rfl
 
 lemma WithZero.ofAdd_neg_ofNat_pow (n : ℕ) :
     (WithZero.coe (Multiplicative.ofAdd (-n : ℤ))) = (Multiplicative.ofAdd (-1 : ℤ)) ^ n := by
@@ -965,5 +931,59 @@ noncomputable def adicCompletionComapContinuousAlgEquiv (v : HeightOneSpectrum A
     __ := adicCompletionComapAlgEquiv A K L B v
     __ := adicCompletionComapRightContinuousAlgEquiv A K L B v
   }
+
+/-- The A-module isomorphism `B ⊗[A] K_v ≅ ∏_{w|v} L_w`. -/
+noncomputable def adicCompletionComapIntegerLinearEquiv (v : HeightOneSpectrum A) :
+    B ⊗[A] v.adicCompletion K ≃ₗ[A] ∀ w : v.Extension B, w.1.adicCompletion L :=
+  (linearEquivTensorProductModule A K L B (v.adicCompletion K)).symm.trans
+    ((adicCompletionComapAlgEquiv A K L B v).toLinearEquiv.restrictScalars A)
+
+@[simp]
+lemma adicCompletionComapIntegerLinearEquiv_tmul_apply (v : HeightOneSpectrum A) (b : B)
+    (x : v.adicCompletion K) (w : Extension B v) :
+    letI := comap_algebra A K L B w.prop
+    adicCompletionComapIntegerLinearEquiv A K L B v (b ⊗ₜ[A] x) w =
+    (algebraMap B _ b) * (algebraMap _ _ x) := by
+  rw [adicCompletionComapIntegerLinearEquiv, LinearEquiv.trans_apply,
+    linearEquivTensorProductModule_symm_tmul]
+  rfl
+
+/-- The canonical A-linear map `B ⊗[A] 𝓞_v → B ⊗[A] K_v`. -/
+noncomputable def adicCompletionTensorIntegerCoe :
+    B ⊗[A] (v.adicCompletionIntegers K) →ₗ[A] B ⊗[A] (v.adicCompletion K) :=
+  (Algebra.algHom A (adicCompletionIntegers K v) (adicCompletion K v)).toLinearMap.lTensor B
+
+omit [Algebra.IsIntegral A B] [IsDedekindDomain B] [Module.Finite A B] in
+@[simp]
+lemma adicCompletionTensorIntegerCoe_tmul (b : B) (x : v.adicCompletionIntegers K) :
+    adicCompletionTensorIntegerCoe A K B v (b ⊗ₜ x) = b ⊗ₜ x.val :=
+  rfl
+
+/-- `𝓞_v` as an `A`-submodule of `K_v`. -/
+noncomputable def integerSubmodule (v : HeightOneSpectrum A) : Submodule A (adicCompletion K v) :=
+  let s : Submodule (adicCompletionIntegers K v) _ := (adicCompletionIntegers K v).toSubmodule
+  s.restrictScalars A
+
+theorem adicCompletionComapIntegerLinearEquiv_bijOn (v : HeightOneSpectrum A) :
+    Set.BijOn (adicCompletionComapIntegerLinearEquiv A K L B v)
+    (LinearMap.range <| adicCompletionTensorIntegerCoe A K B v)
+    (Submodule.pi Set.univ fun (w : Extension B v) ↦ integerSubmodule B L w.val) := by
+  suffices h : ((adicCompletionComapIntegerLinearEquiv A K L B v).toEquiv ''
+      (LinearMap.range (adicCompletionTensorIntegerCoe A K B v))) =
+      Submodule.pi Set.univ
+      (fun (w : Extension B v) ↦ (integerSubmodule B L w.val).restrictScalars A) from
+    h ▸ Equiv.bijOn_image (adicCompletionComapIntegerLinearEquiv A K L B v).toEquiv
+  apply Eq.trans _ congr(SetLike.coe $(adicCompletionComapAlgEquiv_integral A K L B v))
+  rw [LinearMap.range_coe, ← Set.range_comp, AlgHom.coe_range,
+    ← AlgHom.coe_restrictScalars' (R:=A), ← AlgHom.coe_toLinearMap,
+    LinearEquiv.coe_toEquiv, ← LinearEquiv.coe_toLinearMap, ← LinearMap.coe_comp]
+  congr
+  refine TensorProduct.ext' (fun x y ↦ ?_)
+  ext w
+  simp [← IsScalarTower.algebraMap_apply, tensorAdicCompletionComapAlgHom_tmul_apply]
+
+-- Mathlib #26783
+instance [NoZeroSMulDivisors A B] : Module.Flat A B := by
+  sorry
 
 end IsDedekindDomain.HeightOneSpectrum

--- a/FLT/DedekindDomain/FiniteAdeleRing/BaseChange.lean
+++ b/FLT/DedekindDomain/FiniteAdeleRing/BaseChange.lean
@@ -27,6 +27,7 @@ import Mathlib.RingTheory.Valuation.RankOne
 import Mathlib.Topology.Algebra.Module.FiniteDimension
 import FLT.DedekindDomain.AdicValuation
 import FLT.DedekindDomain.Completion.BaseChange
+import FLT.DedekindDomain.FiniteAdeleRing.TensorRestrictedProduct
 
 /-!
 
@@ -101,6 +102,11 @@ noncomputable def FiniteAdeleRing.mapSemialgHom :
         simpa only [Algebra.smul_def'] using
           (adicCompletionComapSemialgHom A K L B (comap A w) w rfl).map_smul' k (a (comap A w))
 
+omit [IsIntegralClosure B A L] [FiniteDimensional K L] in
+lemma FiniteAdeleRing.mapSemialgHom_apply (x : FiniteAdeleRing A K) (w : HeightOneSpectrum B) :
+    letI := comap_algebra A K L B (Eq.refl (comap A w))
+    mapSemialgHom A K L B x w = algebraMap _ _ (x (comap A w)) := rfl
+
 open scoped TensorProduct.RightActions
 
 noncomputable
@@ -139,22 +145,165 @@ attribute [instance 100] RestrictedProduct.instSMulCoeOfSMulMemClass
 -- #synth SMul (FiniteAdeleRing A K) (FiniteAdeleRing B L)
 -- spends 2 seconds failing to find `SMul (FiniteAdeleRing A K) (adicCompletion L w)
 
+noncomputable section bijection
+
+instance baseChangeIntegerAlgebra : Algebra A (FiniteAdeleRing B L) :=
+  Algebra.compHom (FiniteAdeleRing B L) (algebraMap A B)
+
+omit [Module.Finite A B] [IsDedekindDomain B] in
+theorem range_adicCompletionTensorIntegerCoe_eq_lTensorRestriction (v : HeightOneSpectrum A) :
+    LinearMap.range (adicCompletionTensorIntegerCoe A K B v) =
+    RestrictedProduct.rangeLTensor A B (adicCompletion K) (integerSubmodule A K) v := by
+  rfl
+
+/-- The canonical linear isomorphism `L ⊗[K] 𝔸_K^∞ ≅ B ⊗[A] 𝔸_K^∞`. -/
+def FiniteAdeleRing.tensorEquivTensor :
+    L ⊗[K] FiniteAdeleRing A K ≃ₗ[A] B ⊗[A] FiniteAdeleRing A K := by
+  exact linearEquivTensorProductModule A K L B (FiniteAdeleRing A K)
+
+omit [Module.Finite A B] [IsDedekindDomain B] [IsFractionRing B L] in
+lemma FiniteAdeleRing.tensorEquivTensor_tmul (b : B) (x : FiniteAdeleRing A K) :
+    tensorEquivTensor A K L B ((algebraMap B L b) ⊗ₜ[K] x) = b ⊗ₜ[A] x := by
+  simp [tensorEquivTensor, linearEquivTensorProductModule_tmul]
+
+open scoped RestrictedProduct in
+/-- The `A`-linear isomorphism `φ : B ⊗[K] 𝔸_K^∞ ≅ ∏'_v [B ⊗[A] K_v, B ⊗[A] 𝓞_v]`
+given by `φ (b ⊗ x) v = b ⊗ (x v)`. -/
+def FiniteAdeleRing.tensorEquivRestrictedProduct :
+    B ⊗[A] FiniteAdeleRing A K ≃ₗ[A]
+      Πʳ v, [B ⊗[A] (adicCompletion K v), RestrictedProduct.rangeLTensor A
+      B (adicCompletion K) (integerSubmodule A K) v]:= by
+  have := Module.finitePresentation_of_finite A B
+  have := noZeroSMulDivisors A K L B
+  let map :=
+    RestrictedProduct.lTensorEquiv A B (adicCompletion K) Filter.cofinite (integerSubmodule A K)
+  apply LinearEquiv.trans (TensorProduct.congr (LinearEquiv.refl A B) _) map
+  exact {
+    __ := AddEquiv.refl _
+    map_smul' a x := by
+      ext v
+      exact Algebra.smul_def a (x v) |>.symm
+  }
+
+omit [IsIntegralClosure B A L] [FiniteDimensional K L] [IsFractionRing B L] in
+lemma FiniteAdeleRing.tensorEquivRestrictedProduct_tmul (b : B) (x : FiniteAdeleRing A K)
+    (v : HeightOneSpectrum A) :
+    tensorEquivRestrictedProduct A K L B (b ⊗ₜ[A] x) v = b ⊗ₜ[A] (x v) := rfl
+
+open scoped RestrictedProduct in
+/-- The `A`-linear isomorphism `∏'_v [B ⊗[A] K_v, B ⊗[A] 𝓞_v] ≅ ∏'_v [∏_{w|v} L_w, ∏_{w|v} 𝓞_w]`
+given by `adicCompletionComapIntegerLinearEquiv`. -/
+def FiniteAdeleRing.restrictedProduct_tensorProduct_equiv_restrictedProduct_prod :
+    Πʳ v, [B ⊗[A] (adicCompletion K v), RestrictedProduct.rangeLTensor A
+      B (adicCompletion K) (integerSubmodule A K) v] ≃ₗ[A]
+    Πʳ (v : HeightOneSpectrum A), [(w : Extension B v) → adicCompletion L w.val,
+      Submodule.pi Set.univ fun w : Extension B v ↦ (integerSubmodule B L w.val).restrictScalars A]
+    :=
+  LinearEquiv.restrictedProductCongrRight
+    (adicCompletionComapIntegerLinearEquiv A K L B)
+    (Filter.Eventually.of_forall <| adicCompletionComapIntegerLinearEquiv_bijOn A K L B)
+
+lemma FiniteAdeleRing.restrictedProduct_tensorProduct_equiv_restrictedProduct_prod_apply
+    (f) (v : HeightOneSpectrum A) :
+     FiniteAdeleRing.restrictedProduct_tensorProduct_equiv_restrictedProduct_prod A K L B f v =
+     adicCompletionComapIntegerLinearEquiv A K L B v (f v) := rfl
+
+open scoped RestrictedProduct in
+/-- The `A`-linear isomorphism `∏'_v [∏_{w|v} L_w, ∏_{w|v} 𝓞_w] → 𝔸_L^∞` given by
+`RestrictedProduct.flatten_equiv'`. -/
+def FiniteAdeleRing.restrictedProduct_prod_equiv :
+    Πʳ (v : HeightOneSpectrum A), [(w : Extension B v) → adicCompletion L w.val,
+    Submodule.pi Set.univ fun w : Extension B v ↦ (integerSubmodule B L w.val).restrictScalars A]
+    ≃ₗ[A] FiniteAdeleRing B L :=
+  have : FaithfulSMul A B := FaithfulSMul.of_field_isFractionRing A B K L
+  {
+    __ := RestrictedProduct.flatten_equiv'
+      (fun w : HeightOneSpectrum B ↦ SetLike.coe <| w.adicCompletionIntegers L)
+      (tendsTo_comap_cofinite A B)
+    map_add' x y := rfl
+    map_smul' a x := by
+      ext w
+      change a • (x (comap A w) ⟨w, rfl⟩) = _
+      simp only [Submodule.coe_pi, Submodule.coe_restrictScalars, Algebra.smul_def,
+        RingHom.id_apply, Equiv.toFun_as_coe, RestrictedProduct.mul_apply,
+        RestrictedProduct.flatten_equiv'_apply,
+        IsScalarTower.algebraMap_apply A B (w.adicCompletion L)]
+      rfl
+  }
+
+omit [IsIntegralClosure B A L] [FiniteDimensional K L] in
+lemma FiniteAdeleRing.restrictedProduct_prod_equiv_apply (f) (w : HeightOneSpectrum B) :
+  restrictedProduct_prod_equiv A K L B f w = f (comap A w) ⟨w, rfl⟩ := rfl
+
+/-- The `K`-linear isomorphism `L ⊗ A_K^∞ ≅ A_L^∞` given by composing the previous four maps. -/
+def FiniteAdeleRing.baseChangeLinearEquiv :
+    L ⊗[K] FiniteAdeleRing A K ≃ₗ[K] FiniteAdeleRing B L :=
+  have : IsScalarTower A K (FiniteAdeleRing B L) := by
+    have : IsScalarTower A B (FiniteAdeleRing B L) := IsScalarTower.of_algebraMap_eq' rfl
+    apply IsScalarTower.of_algebraMap_eq
+    intro x
+    nth_rw 2 [RingHom.algebraMap_toAlgebra]
+    rw [RingHom.comp_apply, IsScalarTower.algebraMap_apply A B (FiniteAdeleRing B L),
+      ← IsScalarTower.algebraMap_apply A K L, IsScalarTower.algebraMap_apply A B L]
+    rfl
+  let f := (FiniteAdeleRing.tensorEquivTensor A K L B) ≪≫ₗ
+    (FiniteAdeleRing.tensorEquivRestrictedProduct A K L B) ≪≫ₗ
+    (FiniteAdeleRing.restrictedProduct_tensorProduct_equiv_restrictedProduct_prod A K L B) ≪≫ₗ
+    (FiniteAdeleRing.restrictedProduct_prod_equiv A K L B).restrictScalars A
+  LinearEquiv.extendScalarsOfIsLocalization (nonZeroDivisors A) K f
+
+@[simp]
+lemma algebraMap_apply (x : K) (v : HeightOneSpectrum A) :
+    algebraMap K (FiniteAdeleRing A K) x v = algebraMap K (v.adicCompletion K) x := by
+  rfl
+
+@[simp]
+lemma FiniteAdeleRing.baseChangeLinearEquiv_tmul (b : B) (x : FiniteAdeleRing A K) :
+    FiniteAdeleRing.baseChangeLinearEquiv A K L B ((algebraMap B L b) ⊗ₜ x) =
+    (algebraMap _ (FiniteAdeleRing B L) b) * (algebraMap _ (FiniteAdeleRing B L) x) := by
+  ext w
+  simp [baseChangeLinearEquiv, restrictedProduct_prod_equiv_apply, tensorEquivTensor_tmul,
+    restrictedProduct_tensorProduct_equiv_restrictedProduct_prod_apply,
+    tensorEquivRestrictedProduct_tmul, adicCompletionComapIntegerLinearEquiv_tmul_apply,
+    BaseChange.algebraMap_apply, IsScalarTower.algebraMap_apply B L (FiniteAdeleRing B L),
+    IsScalarTower.algebraMap_apply B L (w.adicCompletion L), -Submodule.coe_pi]
+
+open scoped RestrictedProduct in
+theorem FiniteAdeleRing.baseChange_bijective :
+    Function.Bijective (SemialgHom.baseChange_of_algebraMap <|
+      FiniteAdeleRing.mapSemialgHom A K L B) := by
+  suffices ⇑(SemialgHom.baseChange_of_algebraMap <| FiniteAdeleRing.mapSemialgHom A K L B) =
+      ⇑(FiniteAdeleRing.baseChangeLinearEquiv A K L B) by
+      rw [this]
+      exact (FiniteAdeleRing.baseChangeLinearEquiv A K L B).bijective
+  have : IsScalarTower K L (FiniteAdeleRing B L) := by
+    apply IsScalarTower.of_algebraMap_eq' rfl
+  rw [← AlgHom.coe_restrictScalars' (R:=K), ← AlgHom.coe_toLinearMap, ← LinearEquiv.coe_toLinearMap]
+  apply congr_arg
+  have := IsIntegralClosure.isLocalizedModule A K L B
+  apply IsLocalization.tensorProduct_ext (nonZeroDivisors A) B
+  intro b x
+  ext w
+  simp [SemialgHom.baseChange_of_algebraMap_tmul, mapSemialgHom_apply, BaseChange.algebraMap_apply,
+    IsScalarTower.algebraMap_apply B L (FiniteAdeleRing B L)]
+
 /-- The `L`-algebra isomorphism `L ⊗_K 𝔸_K^∞ ≅ 𝔸_L^∞`. -/
-noncomputable def FiniteAdeleRing.baseChangeAlgEquiv :
-    L ⊗[K] FiniteAdeleRing A K ≃ₐ[L] FiniteAdeleRing B L where
-  __ := AlgEquiv.ofBijective
+def FiniteAdeleRing.baseChangeAlgEquiv :
+    L ⊗[K] FiniteAdeleRing A K ≃ₐ[L] FiniteAdeleRing B L :=
+  AlgEquiv.ofBijective
     (SemialgHom.baseChange_of_algebraMap <| FiniteAdeleRing.mapSemialgHom A K L B)
-    -- ⊢ Function.Bijective ⇑(mapSemialgHom A K L B).baseChange_of_algebraWMap
-    sorry -- #243
+    (FiniteAdeleRing.baseChange_bijective A K L B)
 
 /-- The `𝔸_K^∞`-algebra isomorphism `L ⊗_K 𝔸_K^∞ ≅ 𝔸_L^∞`. -/
-noncomputable def FiniteAdeleRing.baseChangeAdeleAlgEquiv :
+def FiniteAdeleRing.baseChangeAdeleAlgEquiv :
     L ⊗[K] FiniteAdeleRing A K ≃ₐ[FiniteAdeleRing A K] FiniteAdeleRing B L where
   __ := SemialgHom.baseChangeRightOfAlgebraMap <| FiniteAdeleRing.mapSemialgHom A K L B
   __ := FiniteAdeleRing.baseChangeAlgEquiv A K L B
 
 instance : Module.Finite (FiniteAdeleRing A K) (FiniteAdeleRing B L) :=
   Module.Finite.equiv (FiniteAdeleRing.baseChangeAdeleAlgEquiv A K L B).toLinearEquiv
+
+end bijection
 
 section moduleTopology
 

--- a/FLT/DedekindDomain/FiniteAdeleRing/TensorRestrictedProduct.lean
+++ b/FLT/DedekindDomain/FiniteAdeleRing/TensorRestrictedProduct.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2025 Matthew Jasper. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matthew Jasper
+-/
+
+import FLT.DedekindDomain.FiniteAdeleRing.TensorPi
+import FLT.Mathlib.Topology.Algebra.RestrictedProduct.Basic
+import Mathlib.RingTheory.Flat.Basic
+
+namespace RestrictedProduct
+
+open TensorProduct
+
+variable (R M : Type*) [CommRing R] [AddCommGroup M] [Module R M]
+  {ι : Type*} (N : ι → Type*) [∀ i, AddCommGroup (N i)]
+  [∀ i, Module R (N i)]
+
+variable (ℱ : Filter ι) (L : ∀ i, Submodule R (N i))
+
+/-- `M ⊗_R (L i)` as a submodule of `M ⊗_R (N i)`. -/
+def rangeLTensor (i : ι) : Submodule R (M ⊗[R] N i) :=
+  LinearMap.range (LinearMap.lTensor M ((L i).subtype))
+
+/-- The `R`-linear map `φ : M ⊗_R ∏'_i [N i, L i]_[𝓕] → ∏'_i [M ⊗_R (N i), M ⊗_R (L i)]_[𝓕]`
+given by `φ (m ⊗ n) i = m ⊗ (n i)`. -/
+def lTensor :
+    M ⊗[R] Πʳ i, [N i, L i]_[ℱ] →ₗ[R] Πʳ i, [M ⊗[R] N i, rangeLTensor R M N L i]_[ℱ] :=
+  have hmap : ∀ (m : M), ∀ᶠ (j : ι) in ℱ, Set.MapsTo
+      (TensorProduct.mk R M (N j) m) (L j) (rangeLTensor R M N L j) := by
+    intro m
+    filter_upwards with i n hn using ⟨m ⊗ₜ[R] ⟨n, hn⟩, rfl⟩
+  TensorProduct.lift {
+    toFun m := mapAlongLinearMap N _ id Filter.tendsto_id
+        (fun i ↦ TensorProduct.mk R M (N i) m) (hmap m)
+    map_add' m n := by ext; simp
+    map_smul' a m := by ext; simp
+  }
+
+@[simp]
+lemma lTensor_tmul (m : M) (f : Πʳ i, [N i, L i]_[ℱ]) (i : ι) :
+    lTensor R M N ℱ L (m ⊗ₜ f) i = m ⊗ₜ (f i) :=
+  rfl
+
+variable (S : Set ι) [Module.FinitePresentation R M] [Module.Flat R M]
+
+/-- `R`-Linear isomorphism between `M ⊗_R (L i)` and `rangeLTensor R M N L i`. -/
+noncomputable def tmulEquivRangeLTensor (i : ι) : M ⊗[R] (L i) ≃ₗ[R] rangeLTensor R M N L i :=
+  LinearEquiv.ofInjective (LinearMap.lTensor M (Submodule.subtype <| L i))
+    (Module.Flat.lTensor_preserves_injective_linearMap (L i).subtype
+      (Submodule.injective_subtype (L i)))
+
+open scoped Filter in
+/-- `R`-Linear isomorphism that's propositionally equal to `lTensor`. -/
+noncomputable def lTensorPrincipalEquiv :
+    M ⊗[R] Πʳ i, [N i, L i]_[𝓟 S] ≃ₗ[R] Πʳ i, [M ⊗[R] N i, rangeLTensor R M N L i]_[𝓟 S] :=
+  open scoped Classical in
+  let N' (i : ι) := if i ∈ S then L i else (⊤ : Submodule R (N i))
+  let f : Πʳ i, [N i, L i]_[𝓟 S] ≃ₗ[R] (Π i, N' i) := {
+    toFun x i := ⟨x i, by
+      by_cases h : i ∈ S
+      · simpa [N', h] using x.property h
+      · simp [N', h]⟩
+    invFun x := ⟨fun i ↦ x i, by
+      rw [Filter.eventually_principal]
+      intro y hy
+      simpa only [N', hy, ↓reduceIte] using (x y).prop⟩
+    map_add' x y := by ext; simp
+    map_smul' a x := by ext; simp
+  }
+  let g1 : M ⊗[R] Πʳ i, [N i, L i]_[𝓟 S] ≃ₗ[R] M ⊗[R] (Π i, N' i) := LinearEquiv.lTensor M f
+  let g2 : M ⊗[R] (Π i, N' i) ≃ₗ[R] Π i, M ⊗[R] N' i :=
+    tensorPi_equiv_piTensor' R M fun i ↦ ↥(N' i)
+  let gEquiv (i : ι) (h : i ∈ S) : M ⊗[R] (N' i) ≃ₗ[R] rangeLTensor R M N L i :=
+    (LinearEquiv.lTensor M (LinearEquiv.ofEq _ _ (by simp [N', h]))) ≪≫ₗ
+      (tmulEquivRangeLTensor R M N L i)
+  let gEquiv' (i : ι) (h : i ∉ S) : M ⊗[R] (N' i) ≃ₗ[R] M ⊗[R] N i :=
+    LinearEquiv.lTensor M <| LinearEquiv.ofTop (N' i) (by simp [N', h])
+  let g3 : (Π i, M ⊗[R] N' i) ≃ₗ[R] Πʳ i, [M ⊗[R] N i, rangeLTensor R M N L i]_[𝓟 S] := {
+    toFun x := ⟨
+      fun i ↦ if h : i ∈ S then gEquiv i h (x i) else gEquiv' i h (x i),
+      by
+        rw [Filter.eventually_principal]
+        intro i h
+        simp [h]⟩
+    invFun x i := if h : i ∈ S then
+        gEquiv i h |>.symm ⟨(x i), by simpa using x.property h⟩
+      else
+        gEquiv' i h |>.symm (x i)
+    left_inv x := by
+      ext i
+      by_cases h : i ∈ S <;> simp [h]
+    right_inv x := by
+      ext i
+      by_cases h : i ∈ S <;> simp [h]
+    map_add' x y := by
+      ext i
+      by_cases h : i ∈ S <;> simp [h]
+    map_smul' a x := by
+      ext i
+      by_cases h : i ∈ S <;> simp [h]
+  }
+  g1 ≪≫ₗ g2 ≪≫ₗ g3
+
+open scoped Filter in
+lemma lTensorPrincipalEquiv_tmul (m : M) (x : Πʳ i, [N i, L i]_[𝓟 S]) (i : ι) :
+    lTensorPrincipalEquiv R M N L S (m ⊗ₜ x) i = m ⊗ₜ x i := by
+  simp [lTensorPrincipalEquiv, tensorPi_equiv_piTensor'_apply, tmulEquivRangeLTensor,
+      rangeLTensor]
+
+lemma lTensor_bijective : Function.Bijective (lTensor R M N ℱ L) :=
+  -- Should follow from the above and general results about direct
+  -- limits of tensor products.
+  sorry
+
+/-- The `R`-linear isomorphism given by `lTensor` when `M` is a finite flat `R`-module. -/
+noncomputable def lTensorEquiv :
+    M ⊗[R] Πʳ i, [N i, L i]_[ℱ] ≃ₗ[R] Πʳ i, [M ⊗[R] N i, rangeLTensor R M N L i]_[ℱ] :=
+  LinearEquiv.ofBijective (lTensor R M N ℱ L) (lTensor_bijective R M N ℱ L)
+
+@[simp]
+lemma lTensorEquiv_tmul (m : M) (f : Πʳ i, [N i, L i]_[ℱ]) (i : ι) :
+    lTensorEquiv R M N ℱ L (m ⊗ₜ f) i = m ⊗ₜ (f i) :=
+  rfl
+
+end RestrictedProduct

--- a/FLT/DedekindDomain/IntegralClosure.lean
+++ b/FLT/DedekindDomain/IntegralClosure.lean
@@ -5,6 +5,7 @@ Authors: Kevin Buzzard, Andrew Yang, Matthew Jasper
 -/
 import FLT.Mathlib.RingTheory.Localization.BaseChange -- removing this breaks a simp proof
 import Mathlib.Algebra.Group.Int.TypeTags
+import Mathlib.Algebra.Module.FinitePresentation
 import Mathlib.NumberTheory.RamificationInertia.Basic
 import Mathlib.RingTheory.DedekindDomain.AdicValuation
 import Mathlib.RingTheory.DedekindDomain.IntegralClosure
@@ -148,6 +149,43 @@ theorem Extension.finite (v : HeightOneSpectrum A) : Finite (v.Extension B) := b
   · intro x hx y hy hxy
     rwa [← @HeightOneSpectrum.ext_iff] at hxy
 
+/-- There are only finitely many nonzero primes of B above a nonzero prime of A. -/
+noncomputable def Extension.fintype : Fintype (Extension B v) :=
+  have := Extension.finite A K L B v
+  Fintype.ofFinite <| Extension B v
+
+omit [IsIntegralClosure B A L] in
+/-- `Ideal.sum_ramification_inertia`, rewritten as a sum over extensions. -/
+lemma _root_.Ideal.sum_ramification_inertia_extensions [Module.Finite A B] :
+    letI := Extension.fintype A K L B v
+    ∑ (w : Extension B v), Ideal.ramificationIdx (algebraMap A B) (v.asIdeal) (w.val.asIdeal)
+      * (v.asIdeal).inertiaDeg (w.val.asIdeal) = Module.finrank K L := by
+  have := v.isMaximal
+  have := noZeroSMulDivisors A K L B
+  -- Use Ideal.sum_ramification_inertia to make this an equivalence of two sums.
+  rw [← Ideal.sum_ramification_inertia B v.asIdeal K L v.ne_bot]
+  -- Check that the sums are equal via a bijection
+  apply Finset.sum_nbij (fun w ↦ w.val.asIdeal)
+  · rintro ⟨a, rfl⟩ -
+    rw [← Finset.mem_coe, coe_primesOverFinset (comap A a).ne_bot]
+    exact ⟨a.isPrime, ⟨rfl⟩⟩
+  · apply Function.Injective.injOn
+    exact fun _ _ hw ↦ Subtype.ext <| HeightOneSpectrum.ext hw
+  · intro y hy
+    rw [coe_primesOverFinset v.ne_bot B] at hy
+    obtain ⟨hprime, ⟨hyover⟩⟩ := hy
+    have hybot : y ≠ ⊥ := by
+      rw [Ideal.under_def] at hyover
+      intro hbot
+      apply v.ne_bot
+      rw [hyover, hbot]
+      exact Ideal.comap_bot_of_injective _ (FaithfulSMul.algebraMap_injective _ _)
+    let w' : HeightOneSpectrum B := ⟨y, hprime, hybot⟩
+    have wcomap : comap A w' = v := HeightOneSpectrum.ext hyover.symm
+    let w : Extension B v := ⟨w', wcomap⟩
+    exact ⟨w, by simp, rfl⟩
+  · exact fun _ _ ↦ rfl
+
 end BaseChange
 
 end IsDedekindDomain.HeightOneSpectrum
@@ -192,7 +230,7 @@ lemma LinearEquivTensorProduct_symm_tmul (k : K) (b : B) :
 variable (M : Type*) [AddCommGroup M] [Module K M] [Module A M] [IsScalarTower A K M]
 
 /-- The canonical `A`-linear isomorphism `L ⊗ M ≅ B ⊗ M` for any `K`-module `M`. -/
-noncomputable def LinearEquivTensorProductModule : L ⊗[K] M ≃ₗ[A] B ⊗[A] M :=
+noncomputable def linearEquivTensorProductModule : L ⊗[K] M ≃ₗ[A] B ⊗[A] M :=
   let f₁ : L ⊗[K] M ≃ₗ[A] L ⊗[A] M := IsLocalization.moduleTensorEquiv (nonZeroDivisors A) K L M
     |>.restrictScalars A
   let f₂ : L ≃ₗ[A] B ⊗[A] K := LinearEquivTensorProduct A K L B
@@ -205,12 +243,36 @@ noncomputable def LinearEquivTensorProductModule : L ⊗[K] M ≃ₗ[A] B ⊗[A]
     (IsLocalization.moduleLid (nonZeroDivisors A) K M |>.restrictScalars A)
   f₁.trans f₃ |>.trans f₄ |>.trans f₅
 
-lemma LinearEquivTensorProductModule_symm_tmul (b : B) (m : M) :
-    (LinearEquivTensorProductModule A K L B M).symm (b ⊗ₜ m) = (algebraMap B L b) ⊗ₜ m := by
-  simp [LinearEquivTensorProductModule, LinearEquivTensorProduct_symm_one_tmul]
+lemma linearEquivTensorProductModule_symm_tmul (b : B) (m : M) :
+    (linearEquivTensorProductModule A K L B M).symm (b ⊗ₜ m) = (algebraMap B L b) ⊗ₜ m := by
+  simp [linearEquivTensorProductModule, LinearEquivTensorProduct_symm_one_tmul]
 
-lemma LinearEquivTensorProductModule_tmul (b : B) (m : M) :
-    (LinearEquivTensorProductModule A K L B M) ((algebraMap B L b) ⊗ₜ m) = b ⊗ₜ m := by
-  rw [← LinearEquiv.eq_symm_apply, LinearEquivTensorProductModule_symm_tmul]
+lemma linearEquivTensorProductModule_tmul (b : B) (m : M) :
+    (linearEquivTensorProductModule A K L B M) ((algebraMap B L b) ⊗ₜ m) = b ⊗ₜ m := by
+  rw [← LinearEquiv.eq_symm_apply, linearEquivTensorProductModule_symm_tmul]
 
 end IsDedekindDomain
+
+variable (A K L B : Type*) [CommRing A] [CommRing B] [Algebra A B] [Field K] [Field L]
+    [Algebra A K] [IsFractionRing A K] [Algebra B L] [IsDedekindDomain A]
+    [Algebra K L] [Algebra A L] [IsScalarTower A B L] [IsScalarTower A K L]
+    [IsIntegralClosure B A L] [Algebra.IsAlgebraic K L]
+
+include K in
+lemma _root_.IsIntegralClosure.isLocalizedModule : IsLocalizedModule (nonZeroDivisors A)
+    ((Algebra.linearMap B L).restrictScalars A) := by
+  have hlocal := IsIntegralClosure.isLocalization A K L B
+  rw [← isLocalizedModule_iff_isLocalization'] at hlocal
+  exact {
+    map_units x := by
+      obtain ⟨x, hx⟩ := x
+      simpa only [← IsScalarTower.algebraMap_apply, Module.End.isUnit_iff]
+          using hlocal.map_units ⟨_, x, hx, rfl⟩
+    surj' y := by
+      obtain ⟨⟨b, _, s, hs, rfl⟩, hx⟩ := (hlocal.surj) y
+      exact ⟨(b, ⟨s, hs⟩), by simpa [Submonoid.smul_def] using hx⟩
+    exists_of_eq {x₁ x₂} e := by
+      obtain ⟨⟨_, c, hc, rfl⟩, he⟩ := hlocal.exists_of_eq e
+      use ⟨c, hc⟩
+      simpa only [Submonoid.smul_def, smul_eq_mul, Algebra.smul_def] using he
+  }

--- a/FLT/Mathlib/Algebra/Algebra/Hom.lean
+++ b/FLT/Mathlib/Algebra/Algebra/Hom.lean
@@ -31,6 +31,10 @@ variable {φ} {A} {B} in
 lemma SemialgHom.map_smul (ψ : A →ₛₐ[φ] B) (m : R) (x : A) : ψ (m • x) = φ m • ψ x :=
   LinearMap.map_smul' ψ.toLinearMap m x
 
+@[simp]
+theorem coe_mk (f : A →ₛₗ[φ] B) (h₁ h₂ h₃) : ((⟨f, h₁, h₂, h₃⟩ : A →ₛₐ[φ] B) : A → B) = f :=
+  rfl
+
 end semialghom
 
 section semialghomclass

--- a/FLT/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/FLT/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -7,6 +7,8 @@ import Mathlib.RingTheory.Localization.BaseChange
 
 namespace IsLocalization
 
+section
+
 variable {R : Type*} [CommSemiring R] (S : Submonoid R)
   (A : Type*) [CommSemiring A] [Algebra R A] [IsLocalization S A]
   (M₁ : Type*) [AddCommMonoid M₁] [Module R M₁] [Module A M₁] [IsScalarTower R A M₁]
@@ -23,5 +25,32 @@ lemma map_moduleTensorEquiv_tmul (m₁ : M₁) (m₂ : M₂) :
 @[simp]
 lemma map_moduleTensorEquiv_symm_tmul (m₁ : M₁) (m₂ : M₂) :
     (moduleTensorEquiv S A M₁ M₂).symm (m₁ ⊗ₜ[R] m₂) = m₁ ⊗ₜ[A] m₂ := rfl
+
+end
+
+section
+
+open TensorProduct
+
+variable {A : Type*} [CommSemiring A] (S : Submonoid A)
+  (B : Type*) [CommSemiring B] [Algebra A B]
+  (K : Type*) [CommSemiring K] [Algebra A K] [IsLocalization S K]
+  (L : Type*) [CommSemiring L] [Algebra B L] [Algebra A L] [Algebra K L] [IsScalarTower A B L]
+    [IsScalarTower A K L] [IsLocalizedModule (M := B) (M' := L) S (Algebra.linearMap B L)]
+  (M : Type*) [AddCommMonoid M] [Module K M]
+  (P : Type*) [AddCommMonoid P] [Module K P]
+
+include S in
+theorem tensorProduct_ext {g h : L ⊗[K] M →ₗ[K] P}
+    (H : ∀ (x : B) (y : M), g ((algebraMap _ L x) ⊗ₜ[K] y) = h ((algebraMap _ L x) ⊗ₜ[K] y))
+    : g = h := by
+  apply TensorProduct.ext'
+  intro l m
+  obtain ⟨⟨x, s⟩, hl : (s : A) • l = algebraMap B L x⟩ :=
+    IsLocalizedModule.surj (M:=B) (M':=L) S (Algebra.linearMap B L) l
+  rw [← IsUnit.smul_left_cancel <| map_units K s]
+  simpa [← map_smul, TensorProduct.smul_tmul', IsScalarTower.algebraMap_smul K, hl] using H x m
+
+end
 
 end IsLocalization

--- a/FLT/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/FLT/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -48,15 +48,51 @@ end RestrictedProduct
 
 open RestrictedProduct
 
+section modules
+
+variable {ι₁ ι₂ : Type*}
+variable (R₁ : ι₁ → Type*) (R₂ : ι₂ → Type*)
+variable {𝓕₁ : Filter ι₁} {𝓕₂ : Filter ι₂}
+variable {A₁ : (i : ι₁) → Set (R₁ i)} {A₂ : (i : ι₂) → Set (R₂ i)}
+variable {S₁ : ι₁ → Type*} {S₂ : ι₂ → Type*}
+variable [Π i, SetLike (S₁ i) (R₁ i)] [Π j, SetLike (S₂ j) (R₂ j)]
+variable {B₁ : Π i, S₁ i} {B₂ : Π j, S₂ j}
+variable (f : ι₂ → ι₁) (hf : Filter.Tendsto f 𝓕₂ 𝓕₁)
+variable {A : Type*} [Semiring A]
+variable [Π i, AddCommMonoid (R₁ i)] [Π i, AddCommMonoid (R₂ i)] [Π i, Module A (R₁ i)]
+    [Π i, Module A (R₂ i)] [∀ i, AddSubmonoidClass (S₁ i) (R₁ i)]
+    [∀ i, AddSubmonoidClass (S₂ i) (R₂ i)] [∀ i, SMulMemClass (S₁ i) A (R₁ i)]
+    [∀ i, SMulMemClass (S₂ i) A (R₂ i)]
+    (φ : ∀ j, R₁ (f j) →ₗ[A] R₂ j)
+    (hφ : ∀ᶠ j in 𝓕₂, Set.MapsTo (φ j) (B₁ (f j)) (B₂ j))
+
+/--
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`
+of `A`-modules, `RestrictedProduct.mapAlongLinearMap` gives an `A`-linear map between them.
+The data needed is a function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and `A`-linear
+maps `φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
+-/
+def RestrictedProduct.mapAlongLinearMap :
+    Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →ₗ[A] Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
+  __ := mapAlongAddMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
+  map_smul' a f := by
+    ext i
+    apply map_smul (φ i)
+
+@[simp]
+lemma RestrictedProduct.mapAlongLinearMap_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
+    x.mapAlongLinearMap R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
+  rfl
+
+end modules
+
 variable {ι : Type*}
 variable {ℱ : Filter ι}
     {G H : ι → Type*}
     {C : (i : ι) → Set (G i)}
     {D : (i : ι) → Set (H i)}
 
--- now let's add groups
-
-section groups
+section equivs
 
 variable {S T : ι → Type*} -- subobject types
 variable [Π i, SetLike (S i) (G i)] [Π i, SetLike (T i) (H i)]
@@ -76,6 +112,20 @@ def MonoidHom.restrictedProductCongrRight (φ : (i : ι) → G i →* H i)
       map_one' := by ext; simp [congrRight]
       map_mul' x y := by ext; simp [congrRight]
 
+variable [Π i, Monoid (G i)] [Π i, SubmonoidClass (S i) (G i)]
+    [Π i, Monoid (H i)] [Π i, SubmonoidClass (T i) (H i)] in
+/-- The `MulEquiv` between restricted products built from `MulEquiv`s on the factors. -/
+@[to_additive "The `AddEquiv` between restricted products built from `AddEquiv`s on the factors."]
+def MulEquiv.restrictedProductCongrRight (φ : (i : ι) → G i ≃* H i)
+    (hφ : ∀ᶠ i in ℱ, Set.BijOn (φ i) (A i) (B i)) :
+    (Πʳ i, [G i, A i]_[ℱ]) ≃* (Πʳ i, [H i, B i]_[ℱ]) where
+  __ := MonoidHom.restrictedProductCongrRight (fun i ↦ φ i)
+    (by filter_upwards [hφ]; exact fun i ↦ Set.BijOn.mapsTo)
+  invFun := MonoidHom.restrictedProductCongrRight (fun i ↦ (φ i).symm)
+    (by filter_upwards [hφ]; exact fun i ↦ Set.BijOn.mapsTo ∘ Set.BijOn.equiv_symm)
+  left_inv x := by ext; simp [MonoidHom.restrictedProductCongrRight, congrRight]
+  right_inv x := by ext; simp [MonoidHom.restrictedProductCongrRight, congrRight]
+
 /-- The isomorphism between the units of a restricted product of monoids,
 and the restricted product of the units of the monoids. -/
 def MulEquiv.restrictedProductUnits {ι : Type*} {ℱ : Filter ι}
@@ -94,7 +144,21 @@ def MulEquiv.restrictedProductUnits {ι : Type*} {ℱ : Filter ι}
         right_inv ui := by ext; rfl
         map_mul' u v := by ext; rfl
 
-end groups
+variable {R : Type*} [Semiring R] [Π i, AddCommMonoid (G i)] [Π i, AddSubmonoidClass (S i) (G i)]
+    [Π i, Module R (G i)] [Π i, SMulMemClass (S i) R (G i)]
+    [Π i, AddCommMonoid (H i)] [Π i, AddSubmonoidClass (T i) (H i)]
+    [Π i, Module R (H i)] [Π i, SMulMemClass (T i) R (H i)] in
+/-- The `LinearEquiv` between restricted products built from `LinearEquiv`s on the factors. -/
+def LinearEquiv.restrictedProductCongrRight (φ : (i : ι) → G i ≃ₗ[R] H i)
+    (hφ : ∀ᶠ i in ℱ, Set.BijOn (φ i) (A i) (B i)) :
+    (Πʳ i, [G i, A i]_[ℱ]) ≃ₗ[R] (Πʳ i, [H i, B i]_[ℱ]) where
+  __ := AddEquiv.restrictedProductCongrRight (fun i ↦ (φ i).toAddEquiv)
+    (by filter_upwards [hφ]; exact fun i ↦ id)
+  map_smul' m x := by
+    ext i
+    apply map_smul
+
+end equivs
 
 section supports
 

--- a/blueprint/src/chapter/AdeleMiniproject.tex
+++ b/blueprint/src/chapter/AdeleMiniproject.tex
@@ -482,7 +482,7 @@ straightforward.
 \begin{corollary}
   \label{IsDedekindDomain.AKLB.tensorProduct_module_algEquiv}
   %%% \uses{IsDedekindDomain.FiniteAdeleRing.baseChangeAlgEquiv} -- uncomment to break leanblueprint
-  \lean{IsDedekindDomain.LinearEquivTensorProductModule}
+  \lean{IsDedekindDomain.linearEquivTensorProductModule}
   \leanok
   If $M$ is any $K$-module then the canonical map $B\otimes_A M\to L\otimes_K M$
   is an isomorphism.


### PR DESCRIPTION
Reduces bijectivity of FiniteAdeleRing.baseChangeAlgEquiv to a result about tensor products commuting with restricted products.

Most of #243