### PR TITLE
perf: switch off docgen, hopefully

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -97,8 +97,11 @@ jobs:
           relevant-labels: FLT
           include-drafts: true
 
-      - name: Compile blueprint and documentation
-        uses: leanprover-community/docgen-action@dac784713171529c96f6d0470f7af30249a02a5d # 2026-02-08
-        with:
-          blueprint: true
-          homepage: docs
+      # On 6th May 2026 this is taking 2.5 hours to fail
+      # and I am just sick of it.
+      #
+      # - name: Compile blueprint and documentation
+      #   uses: leanprover-community/docgen-action@dac784713171529c96f6d0470f7af30249a02a5d # 2026-02-08
+      #   with:
+      #     blueprint: true
+      #     homepage: docs


### PR DESCRIPTION
Right now there's an over 50% chance that doc-gen takes over 2.5 hours and then fails at the very end. Sometimes clearing all the cache fixes this. Sometimes it doesn't. I have had enough and am disabling it for now.