### PR TITLE
feat: cocompactness of principal adeles

### DIFF
--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -398,18 +398,21 @@ theorem FiniteAdeleRing.isCompact_finiteIntegralAdeles :
   HeightOneSpectrum.adicCompletionIntegers K v) := Pi.compactSpace
   apply isCompact_range; exact RestrictedProduct.isEmbedding_structureMap.continuous
 
+/-- The subgroup of principal adeles `(x)ᵥ` where `x ∈ K`. -/
+noncomputable def FiniteAdeleRing.principalSubgroup : AddSubgroup (FiniteAdeleRing (𝓞 K) K) :=
+  (algebraMap K _).range.toAddSubgroup
+
 def finiteAdeleRing_equiv_qHat : FiniteAdeleRing (𝓞 ℚ) ℚ ≃+ QHat := sorry
 
 
-
+open FiniteAdeleRing in
 theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 ℚ) ℚ) :
-  ∃ x : ℚ,
-    ∀ v, (a - algebraMap ℚ (FiniteAdeleRing (𝓞 ℚ) ℚ) x) v
-    ∈ HeightOneSpectrum.adicCompletionIntegers ℚ v := by
-  let S := {v | a v ∉ HeightOneSpectrum.adicCompletionIntegers ℚ v}
+  ∃ x : principalSubgroup ℚ,
+    a - x ∈ finiteIntegralAdeles ℚ := by
+  /- let S := {v | a v ∉ HeightOneSpectrum.adicCompletionIntegers ℚ v}
   have h_S_finite : S.Finite := Filter.eventually_cofinite.mp a.eventually
   let π (v : HeightOneSpectrum (𝓞 ℚ)) : ℚ :=
-    (HeightOneSpectrum.valuation_exists_uniformizer ℚ v).choose
+    (HeightOneSpectrum.valuation_exists_uniformizer ℚ v).choose -/
 
   sorry
 
@@ -417,6 +420,7 @@ open Metric NumberField.InfinitePlace in
 theorem InfiniteAdeleRing.sub_mem_closedBalls (a : InfiniteAdeleRing ℚ) :
     ∃ (x : 𝓞 ℚ), ∀ v, norm ((a - algebraMap ℚ _ x) v) ≤ 1 := by
   sorry
+  -- https://github.com/smmercuri/adele-ring_locally-compact/blob/55396f8e8de5c45780a615ee1684f510b02b4e1f/AdeleRingLocallyCompact/NumberTheory/NumberField/AdeleRing.lean#L228
 
 open Metric in
 theorem Rat.AdeleRing.cocompact :
@@ -433,10 +437,11 @@ theorem Rat.AdeleRing.cocompact :
     QuotientAddGroup.mk' _
   have h_W_image : q '' W = Set.univ := by
     simp only [q, Set.eq_univ_iff_forall]
-    intro x
-    let a := Quotient.out x
+    intro x; let a := Quotient.out x
     rw [Set.mem_image]
-    choose xf hf using FiniteAdeleRing.sub_mem_finiteIntegralAdeles a.2
+    choose xf hf using
+      Set.exists_subtype_range_iff.mp (FiniteAdeleRing.sub_mem_finiteIntegralAdeles a.2)
+    rw [FiniteAdeleRing.finiteIntegralAdeles, RestrictedProduct.range_structureMap] at hf
     choose xi hi using InfiniteAdeleRing.sub_mem_closedBalls (a.1 - algebraMap _ _ xf)
     let c := algebraMap ℚ (AdeleRing (𝓞 ℚ) ℚ) <| xi + xf
     let b := a - c

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -390,8 +390,14 @@ variable (K : Type*) [Field K] [NumberField K]
 open IsDedekindDomain in
 theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 K) K) :
   ∃ x : K,
