### PR TITLE
chore: allow CI to run on github-actions

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'github-actions/**'
     paths:
       - '**/*.lean'
       - '**/blueprint.yml'


### PR DESCRIPTION
PRs like #700 and #692 are a bot updating mathlib and CI is not running on them. This is an attempt to run CI on these bot-generated PRs.