### PR TITLE
chore: fail CI on any output

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -83,6 +83,8 @@ jobs:
           test: true
           lint: true
           mk_all-check: true
+          build-args: --iofail
+          test-args: --iofail
 
       - name: Adjusting for test copy
         if: always()

--- a/FLT/GaloisRepresentation/Automorphic.lean
+++ b/FLT/GaloisRepresentation/Automorphic.lean
@@ -180,5 +180,3 @@ theorem cyclic_base_change
     ((ρ.map (algebraMap F E)).IsAutomorphicOfLevel p hV
       (HeightOneSpectrum.preimageComapFinset (𝓞 F) F E (𝓞 E) S)) :=
   sorry
-
-#lint

--- a/FLT/GaloisRepresentation/Automorphic.lean
+++ b/FLT/GaloisRepresentation/Automorphic.lean
@@ -180,3 +180,5 @@ theorem cyclic_base_change
     ((ρ.map (algebraMap F E)).IsAutomorphicOfLevel p hV
       (HeightOneSpectrum.preimageComapFinset (𝓞 F) F E (𝓞 E) S)) :=
   sorry
+
+#lint

--- a/FermatsLastTheorem.lean
+++ b/FermatsLastTheorem.lean
@@ -27,10 +27,11 @@ theorem PNat.pow_add_pow_ne_pow
     x^n + y^n ≠ z^n :=
   PNat.pow_add_pow_ne_pow_of_FermatLastTheorem Wiles_Taylor_Wiles x y z n hn
 
-#print axioms PNat.pow_add_pow_ne_pow
-/-
-'PNat.pow_add_pow_ne_pow' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]
+/--
+info: 'PNat.pow_add_pow_ne_pow' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]
 -/
+#guard_msgs in
+#print axioms PNat.pow_add_pow_ne_pow
 
 -- The project will be complete when `sorryAx` is no longer
 -- mentioned in the output of this last command.


### PR DESCRIPTION
Fails the build in CI on any output, including warnings (e.g. if a line exceeds 100 chars) and info messages (e.g. a stray `#check` or `#lint`).

This works by passing the flag [`--iofail`](https://github.com/leanprover/lean4/blob/ad1c983a43face43c3e69b72f7db105f40ef280a/src/lake/Lake/CLI/Help.lean#L72-L73) to `lake build`, like [Mathlib](https://github.com/leanprover-community/mathlib4/blob/50622aa047ff449311db5bbdaf31784bd95a1232/.github/workflows/build_template.yml#L489) and [Cslib](https://github.com/leanprover/cslib/blob/6cc5327b2a45ea7a317f1a4951f31c345a267c75/.github/workflows/lean_action_ci.yml#L23-L24) do.

Also adds a `#guard_msgs in` to the `#print axioms` in `FermatsLastTheorem.lean`, which otherwise would fail CI.

Fixes #768, see the [failed run](https://github.com/ImperialCollegeLondon/FLT/actions/runs/26330788639/job/77516438871?pr=975) after adding a `#lint`.