### PR TITLE
Speed up quaternion automorphic form definitions

### DIFF
--- a/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
+++ b/FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean
@@ -5,10 +5,9 @@ Authors: Kevin Buzzard
 -/
 module
 
-public import FLT.Hacks.RightActionInstances
-public import FLT.Mathlib.Algebra.FixedPoints.Basic
+public import Mathlib.Topology.Algebra.Module.ModuleTopology
+public import Mathlib.Algebra.Ring.Action.Submonoid
 public import Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing
-import Mathlib.MeasureTheory.Integral.Bochner.Basic
 
 /-!
 # Definitions for automorphic forms on quaternion algebras
@@ -77,21 +76,116 @@ docstring in LaTeX and the `incl₂` one in unicode. Which is better? -/
 noncomputable abbrev incl₁ : Dˣ →* Dfx F D :=
   Units.map (Algebra.TensorProduct.includeLeftRingHom.toMonoidHom)
 
-open scoped TensorProduct.RightActions in
 /-- `incl₂` is he inclusion `𝔸_F^∞ˣ → (D ⊗ 𝔸_F^∞ˣ)`. Remark: I wrote the `incl₁`
 docstring in LaTeX and the `incl₂` one in unicode. Which is better? -/
 noncomputable abbrev incl₂ : (FiniteAdeleRing (𝓞 F) F)ˣ →* Dfx F D :=
-  Units.map (algebraMap _ _).toMonoidHom
+  Units.map (Algebra.TensorProduct.includeRight.toRingHom.toMonoidHom)
+
+omit [FiniteDimensional F D] in
+lemma includeRight_mul_comm
+    (y : FiniteAdeleRing (𝓞 F) F) (z : D ⊗[F] FiniteAdeleRing (𝓞 F) F) :
+    z * Algebra.TensorProduct.includeRight y =
+      Algebra.TensorProduct.includeRight y * z := by
+  refine TensorProduct.induction_on z ?_ ?_ ?_
+  · simp [Algebra.TensorProduct.includeRight_apply]
+  · intro d a
+    simp [Algebra.TensorProduct.includeRight_apply, Algebra.TensorProduct.tmul_mul_tmul, mul_comm]
+  · intro z₁ z₂ hz₁ hz₂
+    rw [add_mul, mul_add, hz₁, hz₂]
 
 -- it's actually equal but ⊆ is all we need, and equality is harder
-open scoped TensorProduct.RightActions in
 omit [FiniteDimensional F D] in
 lemma range_incl₂_le_center : MonoidHom.range (incl₂ F D) ≤ Subgroup.center (Dfx F D) := by
   rintro x ⟨y, rfl⟩
   refine Subgroup.mem_center_iff.mpr fun g ↦ Units.ext ?_
-  exact (Algebra.commutes _ _).symm
+  simpa [incl₂] using includeRight_mul_comm (F := F) (D := D) (↑y) (↑g)
 
