### PR TITLE
feat: commutativity of Hecke operators at bad primes modulo two sorries

### DIFF
--- a/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Abstract.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Abstract.lean
@@ -123,7 +123,7 @@ open MulAction
 
 -- finiteness hypothesis we need to make Hecke operators work: UgV is
 -- a finite number of left V-cosets.
-variable (h : (QuotientGroup.mk '' (U * g • V) : Set (G ⧸ V)).Finite)
+variable (h : (QuotientGroup.mk '' (U * {g}) : Set (G ⧸ V)).Finite)
 
 open ConjAct
 
@@ -147,7 +147,7 @@ lemma eq_finsum_quotient_out_of_bijOn' (a : fixedPoints V A)
 
 /-- The Hecke operator T_g = [UgV] : A^V → A^U associated to the double coset UgV. -/
 noncomputable def HeckeOperator_toFun (a : fixedPoints V A) : fixedPoints U A :=
-  ⟨∑ᶠ gᵢ ∈ Quotient.out '' (QuotientGroup.mk '' (U * g • V) : Set (G ⧸ V)), gᵢ • a.1, by
+  ⟨∑ᶠ gᵢ ∈ Quotient.out '' (QuotientGroup.mk '' (U * {g}) : Set (G ⧸ V)), gᵢ • a.1, by
   rintro ⟨u, huU⟩
   rw [smul_finsum_mem (h.image Quotient.out), ← eq_finsum_quotient_out_of_bijOn' a]
   · rw [finsum_mem_eq_of_bijOn (fun g ↦ u • g)]
@@ -173,7 +173,9 @@ noncomputable def HeckeOperator_addMonoidHom : fixedPoints V A →+ fixedPoints 
     simp [HeckeOperator_toFun]
   map_add' a b := by
     ext
-    simp [HeckeOperator_toFun, -Set.mem_image, finsum_mem_add_distrib (h.image Quotient.out)]
+    simp only [HeckeOperator_toFun, FixedPoints.coe_add, smul_add,
+      finsum_mem_add_distrib (h.image Quotient.out)]
+
 
 variable {R : Type*} [Ring R] [Module R A] [SMulCommClass G R A]
 
@@ -182,21 +184,24 @@ noncomputable def HeckeOperator : fixedPoints V A →ₗ[R] fixedPoints U A wher
   toFun := HeckeOperator_toFun h
   map_add' a b := by
     ext
-    simp [HeckeOperator_toFun, -Set.mem_image, finsum_mem_add_distrib (h.image Quotient.out)]
+    simp only [HeckeOperator_toFun, FixedPoints.coe_add, smul_add,
+      finsum_mem_add_distrib (h.image Quotient.out)]
   map_smul' r a := by
     ext
-    simp [-Set.mem_image, HeckeOperator_toFun, smul_comm, smul_finsum_mem (h.image Quotient.out)]
+    simp only [HeckeOperator_toFun, FixedPoints.coe_smul, smul_comm,
+      smul_finsum_mem (h.image Quotient.out)]
+    rfl
 
 lemma HeckeOperator_apply (a : fixedPoints V A) :
     (HeckeOperator (R := R) g U V h a : A) =
-    ∑ᶠ (gᵢ ∈ Quotient.out '' (QuotientGroup.mk '' (U * g • ↑V) : Set (G ⧸ V))), gᵢ • (a : A) :=
+    ∑ᶠ (gᵢ ∈ Quotient.out '' (QuotientGroup.mk '' (U * {g}) : Set (G ⧸ V))), gᵢ • (a : A) :=
   rfl
 
-theorem comm {g₁ g₂ : G} (h₁ : (QuotientGroup.mk '' (U * g₁ • U) : Set (G ⧸ U)).Finite)
-    (h₂ : (QuotientGroup.mk '' (U * g₂ • U) : Set (G ⧸ U)).Finite)
+theorem comm {g₁ g₂ : G} (h₁ : (QuotientGroup.mk '' (U * {g₁}) : Set (G ⧸ U)).Finite)
+    (h₂ : (QuotientGroup.mk '' (U * {g₂}) : Set (G ⧸ U)).Finite)
     (hcomm : ∃ s₁ s₂ : Set G,
-      Set.BijOn QuotientGroup.mk s₁ (QuotientGroup.mk '' (U * g₁ • U) : Set (G ⧸ U)) ∧
-      Set.BijOn QuotientGroup.mk s₂ (QuotientGroup.mk '' (U * g₂ • U) : Set (G ⧸ U)) ∧
+      Set.BijOn QuotientGroup.mk s₁ (QuotientGroup.mk '' (U * {g₁}) : Set (G ⧸ U)) ∧
+      Set.BijOn QuotientGroup.mk s₂ (QuotientGroup.mk '' (U * {g₂}) : Set (G ⧸ U)) ∧
       ∀ a ∈ s₁, ∀ b ∈ s₂, a * b = b * a) :
     (HeckeOperator g₁ U U h₁ ∘ₗ HeckeOperator g₂ U U h₂ : fixedPoints U A →ₗ[R] fixedPoints U A) =
     HeckeOperator g₂ U U h₂ ∘ₗ HeckeOperator g₁ U U h₁ := by

--- a/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
@@ -58,9 +58,9 @@ variable {G : Type*} [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
     {g : G} {U V : Subgroup G}
 
 open scoped Pointwise in
-lemma QuotientGroup.mk_image_finite_of_compact_of_open (hU : IsCompact (U : Set G))
-    (hV : IsCompact (V : Set G)) (hVopen : IsOpen (V : Set G)) :
-    (QuotientGroup.mk '' (U * g • V) : Set (G ⧸ V)).Finite := by
+lemma QuotientGroup.mk_image_finite_of_compact_of_open
+    (hU : IsCompact (U : Set G)) (hVopen : IsOpen (V : Set G)) :
+    (QuotientGroup.mk '' (U * {g}) : Set (G ⧸ V)).Finite := by
   have : DiscreteTopology (G ⧸ V) := by
     rw [← forall_open_iff_discrete]
     intro s
@@ -69,7 +69,7 @@ lemma QuotientGroup.mk_image_finite_of_compact_of_open (hU : IsCompact (U : Set 
     conv in ⋃ x ∈ _, _ => change ⋃ x ∈ (V : Set G), _
     rw [iUnion_mul_right_image]
     exact IsOpen.mul_left hVopen
-  exact ((hU.mul <| hV.image (by fun_prop)).image continuous_mk).finite_of_discrete
+  exact ((hU.mul <| isCompact_singleton).image continuous_mk).finite_of_discrete
 
 end finiteness
 
@@ -135,7 +135,7 @@ noncomputable def T (v : HeightOneSpectrum (𝓞 F)) :
     Units.map r.symm.toMonoidHom (Matrix.GeneralLinearGroup.diagonal
     ![FiniteAdeleRing.localUniformiserUnit F v, 1])
   AbstractHeckeOperator.HeckeOperator (R := R) g (U1 r S) (U1 r S)
-  (QuotientGroup.mk_image_finite_of_compact_of_open (U1_compact r S) (U1_compact r S) (U1_open r S))
+  (QuotientGroup.mk_image_finite_of_compact_of_open (U1_compact r S) (U1_open r S))
 
 section U
 
@@ -158,7 +158,7 @@ variable {F D} in
 /-- The double coset space `U1 diag U1` as a set of left cosets. -/
 noncomputable def U1diagU1 :
     Set ((D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ ⧸ (U1 r S)) :=
-  (QuotientGroup.mk '' ((U1 r S) * {diag r α hα}))
+  QuotientGroup.mk '' ((U1 r S) * {diag r α hα})
 
 noncomputable def local_cosets_equiv_global_cosets :
     (Local.U1diagU1 v α hα) ≃ (U1diagU1 r S α hα) :=
@@ -176,7 +176,7 @@ noncomputable def U :
     WeightTwoAutomorphicFormOfLevel (U1 r S) R →ₗ[R]
     WeightTwoAutomorphicFormOfLevel (U1 r S) R :=
   AbstractHeckeOperator.HeckeOperator (R := R) (diag r α hα) (U1 r S) (U1 r S)
-  (QuotientGroup.mk_image_finite_of_compact_of_open (U1_compact r S) (U1_compact r S) (U1_open r S))
+  (QuotientGroup.mk_image_finite_of_compact_of_open (U1_compact r S) (U1_open r S))
 
 lemma _root_.Ne.mul {M₀ : Type*} [Mul M₀] [Zero M₀] [NoZeroDivisors M₀] {a b : M₀}
   (ha : a ≠ 0) (hb : b ≠ 0) : a * b ≠ 0 := mul_ne_zero ha hb
@@ -196,7 +196,8 @@ lemma U_mul {v : HeightOneSpectrum (𝓞 F)}
   conv_lhs =>
     arg 1; ext; arg 1; ext; arg 2;
     apply AbstractHeckeOperator.HeckeOperator_apply
-  simp [← finsum_comp (Units.mapEquiv r.toMulEquiv).symm (by apply Equiv.bijective)]
+  rw [← U1diagU1]
+  -- simp [← finsum_comp (Units.mapEquiv r.toMulEquiv).symm (by apply Equiv.bijective)]
 
   sorry -- #584, long
 

--- a/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
@@ -181,6 +181,11 @@ noncomputable def U :
 lemma _root_.Ne.mul {M₀ : Type*} [Mul M₀] [Zero M₀] [NoZeroDivisors M₀] {a b : M₀}
   (ha : a ≠ 0) (hb : b ≠ 0) : a * b ≠ 0 := mul_ne_zero ha hb
 
+noncomputable instance :
+    DistribSMul (D ⊗[F] FiniteAdeleRing (𝓞 F) F)ˣ (WeightTwoAutomorphicForm F D R) :=
+  distribMulAction.toDistribSMul
+
+open AbstractHeckeOperator in
 lemma U_mul {v : HeightOneSpectrum (𝓞 F)}
     {α β : v.adicCompletionIntegers F} (hα : α ≠ 0) (hβ : β ≠ 0) :
     (U r S R α hα ∘ₗ U r S R β hβ) =
@@ -190,16 +195,22 @@ lemma U_mul {v : HeightOneSpectrum (𝓞 F)}
   simp only [U, LinearMap.coe_comp, Function.comp_apply]
   apply (Subtype.coe_inj).mp
   conv_rhs =>
-    apply AbstractHeckeOperator.HeckeOperator_apply
+    apply HeckeOperator_apply
   conv_lhs =>
-    apply AbstractHeckeOperator.HeckeOperator_apply
+    apply HeckeOperator_apply
   conv_lhs =>
     arg 1; ext; arg 1; ext; arg 2;
-    apply AbstractHeckeOperator.HeckeOperator_apply
-  rw [← U1diagU1]
-  -- simp [← finsum_comp (Units.mapEquiv r.toMulEquiv).symm (by apply Equiv.bijective)]
+    apply HeckeOperator_apply
+  conv_lhs =>
+    arg 1; ext; arg 1; ext;
+    rw [smul_finsum_mem (by
+      apply Set.Finite.image Quotient.out
+      exact (QuotientGroup.mk_image_finite_of_compact_of_open (U1_compact r S) (U1_open r S)))]
+  repeat rw [← U1diagU1]
 
-  sorry -- #584, long
+  -- repeat rw [← eq_finsum_quotient_out_of_bijOn']
+  -- simp [← finsum_comp (Units.mapEquiv r.toMulEquiv).symm (by apply Equiv.bijective)]
+  all_goals sorry -- #584, long
 
 lemma U_comm {v : HeightOneSpectrum (𝓞 F)}
     {α β : v.adicCompletionIntegers F} (hα : α ≠ 0) (hβ : β ≠ 0) :

--- a/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
@@ -147,6 +147,7 @@ open scoped Pointwise
 noncomputable instance : DecidableEq (HeightOneSpectrum (𝓞 F)) := Classical.typeDecidableEq _
 
 variable {F D} in
+/-- The (global) matrix element `diag[α, 1]`. -/
 noncomputable abbrev diag :
     (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ :=
   Units.map r.symm.toMonoidHom
@@ -158,6 +159,10 @@ variable {F D} in
 noncomputable def U1diagU1 :
     Set ((D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ ⧸ (U1 r S)) :=
   (QuotientGroup.mk '' ((U1 r S) * {diag r α hα}))
+
+noncomputable def local_cosets_equiv_global_cosets :
+    (Local.U1diagU1 v α hα) ≃ (U1diagU1 r S α hα) :=
+  sorry
 
 variable {F D} in
 set_option maxSynthPendingDepth 1 in

--- a/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
@@ -144,17 +144,14 @@ variable {v : HeightOneSpectrum (𝓞 F)} (α : v.adicCompletionIntegers F) (hα
 open scoped TensorProduct.RightActions
 open scoped Pointwise
 
+noncomputable instance : DecidableEq (HeightOneSpectrum (𝓞 F)) := Classical.typeDecidableEq _
+
 variable {F D} in
 noncomputable abbrev diag :
     (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ :=
-  letI : DecidableEq (HeightOneSpectrum (𝓞 F)) := Classical.typeDecidableEq _
-  Units.map r.symm.toMonoidHom (Matrix.GeneralLinearGroup.diagonal
-    ![FiniteAdeleRing.localUnit F ⟨(α : v.adicCompletion F),
-    (α : v.adicCompletion F)⁻¹, by
-      rw [mul_inv_cancel₀]
-      exact_mod_cast hα, by
-      rw [inv_mul_cancel₀]
-      exact_mod_cast hα⟩, 1])
+  Units.map r.symm.toMonoidHom
+    (FiniteAdeleRing.GL2.restrictedProduct.symm
+    (RestrictedProduct.mulSingle _ _ (Local.GL2.diag α hα)))
 
 variable {F D} in
 /-- The double coset space `U1 diag U1` as a set of left cosets. -/

--- a/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
@@ -139,6 +139,8 @@ noncomputable def T (v : HeightOneSpectrum (𝓞 F)) :
 
 section U
 
+variable {F D}
+
 variable {v : HeightOneSpectrum (𝓞 F)} (α : v.adicCompletionIntegers F) (hα : α ≠ 0)
 
 open scoped TensorProduct.RightActions
@@ -146,7 +148,6 @@ open scoped Pointwise
 
 noncomputable instance : DecidableEq (HeightOneSpectrum (𝓞 F)) := Classical.typeDecidableEq _
 
-variable {F D} in
 /-- The (global) matrix element `diag[α, 1]`. -/
 noncomputable abbrev diag :
     (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ :=
@@ -154,7 +155,13 @@ noncomputable abbrev diag :
     (FiniteAdeleRing.GL2.restrictedProduct.symm
     (RestrictedProduct.mulSingle _ _ (Local.GL2.diag α hα)))
 
-variable {F D} in
+/-- The (global) matrix element `(unipotent t) * (diag α hα) = !![α, t; 0, 1]`. -/
+noncomputable def unipotent_mul_diag (t : v.adicCompletionIntegers F) :
+    (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ :=
+  Units.map r.symm.toMonoidHom
+    (FiniteAdeleRing.GL2.restrictedProduct.symm
+    (RestrictedProduct.mulSingle _ _ (Local.GL2.unipotent_mul_diag α hα t)))
+
 /-- The double coset space `U1 diag U1` as a set of left cosets. -/
 noncomputable def U1diagU1 :
     Set ((D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ ⧸ (U1 r S)) :=
@@ -164,7 +171,6 @@ noncomputable def local_cosets_equiv_global_cosets :
     (Local.U1diagU1 v α hα) ≃ (U1diagU1 r S α hα) :=
   sorry
 
-variable {F D} in
 set_option maxSynthPendingDepth 1 in
 /-- The Hecke operator U_{v,α} associated to the matrix (α 0;0 1) at v,
 considered as an R-linear map from R-valued quaternionic weight 2
@@ -185,32 +191,27 @@ noncomputable instance :
     DistribSMul (D ⊗[F] FiniteAdeleRing (𝓞 F) F)ˣ (WeightTwoAutomorphicForm F D R) :=
   distribMulAction.toDistribSMul
 
+lemma U_apply (a : WeightTwoAutomorphicFormOfLevel (U1 r S) R) :
+    ((U r S R α hα) a).1 =
+    ∑ᶠ (gᵢ : (D ⊗[F] FiniteAdeleRing (𝓞 F) F)ˣ) (_ : gᵢ ∈ Quotient.out '' (U1diagU1 r S α hα)),
+      gᵢ • a.1 :=
+  rfl
+
 open AbstractHeckeOperator in
 lemma U_mul {v : HeightOneSpectrum (𝓞 F)}
     {α β : v.adicCompletionIntegers F} (hα : α ≠ 0) (hβ : β ≠ 0) :
     (U r S R α hα ∘ₗ U r S R β hβ) =
     U r S R (α * β) (hα.mul hβ) := by
-  let hγ := (hα.mul hβ)
+  -- let hγ := (hα.mul hβ)
   ext a
-  simp only [U, LinearMap.coe_comp, Function.comp_apply]
   apply (Subtype.coe_inj).mp
-  conv_rhs =>
-    apply HeckeOperator_apply
-  conv_lhs =>
-    apply HeckeOperator_apply
-  conv_lhs =>
-    arg 1; ext; arg 1; ext; arg 2;
-    apply HeckeOperator_apply
-  conv_lhs =>
-    arg 1; ext; arg 1; ext;
-    rw [smul_finsum_mem (by
+  simp only [LinearMap.coe_comp, Function.comp_apply, U_apply]
+  rw [finsum_mem_congr rfl
+    (fun _ _ => smul_finsum_mem (by
       apply Set.Finite.image Quotient.out
-      exact (QuotientGroup.mk_image_finite_of_compact_of_open (U1_compact r S) (U1_open r S)))]
-  repeat rw [← U1diagU1]
+      exact (QuotientGroup.mk_image_finite_of_compact_of_open (U1_compact r S) (U1_open r S))))]
 
-  -- repeat rw [← eq_finsum_quotient_out_of_bijOn']
-  -- simp [← finsum_comp (Units.mapEquiv r.toMulEquiv).symm (by apply Equiv.bijective)]
-  all_goals sorry -- #584, long
+  sorry -- #584, long
 
 lemma U_comm {v : HeightOneSpectrum (𝓞 F)}
     {α β : v.adicCompletionIntegers F} (hα : α ≠ 0) (hβ : β ≠ 0) :


### PR DESCRIPTION
This PR accomplishes two things:

- refactor terms of the form `(U * g • V) : Set (G ⧸ V)` to `(U * {g}) : Set (G ⧸ V)`;
- reduce the proof of the commutativity of Hecke operators at bad primes `U_mul` to two groups of (easier) sorries:
    - `bijOn_unipotent_mul_diagU1_U1diagU1`: global double coset decomposition, which should be able to be deduced from the local double coset decomposition of #660 
    - `U_mul_aux`: should be a fairly straightforward lemma, relating the sum over O_v/alpha, O_v/beta to the sum over O_v/(alpha*beta). 