### PR TITLE
chore: shake imports

### DIFF
--- a/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard
 -/
-import FLT.Mathlib.Algebra.IsQuaternionAlgebra
 import Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing
 import Mathlib.Topology.Algebra.Module.ModuleTopology
 import FLT.Mathlib.Algebra.FixedPoints.Basic
@@ -197,8 +196,6 @@ lemma _root_.ConjAct.isOpen_smul {G : Type*} [Group G] [TopologicalSpace G]
 
 open ConjAct
 
-variable [IsQuaternionAlgebra F D]
-
 open scoped TensorProduct.RightActions in
 /-- The adelic group action on the space of automorphic forms over a totally definite
 quaternion algebra. -/
@@ -224,7 +221,6 @@ def group_smul (g : (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ) (φ : WeightTwoAu
 instance : SMul (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ (WeightTwoAutomorphicForm F D R) where
   smul := group_smul
 
-omit [IsQuaternionAlgebra F D] in
 @[simp]
 lemma group_smul_apply (g : (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ)
     (φ : WeightTwoAutomorphicForm F D R) (x : (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ) :
@@ -277,8 +273,6 @@ instance module : Module R (WeightTwoAutomorphicForm F D R) where
   add_smul r s g := by ext; simp [smul_apply, add_mul]
   zero_smul g := by ext; simp [smul_apply]
 
-variable [IsQuaternionAlgebra F D]
-
 instance : SMulCommClass (D ⊗[F] (FiniteAdeleRing (𝓞 F) F))ˣ R
     (WeightTwoAutomorphicForm F D R) where
   smul_comm r g φ := by
@@ -290,8 +284,6 @@ end comm_ring
 end WeightTwoAutomorphicForm
 
 section finite_level
-
-variable [IsQuaternionAlgebra F D]
 
 /--
 `WeightTwoAutomorphicFormOfLevel U R` is the `R`-valued weight 2 automorphic forms of a fixed

--- a/FLT/AutomorphicForm/QuaternionAlgebra/FiniteDimensional.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/FiniteDimensional.lean
@@ -1,5 +1,6 @@
 import FLT.AutomorphicForm.QuaternionAlgebra.Defs
 import Mathlib.NumberTheory.NumberField.InfinitePlace.TotallyRealComplex
+import FLT.Mathlib.Algebra.IsQuaternionAlgebra
 
 namespace TotallyDefiniteQuaternionAlgebra
 

--- a/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Concrete.lean
@@ -10,6 +10,7 @@ import Mathlib.NumberTheory.NumberField.InfinitePlace.TotallyRealComplex
 import Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing
 import FLT.DedekindDomain.FiniteAdeleRing.LocalUnits -- for (π 0; 0 1)
 import FLT.Mathlib.Topology.Algebra.RestrictedProduct.TopologicalSpace
+import FLT.Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 /-
 
 # Concrete Hecke operators

--- a/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Local.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/HeckeOperators/Local.lean
@@ -3,14 +3,13 @@ Copyright (c) 2025 Bryan Wang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bryan Wang
 -/
-import FLT.AutomorphicForm.QuaternionAlgebra.HeckeOperators.Abstract -- abstract Hecke ops
-import FLT.AutomorphicForm.QuaternionAlgebra.Defs -- definitions of automorphic forms
 import FLT.QuaternionAlgebra.NumberField -- rigidifications of quat algs
-import FLT.DedekindDomain.FiniteAdeleRing.LocalUnits -- for (π 0; 0 1)
 import Mathlib.Data.Matrix.Reflection
+import Mathlib.Algebra.Lie.OfAssociative
+import Mathlib.NumberTheory.NumberField.FinitePlaces
+import FLT.Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 open NumberField IsQuaternionAlgebra.NumberField IsDedekindDomain
-open TotallyDefiniteQuaternionAlgebra
 open IsDedekindDomain.HeightOneSpectrum
 open scoped TensorProduct
 open scoped Pointwise

--- a/FLT/DedekindDomain/AdicValuation.lean
+++ b/FLT/DedekindDomain/AdicValuation.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Matthew Jasper. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Matthew Jasper
 -/
-import FLT.Mathlib.Topology.Algebra.Valued.ValuationTopology
 import FLT.Mathlib.RingTheory.Valuation.ValuationSubring
 import FLT.Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
 import Mathlib.Algebra.Order.GroupWithZero.Canonical

--- a/FLT/DedekindDomain/FiniteAdeleRing/LocalUnits.lean
+++ b/FLT/DedekindDomain/FiniteAdeleRing/LocalUnits.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard
 -/
 import Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing
-import FLT.Mathlib.Topology.Algebra.RestrictedProduct.Basic -- needed for RestrictedProduct.mk
-import FLT.Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 /-
 
 # Constructions of various "local" elements of adelic groups

--- a/FLT/DedekindDomain/IntegralClosure.lean
+++ b/FLT/DedekindDomain/IntegralClosure.lean
@@ -5,7 +5,6 @@ Authors: Kevin Buzzard, Andrew Yang, Matthew Jasper
 -/
 import FLT.Mathlib.RingTheory.Localization.BaseChange -- removing this breaks a simp proof
 import Mathlib.Algebra.Group.Int.TypeTags
-import Mathlib.Algebra.Module.FinitePresentation
 import Mathlib.NumberTheory.RamificationInertia.Basic
 import Mathlib.RingTheory.DedekindDomain.AdicValuation
 import Mathlib.RingTheory.DedekindDomain.IntegralClosure

--- a/FLT/Deformations/Lemmas.lean
+++ b/FLT/Deformations/Lemmas.lean
@@ -151,6 +151,9 @@ instance {A B : Type*} [Semiring A] [Semiring B]
   convert isLocalHom_equiv f
   exact ⟨fun ⟨H⟩ ↦ ⟨H⟩, fun ⟨H⟩ ↦ ⟨H⟩⟩
 
+instance {R S} [Semiring R] [Semiring S] (e : R ≃+* S) : IsLocalHom e.toRingHom :=
+  ⟨fun x hx ↦ by convert hx.map e.symm; simp⟩
+
 instance ContinuousAlgHom.isLocalHom_comp {R A B C : Type*}
     [CommSemiring R] [Semiring A] [Semiring B] [Semiring C]
     [Algebra R A] [Algebra R B] [Algebra R C]

--- a/FLT/Deformations/RepresentationTheory/IntegralClosure.lean
+++ b/FLT/Deformations/RepresentationTheory/IntegralClosure.lean
@@ -1,8 +1,7 @@
 import FLT.Deformations.Lemmas
 import FLT.Deformations.RepresentationTheory.ContinuousSMulDiscrete
 import Mathlib.Algebra.GCDMonoid.IntegrallyClosed
-import Mathlib.Algebra.GroupWithZero.Action.Faithful
-import Mathlib.RingTheory.Invariant.Basic
+import Mathlib.RingTheory.Invariant.Defs
 
 section
 

--- a/FLT/Mathlib/Data/Set/Prod.lean
+++ b/FLT/Mathlib/Data/Set/Prod.lean
@@ -1,4 +1,4 @@
-import Mathlib.Data.Set.Prod
+import Mathlib.Data.Set.Operations
 
 namespace Set
 

--- a/FLT/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/FLT/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -1,4 +1,5 @@
-import Mathlib.Topology.Algebra.Group.Basic
+import Mathlib.Topology.Algebra.Constructions
+import Mathlib.Topology.Algebra.Monoid.Defs
 
 open MulOpposite Set Units in
 lemma embedProduct_preimageOf (L : Type*) [Monoid L] : (range ⇑(embedProduct L)) =

--- a/FLT/Mathlib/Topology/Algebra/Group/Units.lean
+++ b/FLT/Mathlib/Topology/Algebra/Group/Units.lean
@@ -2,7 +2,6 @@ import Mathlib.Algebra.Group.Pi.Units
 import Mathlib.Algebra.Group.Submonoid.Units
 import Mathlib.Topology.Algebra.Constructions
 import Mathlib.Topology.Algebra.ContinuousMonoidHom
-import Mathlib.Topology.Algebra.Group.Basic
 
 lemma Submonoid.units_isOpen {M : Type*} [TopologicalSpace M] [Monoid M]
   {U : Submonoid M} (hU : IsOpen (U : Set M)) : IsOpen (U.units : Set Mˣ) :=

--- a/FLT/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
+++ b/FLT/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
@@ -1,11 +1,8 @@
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
-import Mathlib.RingTheory.Finiteness.Projective
 import Mathlib.Topology.Algebra.Module.ModuleTopology
 import Mathlib.Topology.Algebra.Algebra.Equiv
-import Mathlib.Topology.Algebra.Algebra.Equiv
-import FLT.Mathlib.Algebra.Module.LinearMap.Defs
 import FLT.Mathlib.Algebra.Algebra.Tower
 import FLT.Deformations.ContinuousRepresentation.IsTopologicalModule
 

--- a/FLT/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/FLT/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -1,8 +1,7 @@
 import Mathlib.Topology.Algebra.RestrictedProduct.Basic
-import Mathlib.Topology.Algebra.ContinuousMonoidHom
-import Mathlib.Topology.Instances.Matrix
-import FLT.Mathlib.Topology.Algebra.Group.Units
-import FLT.Mathlib.Topology.Algebra.Constructions
+import Mathlib.LinearAlgebra.DFinsupp
+import Mathlib.LinearAlgebra.Matrix.Defs
+import Mathlib.Algebra.Group.Submonoid.Units
 
 namespace RestrictedProduct
 

--- a/FLT/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
+++ b/FLT/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
@@ -1,6 +1,9 @@
 import FLT.Mathlib.Topology.Algebra.RestrictedProduct.Basic
 import Mathlib.Topology.Algebra.RestrictedProduct.TopologicalSpace
 import FLT.Mathlib.Topology.Algebra.ContinuousMonoidHom
+import Mathlib.Topology.Instances.Matrix
+import FLT.Mathlib.Topology.Algebra.Constructions
+import FLT.Mathlib.Topology.Algebra.Group.Units
 
 open RestrictedProduct
 

--- a/FLT/Mathlib/Topology/Algebra/Valued/WithZeroMulInt.lean
+++ b/FLT/Mathlib/Topology/Algebra/Valued/WithZeroMulInt.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Salvatore Mercuri
 -/
 import FLT.Mathlib.RingTheory.Ideal.Quotient.Basic
-import FLT.Mathlib.Topology.Algebra.Valued.ValuationTopology
 import Mathlib.Algebra.Order.GroupWithZero.Canonical
 import Mathlib.RingTheory.DiscreteValuationRing.Basic
 import Mathlib.RingTheory.Ideal.IsPrincipalPowQuotient

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -14,7 +14,6 @@ import FLT.Mathlib.NumberTheory.NumberField.Basic
 import Mathlib.NumberTheory.NumberField.AdeleRing
 import Mathlib.LinearAlgebra.TensorProduct.Prod
 import Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing
-import Mathlib.RingTheory.Ideal.NatInt
 import FLT.NumberField.FiniteAdeleRing
 
 open scoped TensorProduct

--- a/FLT/NumberField/FiniteAdeleRing.lean
+++ b/FLT/NumberField/FiniteAdeleRing.lean
@@ -3,8 +3,8 @@ Copyright (c) 2025 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard
 -/
-import Mathlib.NumberTheory.NumberField.AdeleRing
 import FLT.NumberField.Completion.Finite
+import Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing
 /-
 
 # The finite adele ring of a number field is locally compact.

--- a/FLT/Patching/Algebra.lean
+++ b/FLT/Patching/Algebra.lean
@@ -348,9 +348,6 @@ lemma PatchingAlgebra.map_id :
   refine Subtype.ext (funext fun α ↦ ?_)
   simp [← hy, UltraProduct.mapRingHom_π]
 
-instance {R S} [Semiring R] [Semiring S] (e : R ≃+* S) : IsLocalHom e.toRingHom :=
-  ⟨fun x hx ↦ by convert hx.map e.symm; simp⟩
-
 @[simps! apply symm_apply]
 def PatchingAlgebra.mapEquiv (f : ∀ i, R i ≃+* R' i) :
     PatchingAlgebra R F ≃+* PatchingAlgebra R' F where

--- a/FLT/Patching/System.lean
+++ b/FLT/Patching/System.lean
@@ -2,6 +2,7 @@ import FLT.Patching.Algebra
 import FLT.Patching.Over
 import FLT.Patching.Module
 import FLT.Patching.Utils.Depth
+import FLT.Deformations.Lemmas
 
 variable (Λ : Type*) [CommRing Λ]
 variable {ι : Type*} (R : ι → Type*)

--- a/FLT/Patching/Utils/Lemmas.lean
+++ b/FLT/Patching/Utils/Lemmas.lean
@@ -4,9 +4,10 @@ import Mathlib.Topology.Algebra.Module.ModuleTopology
 import Mathlib.Topology.Algebra.OpenSubgroup
 import Mathlib.Topology.Algebra.Ring.Ideal
 import Mathlib.Topology.Separation.Profinite
-import Mathlib.RingTheory.Artinian.Module
 import Mathlib.Data.Set.Card
 import Mathlib.RingTheory.Localization.AtPrime.Basic
+import Mathlib.Data.SetLike.Fintype
+import Mathlib.RingTheory.Spectrum.Prime.Basic
 
 
 lemma IsUnit.pi_iff {ι} {M : ι → Type*} [∀ i, Monoid (M i)] {x : Π i, M i} :


### PR DESCRIPTION
I'm not sure if any of these are intended to stay in the expectation that they'll be used to prove `sorry`s.

I moved the `IsLocalHom e.toRingHom` instance to prevent Lean from generating the same name for two of these similar instances.