### PR TITLE
add CI step to clear out some disk space before building docs

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -56,6 +56,21 @@ jobs:
     runs-on: ubuntu-latest
     name: Build project
     steps:
+      - name: Cleanup to free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: false
+          haskell: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
       - name: Checkout project
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:


### PR DESCRIPTION
Copies @pitmonticone's https://github.com/teorth/equational_theories/commit/b36cfb4f61995ee54a2892a2cfb8a4b11ef7a54b in an attempt to avoid failures like [this one](https://github.com/ImperialCollegeLondon/FLT/actions/runs/19747224681/job/56665186563).