-    a - algebraMap K (FiniteAdeleRing (𝓞 K) K) x
-    ∈ Set.range (RestrictedProduct.structureMap _ _ _) := by
+    ∀ v, (a - algebraMap K (FiniteAdeleRing (𝓞 K) K) x) v
+    ∈ HeightOneSpectrum.adicCompletionIntegers K v := by
+
+  sorry
+
+open Metric NumberField.InfinitePlace in
+theorem InfiniteAdeleRing.sub_mem_closedBalls (a : InfiniteAdeleRing ℚ) :
+    ∃ (x : 𝓞 ℚ), ∀ v, norm ((a - algebraMap ℚ _ x) v) ≤ 1 := by
   sorry
 
 open IsDedekindDomain Metric in
@@ -402,8 +408,6 @@ theorem Rat.AdeleRing.cocompact :
   let W_fin : Set (FiniteAdeleRing (𝓞 ℚ) ℚ) :=
     Set.range (RestrictedProduct.structureMap _ _ _)
   let W : Set (AdeleRing (𝓞 ℚ) ℚ) := W_inf.prod W_fin
-  let f : AdeleRing (𝓞 ℚ) ℚ → AdeleRing (𝓞 ℚ) ℚ ⧸ AdeleRing.principalSubgroup (𝓞 ℚ) ℚ :=
-    QuotientAddGroup.mk' _
   have h_W_compact : IsCompact W := by
     refine IsCompact.prod (isCompact_univ_pi (fun v => ?_))
       (by
@@ -412,35 +416,36 @@ theorem Rat.AdeleRing.cocompact :
       apply isCompact_range; exact RestrictedProduct.isEmbedding_structureMap.continuous)
     letI : ProperSpace v.Completion := ProperSpace.of_locallyCompactSpace v.Completion
     exact isCompact_iff_isClosed_bounded.2 <| ⟨isClosed_closedBall, isBounded_closedBall⟩
+  let f : AdeleRing (𝓞 ℚ) ℚ → AdeleRing (𝓞 ℚ) ℚ ⧸ AdeleRing.principalSubgroup (𝓞 ℚ) ℚ :=
+    QuotientAddGroup.mk' _
   have h_W_image : f '' W = Set.univ := by
     simp only [f, Set.eq_univ_iff_forall]
     intro x
     let a := Quotient.out x
     rw [Set.mem_image]
-    #check a.2
-    /- choose xf yf hf using FiniteAdeleRing.sub_mem_finiteIntegralAdeles ℚ a.2
+    choose xf hf using FiniteAdeleRing.sub_mem_finiteIntegralAdeles ℚ a.2
     choose xi hi using InfiniteAdeleRing.sub_mem_closedBalls (a.1 - algebraMap _ _ xf)
-    let c := algebraMap ℚ (AdeleRing ℚ) <| xi + xf
+    let c := algebraMap ℚ (AdeleRing (𝓞 ℚ) ℚ) <| xi + xf
     let b := a - c
     have hb : b ∈ W := by
       simp only [W, Set.prod, W_inf, W_fin]
       refine ⟨Set.mem_univ_pi.2 fun v => ?_, ?_⟩
-      · simp only [b, map_add, mem_closedBall, dist_zero_right, c,
-          add_comm, Prod.fst_sub, Prod.fst_add, ← sub_sub]
+      · simp only [b, map_add, mem_closedBall, dist_zero_right, c, add_comm, ← sub_sub]
         exact hi v
-      · simp only [Set.image_univ, Set.mem_range, Eq.comm,
-          FiniteAdeleRing.exists_finiteIntegralAdele_iff]
+      · apply RestrictedProduct.exists_structureMap_eq_of_forall
+        simp only [map_add, SetLike.mem_coe, b, c]
+        rw [Prod.snd_sub, Prod.snd_add, sub_add_eq_sub_sub, sub_right_comm]
         intro v
-        simp only [b, c, map_add, add_comm, ← sub_sub]
-        exact (v.adicCompletionIntegers _).sub_mem
-          ((FiniteAdeleRing.exists_finiteIntegralAdele_iff _).1 ⟨_, hf⟩ v)
-            (v.coe_mem_adicCompletionIntegers _)
+        refine sub_mem (hf v) ?_
+        simp only [AdeleRing.algebraMap_snd_apply]
+        exact HeightOneSpectrum.coe_algebraMap_mem (𝓞 ℚ) ℚ v xi
     refine ⟨b, hb, ?_⟩
