### PR TITLE
chore: remove upstreamed Countable.of_countable_fibres

### DIFF
--- a/FLT.lean
+++ b/FLT.lean
@@ -73,7 +73,6 @@ import FLT.Mathlib.Algebra.Order.AbsoluteValue.Basic
 import FLT.Mathlib.Analysis.Normed.Ring.WithAbs
 import FLT.Mathlib.Data.Fin.Basic
 import FLT.Mathlib.Data.Real.Archimedean
-import FLT.Mathlib.Data.Set.Countable
 import FLT.Mathlib.Data.Set.Prod
 import FLT.Mathlib.GroupTheory.DoubleCoset
 import FLT.Mathlib.GroupTheory.Index

--- a/FLT/Mathlib/Data/Set/Countable.lean
+++ b/FLT/Mathlib/Data/Set/Countable.lean
@@ -1,7 +1,0 @@
-import Mathlib.Data.Set.Countable
-
--- should be upstreamed
-lemma Countable.of_countable_fibres {X Y : Type*} {f : X → Y} [Countable Y]
-    (h : ∀ (y : Y), (f ⁻¹' {y}).Countable) : Countable X := by
-  simp_rw [← Set.countable_univ_iff, ← Set.preimage_univ (f := f), ← Set.iUnion_of_singleton,
-    Set.preimage_iUnion, Set.countable_iUnion ‹_›]

--- a/FLT/NumberField/HeightOneSpectrum.lean
+++ b/FLT/NumberField/HeightOneSpectrum.lean
@@ -1,5 +1,4 @@
 import FLT.DedekindDomain.IntegralClosure
-import FLT.Mathlib.Data.Set.Countable
 import FLT.NumberField.Padics.RestrictedProduct
 import Mathlib.NumberTheory.Padics.HeightOneSpectrum
 
@@ -12,5 +11,5 @@ instance : Countable (HeightOneSpectrum (𝓞 ℚ)) := Countable.of_equiv _
   Rat.HeightOneSpectrum.primesEquiv.symm
 
 instance : Countable (HeightOneSpectrum (𝓞 K)) :=
-  Countable.of_countable_fibres <| fun y ↦
+  Set.Countable.of_preimage_singleton <| fun y ↦
   ((preimage_comap_finite (𝓞 ℚ) ℚ K (𝓞 K)) {y} (by simp)).countable


### PR DESCRIPTION
`Countable.of_countable_fibres` was upstreamed as
[`Set.Countable.of_preimage_singleton`](https://github.com/leanprover-community/mathlib4/blob/18a09f90937aa1f3ffe6b80159ca7fa3bf15f981/Mathlib/Data/Set/Countable.lean#L284-L286) in https://github.com/leanprover-community/mathlib4/pull/32975.
