### PR TITLE
chore(ci): sequence bump-mathlib jobs so the first-known-bad PR gets a higher number than the last-known-good PR

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -55,6 +55,7 @@ jobs:
 
   open-issue:
     runs-on: ubuntu-latest
+    needs: bump # ensures the last-known-good PR is created first, so the first-known-bad PR always gets a higher number
     permissions:
       issues: write
       contents: write


### PR DESCRIPTION
We should order these by "order of arrival" so that the latest one is prioritized as the 'latest intended change'