-    rw [← QuotientAddGroup.out_eq' x, QuotientAddGroup.mk'_apply, QuotientAddGroup.eq_iff_sub_mem]
-    simp only [b, sub_sub_cancel_left, neg_mem_iff, principalSubgroup, AddSubgroup.mem_mk,
-      Subsemiring.coe_carrier_toSubmonoid, Subring.coe_toSubsemiring, RingHom.coe_range,
-      Set.mem_range, exists_apply_eq_apply] -/
-    sorry
+    unfold b; unfold a
+    simp only [QuotientAddGroup.mk'_apply, QuotientAddGroup.mk_sub, Quotient.out_eq, sub_eq_self,
+      QuotientAddGroup.eq_zero_iff, AddSubgroup.mem_mk, Subsemiring.coe_carrier_toSubmonoid,
+      Subring.coe_toSubsemiring, RingHom.coe_range, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk,
+      Set.mem_range]
+    use xi + xf
   exact { isCompact_univ := h_W_image ▸ IsCompact.image h_W_compact continuous_quot_mk }
 
 variable (K L : Type*) [Field K] [Field L] [NumberField K] [NumberField L] [Algebra K L]

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -412,21 +412,17 @@ lemma finiteIntegralAdeles_equiv_zHatsub :
 
 open FiniteAdeleRing in
 theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 ℚ) ℚ) :
-  ∃ x : principalSubgroup ℚ,
-    a - x ∈ finiteIntegralAdeles ℚ := by
+  ∃ x : principalSubgroup ℚ, a - x ∈ finiteIntegralAdeles ℚ := by
   have h :=
     AddSubgroup.mem_sup.mp
     (QHat.rat_join_zHat ▸ AddSubgroup.mem_top (finiteAdeleRing_equiv_qHat a))
   choose y hy z hz h' using h
-
   have hy' : y ∈ (QHat.ratsub : Set QHat) := hy
   rw [← principalSubgroup_equiv_ratsub] at hy'
   choose x hx hxy using (Set.mem_image _ _ _).mp hy'
-
   have hz' : z ∈ (QHat.zHatsub : Set QHat) := hz
   rw [← finiteIntegralAdeles_equiv_zHatsub] at hz'
   choose w hw hwz using (Set.mem_image _ _ _).mp hz'
-
   use ⟨x, hx⟩
   rw [← hxy, ← hwz, ← map_add] at h'
   apply finiteAdeleRing_equiv_qHat.injective at h'

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -414,7 +414,7 @@ lemma finiteIntegralAdeles_equiv_zHatsub :
 
 open FiniteAdeleRing in
 theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 ℚ) ℚ) :
-  ∃ x : principalSubgroup ℚ, a - x ∈ finiteIntegralAdeles ℚ := by
+    ∃ x : principalSubgroup ℚ, a - x ∈ finiteIntegralAdeles ℚ := by
   have h := AddSubgroup.mem_sup.mp
     (QHat.rat_join_zHat ▸ AddSubgroup.mem_top (finiteAdeleRing_equiv_qHat a))
   choose y hy z hz h' using h

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -392,6 +392,8 @@ theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 
   ∃ x : K,
     ∀ v, (a - algebraMap K (FiniteAdeleRing (𝓞 K) K) x) v
     ∈ HeightOneSpectrum.adicCompletionIntegers K v := by
+  let S := {v | a v ∉ HeightOneSpectrum.adicCompletionIntegers K v}
+  have h_S_finite : S.Finite := Filter.eventually_cofinite.mp a.eventually
 
   sorry
 

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -404,17 +404,34 @@ noncomputable def FiniteAdeleRing.principalSubgroup : AddSubgroup (FiniteAdeleRi
 
 def finiteAdeleRing_equiv_qHat : FiniteAdeleRing (𝓞 ℚ) ℚ ≃+ QHat := sorry
 
+lemma principalSubgroup_equiv_ratsub :
+    finiteAdeleRing_equiv_qHat '' (FiniteAdeleRing.principalSubgroup ℚ) = QHat.ratsub := sorry
+
+lemma finiteIntegralAdeles_equiv_zHatsub :
+    finiteAdeleRing_equiv_qHat '' (FiniteAdeleRing.finiteIntegralAdeles ℚ) = QHat.zHatsub := sorry
 
 open FiniteAdeleRing in
 theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 ℚ) ℚ) :
   ∃ x : principalSubgroup ℚ,
     a - x ∈ finiteIntegralAdeles ℚ := by
