### PR TITLE
chore: bump mathlib and remove backward.proofsInPublic

### DIFF
--- a/FLT/DedekindDomain/FiniteAdeleRing/TensorPi.lean
+++ b/FLT/DedekindDomain/FiniteAdeleRing/TensorPi.lean
@@ -184,9 +184,6 @@ variable (R M : Type*) [CommRing R] [AddCommGroup M] [Module R M]
   [h : Module.FinitePresentation R M] {ι : Type*} (N : ι → Type*) [∀ i, AddCommGroup (N i)]
   [∀ i, Module R (N i)]
 
--- note that`TensorProduct.piRightHom` is marked `backward.proofsInPublic true` in mathlib
--- so I don't think there's much I can do about this `set_option` here.
-set_option backward.proofsInPublic true in
 /-- Tensoring with a finitely-presented module commutes with arbitrary products.
 To prove this, we consider the following commutative diagram. The goal is to show
 that `i₃` is an isomorphism, which we do using the five lemma:
@@ -201,7 +198,8 @@ Rᵐ ⊗[R] (Π i, N i) --f₁--> Rⁿ ⊗[R] (Π i, N i) --f₂--> M ⊗[R] (Π
 ```
 -/
 noncomputable def tensorPi_equiv_piTensor' [Module.FinitePresentation R M] :
-    M ⊗[R] (Π i, N i) ≃ₗ[R] Π i, (M ⊗[R] N i) := IsTensorProduct.equiv <| by
+    M ⊗[R] (Π i, N i) ≃ₗ[R] Π i, (M ⊗[R] N i) := IsTensorProduct.equiv
+    (f := TensorProduct.piRightHomBil R R M N) <| by
   obtain ⟨n, m, f, g, exact, surj⟩ := Module.FinitePresentation.exists_fin_exact R M
   set i₁ : (Fin m → R) ⊗[R] (Π i, N i) →ₗ[R] Π i, ((Fin m → R) ⊗[R] N i) :=
     (tensorPi_equiv_piTensor R (Fin m → R) N).toLinearMap

--- a/FLT/GlobalLanglandsConjectures/GLnDefs.lean
+++ b/FLT/GlobalLanglandsConjectures/GLnDefs.lean
@@ -164,7 +164,6 @@ def actionTensorC :
   LieHom.baseChange _ (action _ _)
 
 set_option backward.isDefEq.respectTransparency false in
-set_option backward.proofsInPublic true in
 def actionTensorCAlg :
   UniversalEnvelopingAlgebra ℂ (ℂ ⊗[ℝ] LeftInvariantDerivation 𝓘(ℝ, E) G) →ₐ[ℂ]
     ℂ ⊗[ℝ] (Module.End ℝ C^∞⟮𝓘(ℝ, E), G; 𝓘(ℝ, ℝ), ℝ⟯) := by

--- a/FLT/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/FLT/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -179,17 +179,16 @@ lemma mem_coset_and_mulSupport_subset_of_isProductAt
     simp only [smul_eq_mul, mul_assoc, mul_inv_cancel_left, hcomm]⟩,
     mulSupport_mul_subset huᵢ hg⟩
 
-set_option backward.proofsInPublic true in
 /-- For a cofinite restricted product `Πʳ i, [G i, A i]`, `indexSupport` is the finite set of
 indices for which `u ∉ A i`. -/
 noncomputable
-def indexSupport (u : Πʳ i, [G i, A i]) : Finset ι := Set.Finite.toFinset (by simpa using u.2)
+def indexSupport (u : Πʳ i, [G i, A i]) : Finset ι :=
+  Set.Finite.toFinset (s := {x | u x ∉ A x}) (by simpa using u.2)
 
 @[simp]
 theorem mem_indexSupport_iff {u : Πʳ i, [G i, A i]} {i : ι} :
     i ∈ indexSupport u ↔ u i ∉ A i := by
   simp [indexSupport]
-  rfl
 
 end supports
 

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "b80f22719410f979c475e9b1d62221ec1dd7a3c6",
+   "rev": "6cc078933b86576c169521239b2e2f36889c5eca",
    "name": "mathlib",
    "manifestFile": "lake-manifest.json",
    "inputRev": null,


### PR DESCRIPTION
After https://github.com/leanprover-community/mathlib4/pull/38385 we can remove all `set_option backward.proofsInPublic true` in FLT.