### PR TITLE
feat: remove sorries K_v = Q_p which are now resolved in mathlib

### DIFF
--- a/FLT/HaarMeasure/HaarChar/AdeleRing.lean
+++ b/FLT/HaarMeasure/HaarChar/AdeleRing.lean
@@ -63,7 +63,8 @@ lemma MeasureTheory.ringHaarChar_adeles_rat (x : (𝔸 ℚ)ˣ) :
 
 -- depends on `IsDedekindDomain.HeightOneSpectrum.padicEquiv`, from pending mathlib PR #30576
 lemma padicEquiv_norm_eq (v : IsDedekindDomain.HeightOneSpectrum (𝓞 ℚ)) (x : v.adicCompletion ℚ) :
-  ‖v.padicEquiv x‖ = ‖x‖ := sorry
+    ‖(Rat.HeightOneSpectrum.adicCompletion.padicEquiv v) x‖ = ‖x‖ := by
+  sorry
 
 lemma MeasureTheory.ringHaarChar_adeles_units_rat_eq_one (x : ℚˣ) :
   ringHaarChar (Units.map (algebraMap ℚ (𝔸 ℚ)) x : (𝔸 ℚ)ˣ) = 1 := by
@@ -90,7 +91,7 @@ lemma MeasureTheory.ringHaarChar_adeles_units_rat_eq_one (x : ℚˣ) :
     let : Algebra ℤ (p.adicCompletion ℚ) := Ring.toIntAlgebra _
     simp [FinitePlace.equivHeightOneSpectrum,
       ringHaarChar_eq_ringHaarChar_of_continuousAlgEquiv {
-        __ := p.padicEquiv
+        __ := (Rat.HeightOneSpectrum.adicCompletion.padicEquiv p)
         commutes' := by simp},
       padicEquiv_norm_eq]
     rfl

--- a/FLT/NumberField/AdeleRing.lean
+++ b/FLT/NumberField/AdeleRing.lean
@@ -458,18 +458,24 @@ namespace Rat.FiniteAdeleRing
 
 local instance {p : Nat.Primes} : Fact p.1.Prime := ⟨p.2⟩
 
+-- TODO : this declaration `Rat.FiniteAdeleRing.padicEquiv` seems to take a huge amount
+-- of time for the kernel to accept.
 /-- The `ℚ`-algebra equivalence between `FiniteAdeleRing (𝓞 ℚ) ℚ` and the restricted
 product `Πʳ (p : Nat.Primes), [ℚ_[p], subring p]` of `Padic`s lifting the equivalence
 `v.adicCompletion ℚ ≃ₐ[ℚ] ℚ_[v.natGenerator]` at each place. -/
 noncomputable
 def padicEquiv : FiniteAdeleRing (𝓞 ℚ) ℚ ≃ₐ[ℚ] Πʳ (p : Nat.Primes), [ℚ_[p], subring p] where
   __ := RingEquiv.restrictedProductCongr
-      ratEquiv (Function.Injective.comap_cofinite_eq ratEquiv.injective).symm
-      (fun v ↦ v.padicEquiv.toRingEquiv) (Filter.Eventually.of_forall padicEquiv_bijOn)
+      Rat.HeightOneSpectrum.primesEquiv
+      (Function.Injective.comap_cofinite_eq Rat.HeightOneSpectrum.primesEquiv.injective).symm
+      (fun v ↦ (Rat.HeightOneSpectrum.adicCompletion.padicEquiv v).toRingEquiv)
+      (Filter.Eventually.of_forall Rat.HeightOneSpectrum.adicCompletion.padicEquiv_bijOn)
   commutes' q := by
     ext p
-    obtain ⟨v, rfl⟩ := ratEquiv.surjective p
-    change _ = algebraMap ℚ ℚ_[v.natGenerator] q
+    obtain ⟨v, rfl⟩ := Rat.HeightOneSpectrum.primesEquiv (R := 𝓞 ℚ).surjective p
+    have : Fact (Nat.Prime (HeightOneSpectrum.natGenerator v)) :=
+      ⟨Rat.HeightOneSpectrum.prime_natGenerator v⟩
+    change _ = algebraMap ℚ ℚ_[Rat.HeightOneSpectrum.natGenerator v] q
     -- was `simp` when `FiniteAdeleRing` was an `abbrev`.
     -- Ask on Zulip?
     simp [IsDedekindDomain.algebraMap_apply (𝓞 ℚ)]
@@ -477,10 +483,12 @@ def padicEquiv : FiniteAdeleRing (𝓞 ℚ) ℚ ≃ₐ[ℚ] Πʳ (p : Nat.Primes
 theorem padicEquiv_bijOn :
     Set.BijOn padicEquiv (integralAdeles (𝓞 ℚ) ℚ)
       (structureSubring (fun p : Nat.Primes ↦ ℚ_[p]) (fun p ↦ subring p) Filter.cofinite) := by
-  exact RingEquiv.restrictedProductCongr_bijOn_structureSubring
+  apply RingEquiv.restrictedProductCongr_bijOn_structureSubring
     (A₂ := fun p : Nat.Primes ↦ subring p)
-    ratEquiv (Function.Injective.comap_cofinite_eq ratEquiv.injective).symm
-    (fun v ↦ v.padicEquiv.toRingEquiv) (fun v ↦ v.padicEquiv_bijOn)
+    (Rat.HeightOneSpectrum.primesEquiv (R := 𝓞 ℚ))
+    (Function.Injective.comap_cofinite_eq Rat.HeightOneSpectrum.primesEquiv.injective).symm
+  intro v
+  apply (Rat.HeightOneSpectrum.adicCompletion.padicEquiv_bijOn v)
 
 open FiniteAdeleRing in
 theorem sub_mem_integralAdeles

--- a/FLT/NumberField/Completion/Finite.lean
+++ b/FLT/NumberField/Completion/Finite.lean
@@ -11,6 +11,7 @@ import Mathlib.NumberTheory.NumberField.FinitePlaces
 import Mathlib.NumberTheory.Padics.ProperSpace
 import Mathlib.Topology.MetricSpace.Polish
 import FLT.Mathlib.RingTheory.DedekindDomain.AdicValuation
+import Mathlib.NumberTheory.Padics.HeightOneSpectrum
 
 /-!
 
@@ -50,7 +51,8 @@ lemma NumberField.isOpenAdicCompletionIntegers :
 
 instance Rat.adicCompletion.locallyCompactSpace (v : HeightOneSpectrum (𝓞 ℚ)) :
     LocallyCompactSpace (v.adicCompletion ℚ) :=
-  v.padicUniformEquiv.toHomeomorph.isClosedEmbedding.locallyCompactSpace
+  (Rat.HeightOneSpectrum.adicCompletion.padicEquiv v).toHomeomorph.isClosedEmbedding
+  |>.locallyCompactSpace
 
 -- does this exist upstream? Should do.
 example (v : HeightOneSpectrum (𝓞 K)) : SecondCountableTopology (v.adicCompletion K) :=

--- a/FLT/NumberField/HeightOneSpectrum.lean
+++ b/FLT/NumberField/HeightOneSpectrum.lean
@@ -1,6 +1,7 @@
 import FLT.DedekindDomain.IntegralClosure
 import FLT.Mathlib.Data.Set.Countable
 import FLT.NumberField.Padics.RestrictedProduct
+import Mathlib.NumberTheory.Padics.HeightOneSpectrum
 
 -- should be upstreamed but I'll need to extract
 variable (K : Type*) [Field K] [NumberField K]
@@ -8,7 +9,7 @@ variable (K : Type*) [Field K] [NumberField K]
 open IsDedekindDomain NumberField HeightOneSpectrum
 
 instance : Countable (HeightOneSpectrum (𝓞 ℚ)) := Countable.of_equiv _
-  IsDedekindDomain.HeightOneSpectrum.ratEquiv.symm
+  Rat.HeightOneSpectrum.primesEquiv.symm
 
 instance : Countable (HeightOneSpectrum (𝓞 K)) :=
   Countable.of_countable_fibres <| fun y ↦

--- a/FLT/NumberField/Padics/RestrictedProduct.lean
+++ b/FLT/NumberField/Padics/RestrictedProduct.lean
@@ -6,61 +6,6 @@ import Mathlib.Topology.Algebra.Algebra.Equiv
 
 open IsDedekindDomain NumberField PadicInt RestrictedProduct
 
-namespace IsDedekindDomain.HeightOneSpectrum
-
--- From pending mathlib PR #30576
-/-- A generator in `ℕ` of a prime ideal of `𝓞 ℚ`. -/
-noncomputable def natGenerator (v : HeightOneSpectrum (𝓞 ℚ)) : ℕ :=
-  Submodule.IsPrincipal.generator (v.asIdeal.map Rat.ringOfIntegersEquiv) |>.natAbs
-
--- From pending mathlib PR #30576
-instance (v : HeightOneSpectrum (𝓞 ℚ)) : Fact v.natGenerator.Prime :=
-  ⟨Int.prime_iff_natAbs_prime.1 <|
-    Submodule.IsPrincipal.prime_generator_of_isPrime _
-      ((Ideal.map_eq_bot_iff_of_injective Rat.ringOfIntegersEquiv.injective).not.2 v.ne_bot)⟩
-
--- From pending mathlib PR #30576
-/-- The continuous `ℚ`-algebra equivalence between `v.adicCompletion ℚ` and `ℚ_[v.natGenerator]`,
-where `v : HeightOneSpectrum (𝓞 ℚ)`. -/
-def padicEquiv (v : HeightOneSpectrum (𝓞 ℚ)) :
-    v.adicCompletion ℚ ≃A[ℚ] ℚ_[v.natGenerator] := sorry
-
--- From pending mathlib PR #30576
-/-- The uniform-space isomorphism between `v.adicCompletion ℚ` and `ℚ_[v.natGenerator]`, where
-`v : HeightOneSpectrum (𝓞 ℚ)`. -/
-def padicUniformEquiv (v : HeightOneSpectrum (𝓞 ℚ)) :
-    v.adicCompletion ℚ ≃ᵤ ℚ_[v.natGenerator] := sorry
-
--- From pending mathlib PR #30576
-theorem padicEquiv_bijOn (v : HeightOneSpectrum (𝓞 ℚ)) :
-    Set.BijOn (IsDedekindDomain.HeightOneSpectrum.padicEquiv v) (v.adicCompletionIntegers ℚ)
-      (PadicInt.subring v.natGenerator) := by
-  sorry
-
-/-- The prime ideal of `𝓞 ℚ` constructed from a prime in `ℕ`. -/
-def ofNatPrime {p : ℕ} (hp : p.Prime) : HeightOneSpectrum (𝓞 ℚ) where
-  asIdeal := Ideal.span {Rat.ringOfIntegersEquiv.symm p}
-  isPrime := by
-    have : (Ideal.span {(p : ℤ)}).IsPrime :=
-      (Ideal.span_singleton_prime (by simp [hp.ne_zero])).2 (Nat.prime_iff_prime_int.1 hp)
-    have := Ideal.map_isPrime_of_equiv (I := Ideal.span {(p : ℤ)}) Rat.ringOfIntegersEquiv.symm
-    simpa [Ideal.map_span] using this
-  ne_bot := by simp [hp.ne_zero]
-
-/-- The equivalence between prime ideals of `𝓞 ℚ` and primes in `ℕ`. -/
-noncomputable def ratEquiv :
-    HeightOneSpectrum (𝓞 ℚ) ≃ Nat.Primes where
-  toFun v := ⟨v.natGenerator, Fact.out⟩
-  invFun p := ofNatPrime p.2
-  left_inv v := by
-    simp only [ofNatPrime, natGenerator, ← Set.image_singleton, ← Ideal.map_span]
-    ext; simp
-  right_inv p := by
-    simp [ofNatPrime, natGenerator, Ideal.map_span, Set.image_singleton, map_natCast,
-      Int.associated_iff_natAbs.1 (Submodule.IsPrincipal.associated_generator_span_self (p : ℤ))]
-
-end IsDedekindDomain.HeightOneSpectrum
-
 namespace Padic
 
 local instance {p : Nat.Primes} : Fact p.1.Prime := ⟨p.2⟩


### PR DESCRIPTION
Mathlib PR [#30576](https://github.com/leanprover-community/mathlib4/pull/30576) by Salvatore Mercuri resolves these sorries.

Still currently unresolved is another sorry in `FLT/HaarMeasure/HaarChar/AdeleRing.lean`: 
```lean4
lemma padicEquiv_norm_eq (v : IsDedekindDomain.HeightOneSpectrum (𝓞 ℚ)) (x : v.adicCompletion ℚ) :
    ‖(Rat.HeightOneSpectrum.adicCompletion.padicEquiv v) x‖ = ‖x‖ := by
  sorry
```
This would follow from the function underlying `Rat.HeightOneSpectrum.adicCompletion.padicEquiv` being
an isometry. Note that in the infinite case this is exactly what they do:
```lean4
/-- The ring isomorphism `v.Completion ≃+* ℝ`, when `v` is real, given by the bijection
`v.Completion →+* ℝ`. -/
def ringEquivRealOfIsReal {v : InfinitePlace K} (hv : IsReal v) : v.Completion ≃+* ℝ :=
  RingEquiv.ofBijective _ (bijective_extensionEmbeddingOfIsReal hv)

/-- If the infinite place `v` is real, then `v.Completion` is isometric to `ℝ`. -/
def isometryEquivRealOfIsReal {v : InfinitePlace K} (hv : IsReal v) : v.Completion ≃ᵢ ℝ where
  toEquiv := ringEquivRealOfIsReal hv
  isometry_toFun := isometry_extensionEmbeddingOfIsReal hv
```