-  /- let S := {v | a v ∉ HeightOneSpectrum.adicCompletionIntegers ℚ v}
-  have h_S_finite : S.Finite := Filter.eventually_cofinite.mp a.eventually
-  let π (v : HeightOneSpectrum (𝓞 ℚ)) : ℚ :=
-    (HeightOneSpectrum.valuation_exists_uniformizer ℚ v).choose -/
+  have h :=
+    AddSubgroup.mem_sup.mp
+    (QHat.rat_join_zHat ▸ AddSubgroup.mem_top (finiteAdeleRing_equiv_qHat a))
+  choose y hy z hz h' using h
 
-  sorry
+  have hy' : y ∈ (QHat.ratsub : Set QHat) := hy
+  rw [← principalSubgroup_equiv_ratsub] at hy'
+  choose x hx hxy using (Set.mem_image _ _ _).mp hy'
+
+  have hz' : z ∈ (QHat.zHatsub : Set QHat) := hz
+  rw [← finiteIntegralAdeles_equiv_zHatsub] at hz'
+  choose w hw hwz using (Set.mem_image _ _ _).mp hz'
+
+  use ⟨x, hx⟩
+  rw [← hxy, ← hwz, ← map_add] at h'
+  apply finiteAdeleRing_equiv_qHat.injective at h'
+  rw [← h']
+  simpa
 
 open Metric NumberField.InfinitePlace in
 theorem InfiniteAdeleRing.sub_mem_closedBalls (a : InfiniteAdeleRing ℚ) :

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -1,6 +1,7 @@
 import FLT.DedekindDomain.FiniteAdeleRing.BaseChange
 import FLT.NumberField.InfiniteAdeleRing
 import FLT.NumberField.Completion.Finite
+import FLT.AutomorphicRepresentation.Example
 import FLT.Mathlib.Algebra.Algebra.Tower
 import FLT.Mathlib.LinearAlgebra.Dimension.Constructions
 import FLT.Mathlib.RingTheory.TensorProduct.Pi
@@ -384,9 +385,23 @@ end Discrete
 
 section Compact
 
-open NumberField
+open NumberField IsDedekindDomain
 
-open IsDedekindDomain in
+variable (K : Type*) [Field K] [NumberField K]
+
+def FiniteAdeleRing.finiteIntegralAdeles : Set (FiniteAdeleRing (𝓞 K) K) :=
+  Set.range (RestrictedProduct.structureMap _ _ _)
+
+theorem FiniteAdeleRing.isCompact_finiteIntegralAdeles :
+    IsCompact (FiniteAdeleRing.finiteIntegralAdeles K) := by
+  letI : CompactSpace ((v : HeightOneSpectrum (𝓞 K)) →
+  HeightOneSpectrum.adicCompletionIntegers K v) := Pi.compactSpace
+  apply isCompact_range; exact RestrictedProduct.isEmbedding_structureMap.continuous
+
+def finiteAdeleRing_equiv_qHat : FiniteAdeleRing (𝓞 ℚ) ℚ ≃+ QHat := sorry
+
+
+
 theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 ℚ) ℚ) :
   ∃ x : ℚ,
     ∀ v, (a - algebraMap ℚ (FiniteAdeleRing (𝓞 ℚ) ℚ) x) v
@@ -403,20 +418,15 @@ theorem InfiniteAdeleRing.sub_mem_closedBalls (a : InfiniteAdeleRing ℚ) :
     ∃ (x : 𝓞 ℚ), ∀ v, norm ((a - algebraMap ℚ _ x) v) ≤ 1 := by
   sorry
 
-open IsDedekindDomain Metric in
+open Metric in
 theorem Rat.AdeleRing.cocompact :
