### PR TITLE
chore: remove upstreamed IsLocalRing.map_maximalIdeal

### DIFF
--- a/FLT/Deformations/IsProartinian.lean
+++ b/FLT/Deformations/IsProartinian.lean
@@ -54,7 +54,7 @@ lemma exists_maximalIdeal_pow_le_of_isProartinian [IsProartinian R]
   have : IsLocalRing (R ⧸ I) := .of_surjective' _ Ideal.Quotient.mk_surjective
   obtain ⟨n, hn⟩ := IsArtinianRing.isNilpotent_jacobson_bot (R := R ⧸ I)
   rw [jacobson_eq_maximalIdeal _ bot_ne_top,
-    ← IsLocalRing.map_maximalIdeal _ Ideal.Quotient.mk_surjective,
+    ← IsLocalRing.map_maximalIdeal_of_surjective _ Ideal.Quotient.mk_surjective,
     ← Ideal.map_pow, Ideal.zero_eq_bot, ← le_bot_iff, Ideal.map_le_iff_le_comap,
     ← RingHom.ker, Ideal.mk_ker] at hn
   exact ⟨n, hn⟩

--- a/FLT/Deformations/Lemmas.lean
+++ b/FLT/Deformations/Lemmas.lean
@@ -84,12 +84,6 @@ instance IsTopologicalGroup.discreteUniformity
   simp only [discreteUniformity_iff_setRelId_mem_uniformity]
   exact ⟨{1}, by simp [Set.subset_def, ← div_eq_mul_inv, div_eq_one]⟩
 
-lemma IsLocalRing.map_maximalIdeal {R S} [CommRing R] [CommRing S]
-    [IsLocalRing R] [IsLocalRing S] (f : R →+* S) (hf : Function.Surjective f) :
-    (maximalIdeal R).map f = maximalIdeal S := by
-  have := (IsLocalRing.local_hom_TFAE f).out 0 4
-  rw [← this.mp (by exact .of_surjective f hf), Ideal.map_comap_of_surjective f hf]
-
 lemma IsLocalRing.ResidueField.map_surjective {R S : Type*} [CommRing R] [CommRing S]
     [IsLocalRing R] [IsLocalRing S] (f : R →+* S) [IsLocalHom f] (H : Function.Surjective f) :
     Function.Surjective (IsLocalRing.ResidueField.map f) :=

--- a/FLT/Patching/System.lean
+++ b/FLT/Patching/System.lean
@@ -330,7 +330,7 @@ lemma smul_lemma₀
         { __ := (sM i).toLinearMap.comp (Submodule.mkQ _), map_smul' := fun _ _ ↦ HCompat _ _ _ }
       have hl : LinearMap.range l = ⊤ :=
         LinearMap.range_eq_top.mpr ((sM i).surjective.comp (Submodule.mkQ_surjective _))
-      rw [min_eq_right h, ← IsLocalRing.map_maximalIdeal F hF, ← Ideal.map_pow]
+      rw [min_eq_right h, ← IsLocalRing.map_maximalIdeal_of_surjective F hF, ← Ideal.map_pow]
       have : maximalIdeal (R i) ^ n₁ • ⊤ ≤ _ := PatchingAlgebra.smulData.pow_f_smul_le i α
       replace this := Submodule.map_mono (f := l) this
       rw [Submodule.map_smul'', ← Submodule.map_algebraMap_smul (R := Λ),
@@ -348,7 +348,7 @@ lemma smul_lemma₀
   refine Submodule.smul_mem_smul ?_ trivial
   rw [← Ideal.mem_comap]
   refine SetLike.le_def.mp ?_ ((Ideal.Quotient.mk_eq_mk_iff_sub_mem _ _).mp (hi₂.trans hi₁.symm))
-  rw [← Ideal.map_le_iff_le_comap, Ideal.map_pow, ← IsLocalRing.map_maximalIdeal F hF]
+  rw [← Ideal.map_le_iff_le_comap, Ideal.map_pow, ← IsLocalRing.map_maximalIdeal_of_surjective F hF]
 
 omit [NonarchimedeanRing Λ] [Module.Finite R₀ M₀] in
 lemma smul_lemma₁


### PR DESCRIPTION
`IsLocalRing.map_maximalIdeal` was upstreamed as
[`IsLocalRing.map_maximalIdeal_of_surjective`](https://github.com/leanprover-community/mathlib4/blob/18a09f90937aa1f3ffe6b80159ca7fa3bf15f981/Mathlib/RingTheory/LocalRing/RingHom/Basic.lean#L146-L149) in https://github.com/leanprover-community/mathlib4/pull/35337.