### PR TITLE
docs: fix blueprint link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ The project is currently being led by Kevin Buzzard. Until September 2029 it is 
 
 General information ("What is Fermat's Last Theorem/Lean?" / "Why are you doing this?" etc) is [here](GENERAL.md).
 
-The route we will be taking was planned out essentially entirely by Richard Taylor in discussions with Buzzard. It is a modern variant of the original Wiles/Taylor-Wiles proof, borrowing heavily from the ideas of Khare and Wintenberger. For more details about the mathematics behind the proof, a good place to start is the [blueprint](https://ImperialCollegeLondon.github.io/FLT/blueprint/).
+The route we will be taking was planned out essentially entirely by Richard Taylor in discussions with Buzzard. It is a modern variant of the original Wiles/Taylor-Wiles proof, borrowing heavily from the ideas of Khare and Wintenberger. For more details about the mathematics behind the proof, a good place to start is the [blueprint](https://imperialcollegelondon.github.io/FLT/).
 
 Information on how to contribute is available [here](CONTRIBUTING.md).


### PR DESCRIPTION
Updates the blueprint link in the README so it points to the correct URL.

- Before: `https://ImperialCollegeLondon.github.io/FLT/blueprint/`
- After: `https://imperialcollegelondon.github.io/FLT/`