-open scoped TensorProduct.RightActions in
+noncomputable local instance : SMul (FiniteAdeleRing (𝓞 F) F)
+    (D ⊗[F] FiniteAdeleRing (𝓞 F) F) where
+  smul a x := TensorProduct.comm _ _ _ (a • (TensorProduct.comm _ _ _ x))
+
+omit [FiniteDimensional F D] in
+@[simp]
+private lemma tensor_right_smul_def (a : FiniteAdeleRing (𝓞 F) F)
+    (x : D ⊗[F] FiniteAdeleRing (𝓞 F) F) :
+    a • x = (TensorProduct.comm _ _ _).symm (a • (TensorProduct.comm _ _ _ x)) := rfl
+
+local instance : Module (FiniteAdeleRing (𝓞 F) F)
+    (D ⊗[F] FiniteAdeleRing (𝓞 F) F) where
+  one_smul x := by
+    simp_rw [tensor_right_smul_def, one_smul, (TensorProduct.comm F D _).symm_apply_apply]
+  mul_smul a b x := by
+    simp_rw [tensor_right_smul_def, mul_smul, (TensorProduct.comm F D _).apply_symm_apply]
+  smul_zero := by simp
+  smul_add := by simp
+  add_smul := by simp [add_smul]
+  zero_smul := by simp
+
+noncomputable local instance : Algebra (FiniteAdeleRing (𝓞 F) F)
+    (D ⊗[F] FiniteAdeleRing (𝓞 F) F) where
+  algebraMap := Algebra.TensorProduct.includeRight.toRingHom
+  commutes' a x := by
+    induction x with
+    | zero =>
+        simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe,
+          Algebra.TensorProduct.includeRight_apply, mul_zero, zero_mul]
+    | tmul d b =>
+        simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe,
+          Algebra.TensorProduct.includeRight_apply, Algebra.TensorProduct.tmul_mul_tmul, one_mul,
+          mul_one, mul_comm]
+    | add x y hx hy =>
+        simp_all only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe,
+          Algebra.TensorProduct.includeRight_apply, mul_add, add_mul]
+  smul_def' a x := by
+    induction x with
+    | zero =>
+        simp only [smul_zero, AlgHom.toRingHom_eq_coe, RingHom.coe_coe,
+          Algebra.TensorProduct.includeRight_apply, mul_zero]
+    | tmul d b =>
+        simp only [tensor_right_smul_def, TensorProduct.comm_tmul, AlgHom.toRingHom_eq_coe,
+          RingHom.coe_coe, Algebra.TensorProduct.includeRight_apply,
+          Algebra.TensorProduct.tmul_mul_tmul, one_mul]
+        rw [TensorProduct.smul_tmul']
+        simp only [smul_eq_mul, TensorProduct.comm_symm_tmul]
+    | add x y hx hy =>
+        simp_all only [tensor_right_smul_def, AlgHom.toRingHom_eq_coe, RingHom.coe_coe,
+          Algebra.TensorProduct.includeRight_apply, smul_add, mul_add]
+
+private def tensorCommRightLinearEquiv :
+    (FiniteAdeleRing (𝓞 F) F ⊗[F] D) ≃ₗ[FiniteAdeleRing (𝓞 F) F]
+      (D ⊗[F] FiniteAdeleRing (𝓞 F) F) where
+  __ := (_root_.TensorProduct.comm F (FiniteAdeleRing (𝓞 F) F) D).toAddEquiv
+  map_smul' a x := by
+    induction x with
+    | zero =>
+        simp only [smul_zero, AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, map_zero,
+          RingHom.id_apply]
+    | tmul b d =>
+        simp only [TensorProduct.smul_tmul', AddHom.toFun_eq_coe, LinearMap.coe_toAddHom,
+          LinearEquiv.coe_coe, TensorProduct.comm_tmul, RingHom.id_apply,
+          tensor_right_smul_def, TensorProduct.comm_symm_tmul]
+    | add x y hx hy =>
+        simp_all only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, LinearEquiv.coe_coe,
+          RingHom.id_apply, tensor_right_smul_def, smul_add, map_add]
+
+local instance : Module.Finite (FiniteAdeleRing (𝓞 F) F)
+    (D ⊗[F] FiniteAdeleRing (𝓞 F) F) :=
+  Module.Finite.equiv
+    (tensorCommRightLinearEquiv (F := F) (D := D))
+
+noncomputable local instance : TopologicalSpace (D ⊗[F] FiniteAdeleRing (𝓞 F) F) :=
+  moduleTopology (FiniteAdeleRing (𝓞 F) F) _
+
+local instance : IsModuleTopology (FiniteAdeleRing (𝓞 F) F)
+    (D ⊗[F] FiniteAdeleRing (𝓞 F) F) := ⟨rfl⟩
+
+local instance : IsTopologicalRing (D ⊗[F] FiniteAdeleRing (𝓞 F) F) :=
+  IsModuleTopology.isTopologicalRing (FiniteAdeleRing (𝓞 F) F) _
+
+local instance : TopologicalSpace (Dfx F D) := inferInstance
+
+local instance : IsTopologicalGroup (Dfx F D) := inferInstance
+
 /--
 This definition is made in mathlib-generality but is *not* the definition of a
 weight 2 automorphic form unless `Dˣ` is compact mod centre at infinity.
@@ -207,7 +301,6 @@ lemma _root_.ConjAct.isOpen_smul {G : Type*} [Group G] [TopologicalSpace G]
 
 open ConjAct
 
-open scoped TensorProduct.RightActions in
 /-- The adelic group action on the space of automorphic forms over a totally definite
 quaternion algebra. -/
 def group_smul (g : Dfx F D) (φ : WeightTwoAutomorphicForm F D R) :
@@ -300,7 +393,8 @@ section finite_level
 level `U` for a totally definite quaternion algebra over a totally real field.
 -/
 def WeightTwoAutomorphicFormOfLevel (U : Subgroup (Dfx F D))
-    (R : Type*) [CommRing R] : Type _ := MulAction.FixedPoints U (WeightTwoAutomorphicForm F D R)
+    (R : Type*) [CommRing R] : Type _ :=
+  FixedPoints.addSubgroup U (WeightTwoAutomorphicForm F D R)
 
 namespace WeightTwoAutomorphicFormOfLevel
 
@@ -329,10 +423,28 @@ lemma right_invt (f : WeightTwoAutomorphicFormOfLevel U R) (g : Dfx F D) (u : U)
   congr($(f.2 u) g)
 
 instance : AddCommGroup (WeightTwoAutomorphicFormOfLevel U R) := inferInstanceAs <|
-  AddCommGroup (MulAction.FixedPoints U (WeightTwoAutomorphicForm F D R))
+  AddCommGroup (FixedPoints.addSubgroup U (WeightTwoAutomorphicForm F D R))
 
