### PR TITLE
fix: restore `#print axioms`

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -76,9 +76,9 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
 
-      - name: Delete print-axioms before building
+      - name: Delete `print axioms` before building
         run: |
-          sed -i '/#print axioms/d' ./FermatsLastTheorem.lean
+          sed -i '/#printaxioms/d' ./FermatsLastTheorem.lean
 
       - name: Build and lint project
         uses: leanprover/lean-action@v1

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Delete `print axioms` before building
         run: |
-          sed -i '/#printaxioms/d' ./FermatsLastTheorem.lean
+          sed -i '/#print axioms/d' ./FermatsLastTheorem.lean
 
       - name: Build and lint project
         uses: leanprover/lean-action@v1

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -76,6 +76,10 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
 
+      - name: Delete print-axioms before building
+        run: |
+          sed -i '/#print axioms/d' ./FermatsLastTheorem.lean
+
       - name: Build and lint project
         uses: leanprover/lean-action@v1
         with:

--- a/FermatsLastTheorem.lean
+++ b/FermatsLastTheorem.lean
@@ -27,11 +27,10 @@ theorem PNat.pow_add_pow_ne_pow
     x^n + y^n ≠ z^n :=
   PNat.pow_add_pow_ne_pow_of_FermatLastTheorem Wiles_Taylor_Wiles x y z n hn
 
-/--
-info: 'PNat.pow_add_pow_ne_pow' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]
--/
-#guard_msgs in
 #print axioms PNat.pow_add_pow_ne_pow
+/-
+'PNat.pow_add_pow_ne_pow' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]
+-/
 
 -- The project will be complete when `sorryAx` is no longer
 -- mentioned in the output of this last command.


### PR DESCRIPTION
Restore `#print axioms` (after #975) and instead delete the `#print axioms` line from `./FermatsLastTheorem.lean` before building in CI, so locally `lake build` will still print the axioms.