-    CompactSpace (AdeleRing (𝓞 ℚ) ℚ ⧸ AdeleRing.principalSubgroup (𝓞 ℚ) ℚ) := by
+    CompactSpace (AdeleRing (𝓞 ℚ) ℚ ⧸ AdeleRing.principalSubgroup (𝓞 ℚ) ℚ) :=
   let W_inf : Set (InfiniteAdeleRing ℚ) := Set.pi Set.univ <|
     fun (v : InfinitePlace ℚ) => closedBall 0 1
-  let W_fin : Set (FiniteAdeleRing (𝓞 ℚ) ℚ) :=
-    Set.range (RestrictedProduct.structureMap _ _ _)
-  let W : Set (AdeleRing (𝓞 ℚ) ℚ) := W_inf.prod W_fin
+  let W : Set (AdeleRing (𝓞 ℚ) ℚ) := W_inf.prod (FiniteAdeleRing.finiteIntegralAdeles ℚ)
   have h_W_compact : IsCompact W := by
     refine IsCompact.prod (isCompact_univ_pi (fun v => ?_))
-      (by
-      letI : CompactSpace ((v : HeightOneSpectrum (𝓞 ℚ)) →
-      HeightOneSpectrum.adicCompletionIntegers ℚ v) := Pi.compactSpace
-      apply isCompact_range; exact RestrictedProduct.isEmbedding_structureMap.continuous)
+      (FiniteAdeleRing.isCompact_finiteIntegralAdeles ℚ)
     letI : ProperSpace v.Completion := ProperSpace.of_locallyCompactSpace v.Completion
     exact isCompact_iff_isClosed_bounded.2 <| ⟨isClosed_closedBall, isBounded_closedBall⟩
   let q : AdeleRing (𝓞 ℚ) ℚ → AdeleRing (𝓞 ℚ) ℚ ⧸ AdeleRing.principalSubgroup (𝓞 ℚ) ℚ :=
@@ -431,7 +441,7 @@ theorem Rat.AdeleRing.cocompact :
     let c := algebraMap ℚ (AdeleRing (𝓞 ℚ) ℚ) <| xi + xf
     let b := a - c
     have hb : b ∈ W := by
-      simp only [W, Set.prod, W_inf, W_fin]
+      simp only [W, Set.prod, W_inf, FiniteAdeleRing.finiteIntegralAdeles]
       refine ⟨Set.mem_univ_pi.2 fun v => ?_, ?_⟩
       · simp only [b, map_add, mem_closedBall, dist_zero_right, c, add_comm, ← sub_sub]
         exact hi v
@@ -449,7 +459,7 @@ theorem Rat.AdeleRing.cocompact :
       Subring.coe_toSubsemiring, RingHom.coe_range, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk,
       Set.mem_range]
     use xi + xf
-  exact { isCompact_univ := h_W_image ▸ IsCompact.image h_W_compact continuous_quot_mk }
+  { isCompact_univ := h_W_image ▸ IsCompact.image h_W_compact continuous_quot_mk }
 
 variable (K L : Type*) [Field K] [Field L] [NumberField K] [NumberField L] [Algebra K L]
 

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -389,6 +389,7 @@ open NumberField IsDedekindDomain
 
 variable (K : Type*) [Field K] [NumberField K]
 
+/-- The integral adeles in the finite adele ring. -/
 def FiniteAdeleRing.finiteIntegralAdeles : Set (FiniteAdeleRing (𝓞 K) K) :=
   Set.range (RestrictedProduct.structureMap _ _ _)
 
@@ -402,6 +403,7 @@ theorem FiniteAdeleRing.isCompact_finiteIntegralAdeles :
 noncomputable def FiniteAdeleRing.principalSubgroup : AddSubgroup (FiniteAdeleRing (𝓞 K) K) :=
   (algebraMap K _).range.toAddSubgroup
 