-instance : Module R (WeightTwoAutomorphicFormOfLevel U R) := inferInstanceAs <|
-  Module R (MulAction.FixedPoints U (WeightTwoAutomorphicForm F D R))
+instance : Module R (WeightTwoAutomorphicFormOfLevel U R) where
+  smul r f := ⟨r • f.1, fun u ↦ by simp [smul_comm, f.2 u]⟩
+  one_smul f := by
+    ext x
+    exact one_smul R (f x)
+  mul_smul r s f := by
+    ext x
+    exact mul_smul r s (f x)
+  smul_zero r := by
+    ext x
+    exact smul_zero r
+  smul_add r f g := by
+    ext x
+    exact smul_add r (f x) (g x)
+  add_smul r s f := by
+    ext x
+    exact add_smul r s (f x)
+  zero_smul f := by
+    ext x
+    exact zero_smul R (f x)
 
 end WeightTwoAutomorphicFormOfLevel
 


### PR DESCRIPTION
I focused this PR on the part of #564 that this file can control directly.

`Defs.lean` used to enter the scoped `TensorProduct.RightActions` instance bundle in several places. That made Lean recover a fairly large right-action/topology support stack while elaborating local automorphic-form definitions. This patch spells out the small amount of right-side tensor structure the file needs, and removes that scoped dependency from the file.

1. Mechanism

| area | before | after |
| --- | --- | --- |
| finite adele inclusion | `Units.map (algebraMap _ _).toMonoidHom` under `TensorProduct.RightActions` | `Units.map (Algebra.TensorProduct.includeRight.toRingHom.toMonoidHom)` |
| centrality bridge | `Algebra.commutes _ _` | local `includeRight_mul_comm` lemma |
| right tensor structure | broad scoped `TensorProduct.RightActions` openings | local right `SMul`, `Module`, `Algebra`, `Module.Finite`, and topology instances |
| fixed-level subtype | FLT-specific `MulAction.FixedPoints` helper | mathlib `FixedPoints.addSubgroup` |
| module-topology import | FLT helper module | direct mathlib module import |
| Bochner import | imported here but unused | removed |

2. Structural check

The main result is that `Defs.lean` no longer asks for the scoped right-action bundle at all.

| check | before | after |
| --- | ---: | ---: |
| `open scoped TensorProduct.RightActions` in this file | 4 | 0 |
| textual `TensorProduct.RightActions` references | present | 0 |
| textual `Algebra.commutes` references | 1 | 0 |
| direct import of `FLT.Hacks.RightActionInstances` | yes | no |
| direct import of `FLT.Mathlib.Algebra.FixedPoints.Basic` | yes | no |
| direct import of `Mathlib.MeasureTheory.Integral.Bochner.Basic` | yes | no |

Remaining direct imports:

| import |
| --- |
| `Mathlib.Topology.Algebra.Module.ModuleTopology` |
| `Mathlib.Algebra.Ring.Action.Submonoid` |
| `Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing` |

3. Timing

The benchmark below uses clean runs from the same WSL2 setup, with no active Lean/Lake compile jobs. I am using the baseline as a range because repeated clean baseline runs moved by about a minute on this target, mostly through import time.

Build command:
`lake build FLT.AutomorphicForm.QuaternionAlgebra.Defs`

| benchmark | before | after | delta |
| --- | ---: | ---: | ---: |
| target build time | 451.49s-506.79s | 255s | -196.49s to -251.79s |
| elapsed wall time | not recorded in that baseline table | 358.01s | n/a |
| target jobs | not recorded in that baseline table | 2463 | n/a |

Profile command:
`lake env lean -R . --profile FLT/AutomorphicForm/QuaternionAlgebra/Defs.lean`

| profile metric | before | after | delta |
| --- | ---: | ---: | ---: |
| import | 450s-517s | 359s | -91s to -158s |
| elaboration | not recorded in that baseline table | 101ms | n/a |
| typeclass inference | not recorded in that baseline table | 1.56s | n/a |
| type checking | not recorded in that baseline table | 465ms | n/a |
| tactic execution | not recorded in that baseline table | 159ms | n/a |
| elapsed wall time | 467.74s-542.45s | 409.72s | -58.02s to -132.73s |

4. Why this does not try to push the target below 100s

The current profile puts the remaining cost in imports rather than in the body of this file. After this patch, the local file work is small: elaboration is about 101ms, typeclass inference is about 1.56s, type checking is about 465ms, and tactic execution is about 159ms. The expensive part is still the `FiniteAdeleRing` import stack.

I did not try to force this PR under 100s by continuing to reshape local proofs. That would be optimizing the wrong layer. A real sub-100s attempt would need a larger API split around finite adeles, so that this file can import a light interface instead of the full restricted-product / adic-valuation implementation stack. I also tried a smaller local finite-adele split, and it did not move the boundary enough to justify including it here.

So this PR keeps the scope smaller: remove the broad `TensorProduct.RightActions` dependency from `Defs.lean`, make the needed structure explicit, and leave the finite-adele import-boundary work for a separate change if maintainers want to go after the remaining time.

Fixes #564.