### PR TITLE
chore: remove upstreamed haarScalarFactorMap

### DIFF
--- a/FLT/HaarMeasure/HaarChar/AddEquiv.lean
+++ b/FLT/HaarMeasure/HaarChar/AddEquiv.lean
@@ -22,24 +22,6 @@ variable {G : Type*} [Group G] [TopologicalSpace G] [MeasurableSpace G]
 
 variable [BorelSpace G] [IsTopologicalGroup G] [LocallyCompactSpace G]
 
--- should be in haarScalarFactor API
-@[to_additive]
-lemma haarScalarFactor_map (μ' μ : Measure G) [IsHaarMeasure μ] [IsHaarMeasure μ'] (φ : G ≃ₜ* G) :
-    (map φ μ').haarScalarFactor (map φ μ) = μ'.haarScalarFactor μ := by
-  obtain ⟨⟨f, f_cont⟩, f_comp, f_nonneg, f_one⟩ :
-    ∃ f : C(G, ℝ), HasCompactSupport f ∧ 0 ≤ f ∧ f 1 ≠ 0 := exists_continuous_nonneg_pos 1
-  have int_f_ne_zero : ∫ (x : G), f x ∂(map φ μ) ≠ 0 :=
-    ne_of_gt (f_cont.integral_pos_of_hasCompactSupport_nonneg_nonzero f_comp f_nonneg f_one)
-  have hφ : AEMeasurable φ μ := φ.continuous.aemeasurable
-  rw [← NNReal.coe_inj, haarScalarFactor_eq_integral_div _ _ f_cont f_comp int_f_ne_zero,
-    haarScalarFactor_eq_integral_div μ' μ (f_cont.comp φ.continuous),
-    integral_map hφ f_cont.aestronglyMeasurable, integral_map ?_ f_cont.aestronglyMeasurable]
-  · rfl
-  · exact φ.continuous.aemeasurable
-  · exact f_comp.comp_homeomorph φ.toHomeomorph
-  · change ∫ x, f (φ x) ∂μ ≠ 0
-    rwa [← integral_map hφ f_cont.aestronglyMeasurable]
-
 -- Version of `mulEquivHaarChar_smul_map` without the regularity assumption
 -- In this case, the measures need only be equal on open sets
 @[to_additive]


### PR DESCRIPTION
`MeasureTheorey.haarScalarFactor_map` was upstreamed as [`MeasureTheory.Measure.haarScalarFactor_map`](https://github.com/leanprover-community/mathlib4/blob/19c497800a418208f973be74c9f5c5901aac2f54/Mathlib/MeasureTheory/Measure/Haar/Unique.lean#L395-L411) in https://github.com/leanprover-community/mathlib4/pull/34189.

The one FLT usage of this theorem continue to work, because the name is unchanged (though the namespace is a bit different): https://github.com/ImperialCollegeLondon/FLT/blob/ad709969bbf71cfdc1b71e2850d78ece65dde05e/FLT/HaarMeasure/HaarChar/AddEquiv.lean#L51C68-L51C88