+/-- The equivalence between `FiniteAdeleRing (𝓞 ℚ) ℚ` and `QHat`. -/
 def finiteAdeleRing_equiv_qHat : FiniteAdeleRing (𝓞 ℚ) ℚ ≃+ QHat := sorry
 
 lemma principalSubgroup_equiv_ratsub :

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -413,8 +413,7 @@ lemma finiteIntegralAdeles_equiv_zHatsub :
 open FiniteAdeleRing in
 theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 ℚ) ℚ) :
   ∃ x : principalSubgroup ℚ, a - x ∈ finiteIntegralAdeles ℚ := by
-  have h :=
-    AddSubgroup.mem_sup.mp
+  have h := AddSubgroup.mem_sup.mp
     (QHat.rat_join_zHat ▸ AddSubgroup.mem_top (finiteAdeleRing_equiv_qHat a))
   choose y hy z hz h' using h
   have hy' : y ∈ (QHat.ratsub : Set QHat) := hy
@@ -426,8 +425,7 @@ theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 
   use ⟨x, hx⟩
   rw [← hxy, ← hwz, ← map_add] at h'
   apply finiteAdeleRing_equiv_qHat.injective at h'
-  rw [← h']
-  simpa
+  simpa [← h']
 
 open Metric NumberField.InfinitePlace in
 theorem InfiniteAdeleRing.sub_mem_closedBalls (a : InfiniteAdeleRing ℚ) :

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -1,5 +1,6 @@
 import FLT.DedekindDomain.FiniteAdeleRing.BaseChange
 import FLT.NumberField.InfiniteAdeleRing
+import FLT.NumberField.Completion.Finite
 import FLT.Mathlib.Algebra.Algebra.Tower
 import FLT.Mathlib.LinearAlgebra.Dimension.Constructions
 import FLT.Mathlib.RingTheory.TensorProduct.Pi
@@ -11,6 +12,7 @@ import FLT.Mathlib.Topology.Algebra.Module.ModuleTopology
 import Mathlib.NumberTheory.NumberField.AdeleRing
 import Mathlib.NumberTheory.NumberField.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Prod
+import Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing
 import FLT.NumberField.FiniteAdeleRing
 
 open scoped TensorProduct
@@ -383,9 +385,63 @@ section Compact
 
 open NumberField
 
+variable (K : Type*) [Field K] [NumberField K]
+
+open IsDedekindDomain in
+theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 K) K) :
+  ∃ x : K,
+    a - algebraMap K (FiniteAdeleRing (𝓞 K) K) x
+    ∈ Set.range (RestrictedProduct.structureMap _ _ _) := by
+  sorry
+
+open IsDedekindDomain Metric in
 theorem Rat.AdeleRing.cocompact :
