### PR TITLE
chore: placate overlapping instance linter

### DIFF
--- a/FLT/DedekindDomain/FiniteAdeleRing/TensorPi.lean
+++ b/FLT/DedekindDomain/FiniteAdeleRing/TensorPi.lean
@@ -194,7 +194,7 @@ Rᵐ ⊗[R] (Π i, N i) --f₁--> Rⁿ ⊗[R] (Π i, N i) --f₂--> M ⊗[R] (Π
 Π i, (Rᵐ ⊗[R] N i) --g₁--> Π i, (Rⁿ ⊗[R] N i) --g₂--> Π i, (M ⊗[R] N i) --g₃--> 0 --g₄--> 0
 ```
 -/
-noncomputable def tensorPi_equiv_piTensor' [Module.FinitePresentation R M] :
+noncomputable def tensorPi_equiv_piTensor' :
     M ⊗[R] (Π i, N i) ≃ₗ[R] Π i, (M ⊗[R] N i) := IsTensorProduct.equiv
     (f := TensorProduct.piRightHomBil R R M N) <| by
   obtain ⟨n, m, f, g, exact, surj⟩ := Module.FinitePresentation.exists_fin_exact R M

--- a/FLT/Deformations/RepresentationTheory/GaloisRep.lean
+++ b/FLT/Deformations/RepresentationTheory/GaloisRep.lean
@@ -199,7 +199,7 @@ noncomputable def FramedGaloisRep.equivChar {n : Type*} [Unique n] :
 
 /-- The determinant of a galois rep. -/
 noncomputable
-def GaloisRep.det [IsTopologicalRing A] (ρ : GaloisRep K A M) : Γ K →ₜ* A :=
+def GaloisRep.det (ρ : GaloisRep K A M) : Γ K →ₜ* A :=
   letI := moduleTopology A (Module.End A M)
   .comp ⟨LinearMap.det, IsModuleTopology.continuous_det⟩ ρ
 

--- a/FLT/DivisionAlgebra/Finiteness.lean
+++ b/FLT/DivisionAlgebra/Finiteness.lean
@@ -330,8 +330,7 @@ instance : Module (AdeleRing (𝓞 K) K) (Dinf K D × Df K D) where
   zero_smul mn := by cases mn; ext <;> exact zero_smul _ _
 
 /-- (Dinf K D × Df K D) has the 𝔸_K module topology. -/
-instance [FiniteDimensional K D] :
-    IsModuleTopology (AdeleRing (𝓞 K) K) (Dinf K D × Df K D) :=
+instance : IsModuleTopology (AdeleRing (𝓞 K) K) (Dinf K D × Df K D) :=
   IsModuleTopology.instProd'
 
 /-- The 𝔸_K linear map `D_𝔸 ≃ D_∞ × D_f`. -/

--- a/FLT/Mathlib/Topology/Algebra/RestrictedProduct/Module.lean
+++ b/FLT/Mathlib/Topology/Algebra/RestrictedProduct/Module.lean
@@ -148,7 +148,7 @@ instance : ContinuousSMul (Πʳ i, [R i, B i]_[𝓟 T]) (Πʳ i, [M i, C i]_[�
 variable [hBopen : Fact (∀ i, IsOpen (B i : Set (R i)))]
 variable [hCopen : Fact (∀ i, IsOpen (C i : Set (M i)))]
 
-instance [∀ i, ContinuousSMul (R i) (M i)] :
+instance :
     ContinuousSMul (Πʳ i, [R i, B i]) (Πʳ i, [M i, C i]) where
   continuous_smul := by
     rw [continuous_dom_prod hBopen.elim hCopen.elim]

--- a/FLT/Patching/Module.lean
+++ b/FLT/Patching/Module.lean
@@ -165,6 +165,8 @@ lemma Module.UniformlyBoundedRank.linearMap_eq_zero :
 
 end
 
+section topological_ring
+
 variable (R : Type*) [TopologicalSpace R] [CommRing R] [IsTopologicalRing R]
 variable [CompactSpace R] {ι : Type*}
 
@@ -583,6 +585,25 @@ def PatchingModule.mapOfIsPatchingSystem :
 lemma PatchingModule.continuous_ofPi : Continuous (mapOfIsPatchingSystem R M F) :=
   LinearMap.continuous_on_pi (mapOfIsPatchingSystem R M F)
 
+end topological_ring
+
+section nonarchimedean_ring
+-- overlapping instance linter doesn't like [IsTopologicalRing R] and [NonarchimedeanRing R]
+-- at the same time, for some reason.
+
+variable (R : Type*) [TopologicalSpace R] [CommRing R]
+variable [CompactSpace R] {ι : Type*}
+
+set_option autoImplicit false
+
+open Filter
+
+variable (M : ι → Type*) [∀ i, AddCommGroup (M i)] [∀ i, Module R (M i)]
+variable (F : Ultrafilter ι)
+
+variable [∀ i, Module.Free (R ⧸ Ann R (M i)) (M i)]
+variable [Module.UniformlyBoundedRank R M] [IsPatchingSystem R M F]
+
 -- Compact + T2 actually implies NonarchimedeanRing.
 variable [NonarchimedeanRing R] [T2Space R]
 
@@ -615,7 +636,11 @@ instance : Module.Free R (PatchingModule R M F) :=
 instance : Module.Finite R (PatchingModule R M F) :=
   .of_surjective _ (PatchingModule.mapOfIsPatchingSystem_bijective R M F).surjective
 
+open Module.UniformlyBoundedRank
+
 lemma PatchingModule.rank_patchingModule [Nontrivial R] :
     Module.rank R (PatchingModule R M F) = rank R M F := by
   simpa using LinearEquiv.lift_rank_eq
     (LinearEquiv.ofBijective _ (PatchingModule.mapOfIsPatchingSystem_bijective R M F)).symm
+
+end nonarchimedean_ring

--- a/FLT/Patching/Over.lean
+++ b/FLT/Patching/Over.lean
@@ -33,7 +33,7 @@ variable (F : Ultrafilter ι)
 variable (M : ι → Type*) [∀ i, AddCommGroup (M i)] [∀ i, Module Λ (M i)]
 variable [∀ i, Module (R i) (M i)] [∀ i, IsScalarTower Λ (R i) (M i)]
 variable (F : Ultrafilter ι)
-variable [TopologicalSpace Λ] [IsTopologicalRing Λ] [∀ i, ContinuousSMul Λ (R i)]
+variable [TopologicalSpace Λ] [∀ i, ContinuousSMul Λ (R i)]
 variable [IsLocalRing Λ] [IsNoetherianRing Λ] [NonarchimedeanRing Λ] [T2Space Λ]
   [Algebra.TopologicallyFG ℤ Λ]
 
@@ -111,7 +111,7 @@ omit [IsNoetherianRing Λ]
   [IsPatchingSystem Λ M F]
   [IsLocalRing Λ] in
 -- attribute [local instance] UltraProduct.instIsScalarTower in
-lemma PatchingModule.ker_componentMapModule_mkQ (α : OpenIdeals Λ) :
+lemma PatchingModule.ker_componentMapModule_mkQ [IsTopologicalRing Λ] (α : OpenIdeals Λ) :
     LinearMap.ker ((componentMapModule Λ F (fun i ↦
       (𝔫 • ⊤ : Submodule Λ (M i)).mkQ) α.1).restrictScalars Λ) = 𝔫 • ⊤ := by
   obtain ⟨α, hα₁⟩ := α
@@ -181,7 +181,7 @@ lemma PatchingModule.ker_componentMapModule_mkQ (α : OpenIdeals Λ) :
 set_option backward.isDefEq.respectTransparency false in
 omit [Algebra.TopologicallyFG ℤ Λ]
   [IsPatchingSystem Λ M F] [NonarchimedeanRing Λ] in
-lemma PatchingModule.mem_smul_top (x : PatchingModule Λ M F) :
+lemma PatchingModule.mem_smul_top [IsTopologicalRing Λ] (x : PatchingModule Λ M F) :
     x ∈ (𝔫 • ⊤ : Submodule Λ (PatchingModule Λ M F)) ↔
       ∀ (α : OpenIdeals Λ), x.1 α ∈ (𝔫 • ⊤ : Submodule Λ (Component Λ M F α.1)) := by
   classical
@@ -263,7 +263,7 @@ lemma PatchingModule.mem_smul_top (x : PatchingModule Λ M F) :
 set_option backward.isDefEq.respectTransparency false in
 omit [Algebra.TopologicallyFG ℤ Λ]
   [IsPatchingSystem Λ M F] [NonarchimedeanRing Λ] in
-lemma PatchingModule.ker_map_mkQ :
+lemma PatchingModule.ker_map_mkQ [IsTopologicalRing Λ] :
     LinearMap.ker ((PatchingModule.map Λ F fun i ↦
       (𝔫 • ⊤ : Submodule Λ (M i)).mkQ).restrictScalars Λ) = 𝔫 • ⊤ := by
   apply le_antisymm
@@ -355,7 +355,6 @@ def PatchingAlgebra.quotientToOver :
 
 omit
   [TopologicalSpace Λ]
-  [IsTopologicalRing Λ]
   [∀ (i : ι), ContinuousSMul Λ (R i)]
   [IsLocalRing Λ]
   [IsNoetherianRing Λ]

--- a/FLT/Patching/System.lean
+++ b/FLT/Patching/System.lean
@@ -29,7 +29,7 @@ variable [∀ i, CompactSpace (R i)] [∀ i, IsLocalRing.IsAdicTopology (R i)]
 variable (M : ι → Type*) [∀ i, AddCommGroup (M i)] [∀ i, Module Λ (M i)]
 variable [∀ i, Module (R i) (M i)] [∀ i, IsScalarTower Λ (R i) (M i)]
 variable (F : Ultrafilter ι)
-variable [TopologicalSpace Λ] [IsTopologicalRing Λ]
+variable [TopologicalSpace Λ]
 variable [IsLocalRing Λ] [IsNoetherianRing Λ] [NonarchimedeanRing Λ] [T2Space Λ]
 
 attribute [local instance] Module.quotientAnnihilator
@@ -88,7 +88,7 @@ omit
   [NonarchimedeanRing Λ]
   [T2Space Λ]
   [Algebra.UniformlyBoundedRank R] in
-lemma maximalIdeal_pow_bound_le_smul_top (i) (α : OpenIdeals Λ) :
+lemma maximalIdeal_pow_bound_le_smul_top [IsTopologicalRing Λ] (i) (α : OpenIdeals Λ) :
     (maximalIdeal (R i) ^ (Nat.card (Λ ⧸ α.1) ^ bound Λ M) • ⊤ :
       Submodule (R i) (M i)) ≤ α.1 • ⊤ := by
   rw [← Submodule.map_algebraMap_smul α.1]
@@ -297,7 +297,6 @@ omit
   [∀ (i : ι), IsAdicTopology (R i)]
   [IsLocalRing Λ]
   [IsNoetherianRing Λ]
-  [NonarchimedeanRing Λ]
   [T2Space Λ]
   [Algebra.UniformlyBoundedRank R]
   [IsPatchingSystem Λ M ↑F]
@@ -368,7 +367,7 @@ lemma smul_lemma₀
   refine SetLike.le_def.mp ?_ ((Ideal.Quotient.mk_eq_mk_iff_sub_mem _ _).mp (hi₂.trans hi₁.symm))
   rw [← Ideal.map_le_iff_le_comap, Ideal.map_pow, ← IsLocalRing.map_maximalIdeal_of_surjective F hF]
 
-omit [NonarchimedeanRing Λ] [Module.Finite R₀ M₀] in
+omit [Module.Finite R₀ M₀] in
 lemma smul_lemma₁
     (x : M₀)
     (m : R₀) :


### PR DESCRIPTION
Build is currently broken because it now checks for warnings.