### PR TITLE
ci: bump docgen-action to pick up static-asset cache fix

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -97,11 +97,8 @@ jobs:
           relevant-labels: FLT
           include-drafts: true
 
-      # On 6th May 2026 this is taking 2.5 hours to fail
-      # and I am just sick of it.
-      #
-      # - name: Compile blueprint and documentation
-      #   uses: leanprover-community/docgen-action@dac784713171529c96f6d0470f7af30249a02a5d # 2026-02-08
-      #   with:
-      #     blueprint: true
-      #     homepage: docs
+      - name: Compile blueprint and documentation
+        uses: leanprover-community/docgen-action@7b5b9a1822650bd45aaeb4182d94bceba2030f89 # 2026-04-14
+        with:
+          blueprint: true
+          homepage: docs


### PR DESCRIPTION
This PR bumps the pinned `leanprover-community/docgen-action` SHA from a 2026-02-09 commit to a 2026-04-14 commit, and re-enables the doc-generation step that was commented out in #945.

The pinned SHA predated [leanprover-community/docgen-action#29](https://github.com/leanprover-community/docgen-action/pull/29) and [#30](https://github.com/leanprover-community/docgen-action/pull/30) (both merged 2026-04-14), which added `style.css`, `favicon.svg`, and the JS bundle to the action's cache `path:`. Without those, partial cache restores left Lake believing `FLT/FLT:docs` was already up to date while the static files were absent, causing the doc renderer to die with `error: no such file or directory … /doc/style.css` on roughly 30% of merges. Several other Lean projects (lean-iwasawa, Redhill) hit the same bug and resolved it via Marcelo Lynch's fork containing the same patch; this PR uses the now-merged upstream version.

Background discussion: https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/.22no.20such.20file.20or.20directory.22.20error.20on.20latest.20docgen-action and https://leanprover.zulipchat.com/#narrow/channel/416277-FLT/topic/CI.20failing.

🤖 Prepared with Claude Code