-    CompactSpace (AdeleRing (𝓞 ℚ) ℚ ⧸ AdeleRing.principalSubgroup (𝓞 ℚ) ℚ) :=
-  sorry -- issue #258
+    CompactSpace (AdeleRing (𝓞 ℚ) ℚ ⧸ AdeleRing.principalSubgroup (𝓞 ℚ) ℚ) := by
+  let W_inf : Set (InfiniteAdeleRing ℚ) := Set.pi Set.univ <|
+    fun (v : InfinitePlace ℚ) => closedBall 0 1
+  let W_fin : Set (FiniteAdeleRing (𝓞 ℚ) ℚ) :=
+    Set.range (RestrictedProduct.structureMap _ _ _)
+  let W : Set (AdeleRing (𝓞 ℚ) ℚ) := W_inf.prod W_fin
+  let f : AdeleRing (𝓞 ℚ) ℚ → AdeleRing (𝓞 ℚ) ℚ ⧸ AdeleRing.principalSubgroup (𝓞 ℚ) ℚ :=
+    QuotientAddGroup.mk' _
+  have h_W_compact : IsCompact W := by
+    refine IsCompact.prod (isCompact_univ_pi (fun v => ?_))
+      (by
+      letI : CompactSpace ((v : HeightOneSpectrum (𝓞 ℚ)) →
+      HeightOneSpectrum.adicCompletionIntegers ℚ v) := Pi.compactSpace
+      apply isCompact_range; exact RestrictedProduct.isEmbedding_structureMap.continuous)
+    letI : ProperSpace v.Completion := ProperSpace.of_locallyCompactSpace v.Completion
+    exact isCompact_iff_isClosed_bounded.2 <| ⟨isClosed_closedBall, isBounded_closedBall⟩
+  have h_W_image : f '' W = Set.univ := by
+    simp only [f, Set.eq_univ_iff_forall]
+    intro x
+    let a := Quotient.out x
+    rw [Set.mem_image]
+    #check a.2
+    /- choose xf yf hf using FiniteAdeleRing.sub_mem_finiteIntegralAdeles ℚ a.2
+    choose xi hi using InfiniteAdeleRing.sub_mem_closedBalls (a.1 - algebraMap _ _ xf)
+    let c := algebraMap ℚ (AdeleRing ℚ) <| xi + xf
+    let b := a - c
+    have hb : b ∈ W := by
+      simp only [W, Set.prod, W_inf, W_fin]
+      refine ⟨Set.mem_univ_pi.2 fun v => ?_, ?_⟩
+      · simp only [b, map_add, mem_closedBall, dist_zero_right, c,
+          add_comm, Prod.fst_sub, Prod.fst_add, ← sub_sub]
+        exact hi v
+      · simp only [Set.image_univ, Set.mem_range, Eq.comm,
+          FiniteAdeleRing.exists_finiteIntegralAdele_iff]
+        intro v
+        simp only [b, c, map_add, add_comm, ← sub_sub]
+        exact (v.adicCompletionIntegers _).sub_mem
+          ((FiniteAdeleRing.exists_finiteIntegralAdele_iff _).1 ⟨_, hf⟩ v)
+            (v.coe_mem_adicCompletionIntegers _)
+    refine ⟨b, hb, ?_⟩
+    rw [← QuotientAddGroup.out_eq' x, QuotientAddGroup.mk'_apply, QuotientAddGroup.eq_iff_sub_mem]
+    simp only [b, sub_sub_cancel_left, neg_mem_iff, principalSubgroup, AddSubgroup.mem_mk,
+      Subsemiring.coe_carrier_toSubmonoid, Subring.coe_toSubsemiring, RingHom.coe_range,
+      Set.mem_range, exists_apply_eq_apply] -/
+    sorry
+  exact { isCompact_univ := h_W_image ▸ IsCompact.image h_W_compact continuous_quot_mk }
 
 variable (K L : Type*) [Field K] [Field L] [NumberField K] [NumberField L] [Algebra K L]
 

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -461,22 +461,16 @@ theorem Rat.AdeleRing.cocompact :
     have hb : b ∈ W := by
       simp only [W, Set.prod, W_inf, FiniteAdeleRing.finiteIntegralAdeles]
       refine ⟨Set.mem_univ_pi.2 fun v => ?_, ?_⟩
-      · simp only [b, map_add, mem_closedBall, dist_zero_right, c, add_comm, ← sub_sub]
-        exact hi v
+      · simpa [b, c, add_comm, ← sub_sub] using hi v
       · apply RestrictedProduct.exists_structureMap_eq_of_forall
         simp only [map_add, SetLike.mem_coe, b, c]
         rw [Prod.snd_sub, Prod.snd_add, sub_add_eq_sub_sub, sub_right_comm]
         intro v
         refine sub_mem (hf v) ?_
-        simp only [AdeleRing.algebraMap_snd_apply]
-        exact HeightOneSpectrum.coe_algebraMap_mem (𝓞 ℚ) ℚ v xi
+        simpa using HeightOneSpectrum.coe_algebraMap_mem (𝓞 ℚ) ℚ v xi
     refine ⟨b, hb, ?_⟩
     unfold b; unfold a
-    simp only [QuotientAddGroup.mk'_apply, QuotientAddGroup.mk_sub, Quotient.out_eq, sub_eq_self,
-      QuotientAddGroup.eq_zero_iff, AddSubgroup.mem_mk, Subsemiring.coe_carrier_toSubmonoid,
-      Subring.coe_toSubsemiring, RingHom.coe_range, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk,
-      Set.mem_range]
-    use xi + xf
+    simp [c]
   { isCompact_univ := h_W_image ▸ IsCompact.image h_W_compact continuous_quot_mk }
 
 variable (K L : Type*) [Field K] [Field L] [NumberField K] [NumberField L] [Algebra K L]

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -13,6 +13,7 @@ import Mathlib.NumberTheory.NumberField.AdeleRing
 import Mathlib.NumberTheory.NumberField.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Prod
 import Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing
+import Mathlib.RingTheory.Ideal.NatInt
 import FLT.NumberField.FiniteAdeleRing
 
 open scoped TensorProduct
@@ -385,15 +386,15 @@ section Compact
 
 open NumberField
 
-variable (K : Type*) [Field K] [NumberField K]
-
 open IsDedekindDomain in
-theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 K) K) :
-  ∃ x : K,
-    ∀ v, (a - algebraMap K (FiniteAdeleRing (𝓞 K) K) x) v
-    ∈ HeightOneSpectrum.adicCompletionIntegers K v := by
-  let S := {v | a v ∉ HeightOneSpectrum.adicCompletionIntegers K v}
+theorem FiniteAdeleRing.sub_mem_finiteIntegralAdeles (a : FiniteAdeleRing (𝓞 ℚ) ℚ) :
+  ∃ x : ℚ,
+    ∀ v, (a - algebraMap ℚ (FiniteAdeleRing (𝓞 ℚ) ℚ) x) v
+    ∈ HeightOneSpectrum.adicCompletionIntegers ℚ v := by
+  let S := {v | a v ∉ HeightOneSpectrum.adicCompletionIntegers ℚ v}
   have h_S_finite : S.Finite := Filter.eventually_cofinite.mp a.eventually
+  let π (v : HeightOneSpectrum (𝓞 ℚ)) : ℚ :=
+    (HeightOneSpectrum.valuation_exists_uniformizer ℚ v).choose
 
   sorry
 
@@ -418,14 +419,14 @@ theorem Rat.AdeleRing.cocompact :
       apply isCompact_range; exact RestrictedProduct.isEmbedding_structureMap.continuous)
     letI : ProperSpace v.Completion := ProperSpace.of_locallyCompactSpace v.Completion
     exact isCompact_iff_isClosed_bounded.2 <| ⟨isClosed_closedBall, isBounded_closedBall⟩
-  let f : AdeleRing (𝓞 ℚ) ℚ → AdeleRing (𝓞 ℚ) ℚ ⧸ AdeleRing.principalSubgroup (𝓞 ℚ) ℚ :=
+  let q : AdeleRing (𝓞 ℚ) ℚ → AdeleRing (𝓞 ℚ) ℚ ⧸ AdeleRing.principalSubgroup (𝓞 ℚ) ℚ :=
     QuotientAddGroup.mk' _
-  have h_W_image : f '' W = Set.univ := by
-    simp only [f, Set.eq_univ_iff_forall]
+  have h_W_image : q '' W = Set.univ := by
+    simp only [q, Set.eq_univ_iff_forall]
     intro x
     let a := Quotient.out x
     rw [Set.mem_image]
-    choose xf hf using FiniteAdeleRing.sub_mem_finiteIntegralAdeles ℚ a.2
+    choose xf hf using FiniteAdeleRing.sub_mem_finiteIntegralAdeles a.2
     choose xi hi using InfiniteAdeleRing.sub_mem_closedBalls (a.1 - algebraMap _ _ xf)
     let c := algebraMap ℚ (AdeleRing (𝓞 ℚ) ℚ) <| xi + xf
     let b := a - c


### PR DESCRIPTION
Cocompactness of principal adeles, modulo two (groups of) sorries:

- the first sorry concerns the finite adeles of Q, where I propose that we might want to relate the `FiniteAdeleRing ℚ` API to the `QHat` API developed in chapter 5 of the blueprint;
- the second sorry concerns the infinite adeles of Q, which has already been filled in by @smmercuri [here](https://github.com/smmercuri/adele-ring_locally-compact/blob/55396f8e8de5c45780a615ee1684f510b02b4e1f/AdeleRingLocallyCompact/NumberTheory/NumberField/AdeleRing.lean#L228), but is pending my familiarization with the infinite place API. 

Co-authored-by: Salvatore Mercuri @smmercuri 