### PR TITLE
feat: various sorried known-in-1980s elliptic curve facts

### DIFF
--- a/FLT.lean
+++ b/FLT.lean
@@ -72,6 +72,14 @@ public import FLT.Hacks.RightActionInstances
 public import FLT.HenselianLocalRing.EtaleDecomposition
 public import FLT.HenselianLocalRing.Finite
 public import FLT.HenselianLocalRing.Stuff
+public import FLT.KnownIn1980s.EllipticCurves.Flat
+public import FLT.KnownIn1980s.EllipticCurves.GoodReduction
+public import FLT.KnownIn1980s.EllipticCurves.QuadraticTwists
+public import FLT.KnownIn1980s.EllipticCurves.TateCurve
+public import FLT.KnownIn1980s.EllipticCurves.TateCurveConstruction
+public import FLT.KnownIn1980s.EllipticCurves.TateCurveConstructionExperiment
+public import FLT.KnownIn1980s.EllipticCurves.Torsion
+public import FLT.KnownIn1980s.EllipticCurves.WeilPairing
 public import FLT.Mathlib.Algebra.Algebra.Bilinear
 public import FLT.Mathlib.Algebra.Algebra.Hom
 public import FLT.Mathlib.Algebra.Algebra.Pi

--- a/FLT/KnownIn1980s/EllipticCurves/Flat.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/Flat.lean
@@ -1,4 +1,17 @@
-import Mathlib
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Reduction
+public import Mathlib.RingTheory.Bialgebra.Convolution
+public import Mathlib.RingTheory.Etale.Basic
+public import Mathlib.RingTheory.Flat.Basic
+public import Mathlib.RingTheory.HopfAlgebra.Basic
+public import Mathlib.RingTheory.Polynomial.Resultant.Basic
 
 /-!
 
@@ -95,6 +108,8 @@ above honest; compare the corresponding condition in `GaloisRep.HasFlatProlongat
   isolate the arithmetic input to the theorem as a purely polynomial statement.
 
 -/
+
+@[expose] public section
 
 open scoped WeierstrassCurve.Affine -- `(E⁄K).Point` notation for the group of points
 open scoped TensorProduct -- `⊗[R]` notation

--- a/FLT/KnownIn1980s/EllipticCurves/Flat.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/Flat.lean
@@ -1,0 +1,226 @@
+import Mathlib
+
+/-!
+
+# Good reduction implies flat torsion
+
+Let `E` be an elliptic curve over the field of fractions `K` of a discrete valuation
+ring `R`, suppose that `E` has good reduction over `R`, and let `n ≥ 1` be a natural
+number. Then the `n`-torsion of `E` "is a finite flat group scheme": the Galois module
+`E(Kˢᵉᵖ)[n]` is, Galois-equivariantly, the group of `Kˢᵉᵖ`-points of the generic fibre
+of a finite flat group scheme over `R`.
+
+Mathlib has no group schemes, so we speak throughout of the (commutative) Hopf algebra
+of functions on the group scheme instead: the statement below produces a commutative
+Hopf algebra `H` over `R`, finite and flat as an `R`-module (`R` is a DVR, so this
+says finite free; over a general base the right condition is finite locally free),
+together with a Galois-equivariant isomorphism of groups from the `Kˢᵉᵖ`-points
+`K ⊗[R] H →ₐ[K] Kˢᵉᵖ` of its generic fibre (a group under convolution, `K ⊗[R] H`
+being a Hopf algebra over `K`) to the `n`-torsion subgroup of `E(Kˢᵉᵖ)`.
+
+## Mathematical discussion: what is the correct generality?
+
+Good reduction means that the minimal Weierstrass equation of `E` has unit discriminant
+over `R`, so it defines an elliptic scheme (an abelian scheme of relative dimension 1)
+`𝓔` over `R` with generic fibre `E`. Multiplication by `n` on an elliptic scheme is a
+finite locally free morphism of degree `n²` for every `n ≥ 1` [Katz–Mazur, *Arithmetic
+moduli of elliptic curves*, Theorem 2.3.1], so its kernel `𝓔[n]` is a finite flat group
+scheme over `R` of order `n²` with generic fibre `E[n]`. This is the robust form of the
+statement: it holds for every `n` over any DVR (indeed over any base scheme), in every
+characteristic.
+
+The statement formalised below is instead about the Galois module `E(Kˢᵉᵖ)[n]`, because
+mathlib cannot yet express `E[n]` as a group scheme. How the two statements compare
+depends on whether `n` is invertible in `K`:
+
+* If `n` is invertible in `K` then `E[n]` is a finite étale group scheme over `K` of
+  order `n²`. It is therefore determined by its Galois module of `Kˢᵉᵖ`-points, which is
+  free of rank 2 over `ℤ/nℤ`, and the statement below carries the full content of the
+  group-scheme statement.
+
+* If `K` has characteristic `p` and `p ∣ n` then `E[n]` is not étale, and `E(Kˢᵉᵖ)[n]`
+  sees only its maximal étale quotient (for `n = p`: a group of order `p` if the
+  reduction is ordinary and of order `1` if it is supersingular). The statement below
+  should still be true — for `H` one can take the Cartier dual of the schematic closure
+  in `𝓔[n]` of the Cartier dual of the maximal étale quotient of `E[n]` — but it is
+  strictly weaker than flatness of `E[n]` itself. The honest statement in this case is
+  the group-scheme statement of the previous paragraph, which cannot yet be formalised.
+
+Which values of `n` make flatness interesting? Let `p` denote the characteristic of the
+residue field of `R`.
+
+* If `n` is invertible in the residue field then the conclusion is equivalent to the
+  Galois module `E(Kˢᵉᵖ)[n]` being unramified, which is the statement of
+  `FLT.KnownIn1980s.EllipticCurves.GoodReduction`. Indeed, the order of a finite flat
+  group scheme kills its module of invariant differentials [Tate, *Finite flat group
+  schemes*, in *Modular forms and Fermat's Last Theorem*], so a finite flat group scheme
+  over `R` whose order is invertible in `R` is unramified over `R`, hence finite étale;
+  and finite étale group schemes over `R` are the same thing as unramified Galois
+  modules, via normalization. In particular "unramified implies flat" holds for *any*
+  finite abelian Galois module of order invertible in the residue field, for reasons
+  having nothing to do with elliptic curves.
+
+* The interesting case is therefore `p > 0` and `p ∣ n`, where flatness is genuinely
+  stronger than anything expressible via ramification: for `K` of characteristic zero
+  (e.g. a finite extension of `ℚ_p`) and `n = p`, this is the sense in which "`ρ` is
+  flat at `p`" is used for mod `p` representations in [Serre, *Sur les représentations
+  modulaires de degré 2 de Gal(ℚ̄/ℚ)*, Duke Math. J. 54 (1987), §2.8] and in the
+  modularity lifting literature, and it matches the definition `GaloisRep.IsFlatAt` in
+  `FLT.Deformations.RepresentationTheory.GaloisRep` (stated there for number fields; the
+  theorem below is the local statement feeding into it). Note that flat does *not* imply
+  unramified here: the `p`-torsion of a curve with good reduction is flat but in general
+  highly ramified at `p`.
+
+The `Algebra.Etale K (K ⊗[R] H)` condition below pins down the generic fibre as the
+finite étale group scheme attached to the Galois module `E(Kˢᵉᵖ)[n]` (in particular it
+forces the `R`-rank of `H` to equal the number of `n`-torsion points). It is automatic
+when `K` has characteristic zero, by Cartier's theorem that finite group schemes in
+characteristic zero are étale, and it is what makes the equivalence "flat ⟺ unramified"
+above honest; compare the corresponding condition in `GaloisRep.HasFlatProlongationAt`.
+
+## TODO
+
+* `FLT.GroupScheme.FiniteFlat` plans a definition of what it means for an action of
+  `Gal(Kˢᵉᵖ/K)` on a finite abelian group to be *flat*, for `K` the field of fractions
+  of a DVR. Once that definition exists, the conclusion below should be refactored to
+  "the Galois module `E(Kˢᵉᵖ)[n]` is flat".
+
+* Once `E[n]` can be expressed as a group scheme (equivalently, once its Hopf algebra of
+  functions is available), state the stronger result that `E[n]` itself, not just its
+  Galois module of points, prolongs to a finite flat group scheme over `R`; as explained
+  above, this is insensitive to the characteristic of `K`.
+
+* Prove the division polynomial lemmas at the bottom of this file
+  (`WeierstrassCurve.resultant_Φ_ΨSq` and `WeierstrassCurve.isCoprime_Φ_ΨSq`), which
+  isolate the arithmetic input to the theorem as a purely polynomial statement.
+
+-/
+
+open scoped WeierstrassCurve.Affine -- `(E⁄K).Point` notation for the group of points
+open scoped TensorProduct -- `⊗[R]` notation
+
+universe u
+
+-- let R be a discrete valuation ring with field of fractions K
+variable (R : Type u) [CommRing R] [IsDomain R] [IsDiscreteValuationRing R]
+variable (K : Type*) [Field K] [Algebra R K] [IsFractionRing R K]
+
+-- Let E/K be an elliptic curve with good reduction over R. Note that mathlib's
+-- `HasGoodReduction` asks that the given Weierstrass equation for E is a minimal
+-- integral equation whose discriminant has valuation 1; this loses no generality
+-- because every elliptic curve over K is isomorphic to one given by a minimal
+-- equation (`WeierstrassCurve.exists_isMinimal`).
+variable (E : WeierstrassCurve K) [E.IsElliptic] [E.HasGoodReduction R]
+
+-- Let n be a positive natural number. (The interesting case is when n is divisible by
+-- the residue characteristic of R; away from it, flatness reduces to the unramifiedness
+-- statement of `FLT.KnownIn1980s.EllipticCurves.GoodReduction` — see the discussion above.)
+variable (n : ℕ) [NeZero n]
+
+-- Let Ksep be a separable closure of K (`DecidableEq` is needed for the group law on points)
+variable (Ksep : Type*) [Field Ksep] [Algebra K Ksep] [IsSepClosure K Ksep] [DecidableEq Ksep]
+
+/-- If `E` is an elliptic curve over the field of fractions `K` of a discrete valuation
+ring `R` with good reduction over `R`, then the `n`-torsion of `E` is a finite flat group
+scheme: there is a commutative Hopf algebra `H` over `R`, finite and flat as an `R`-module,
+whose generic fibre `K ⊗[R] H` is étale over `K` and whose group of `Kˢᵉᵖ`-points (a group
+under convolution) is isomorphic, compatibly with the actions of `Gal(Kˢᵉᵖ/K)` on the two
+sides, to the `n`-torsion subgroup of `E(Kˢᵉᵖ)`. -/
+theorem WeierstrassCurve.torsion_flat_of_good_reduction :
+    -- There is a commutative Hopf algebra H over R (the functions on a group scheme over R),
+    ∃ (H : Type u) (_ : CommRing H) (_ : HopfAlgebra R H)
+      -- finite and flat as an R-module (so the group scheme is finite flat),
+      (_ : Module.Finite R H) (_ : Module.Flat R H)
+      -- whose generic fibre K ⊗[R] H is étale over K,
+      (_ : Algebra.Etale K (K ⊗[R] H))
+      -- together with an isomorphism of groups from the Kˢᵉᵖ-points of the generic fibre
+      -- (a group under convolution, because K ⊗[R] H is a Hopf algebra over K)
+      -- to the n-torsion subgroup of E(Kˢᵉᵖ),
+      (f : Additive (WithConv (K ⊗[R] H →ₐ[K] Ksep)) ≃+
+        AddSubgroup.torsionBy (E⁄Ksep).Point (n : ℤ)),
+      -- which is equivariant for the actions of Gal(Kˢᵉᵖ/K) on the two sides.
+      ∀ (σ : Ksep ≃ₐ[K] Ksep) (φ : K ⊗[R] H →ₐ[K] Ksep),
+        (f (Additive.ofMul (WithConv.toConv (σ.toAlgHom.comp φ))) : (E⁄Ksep).Point) =
+          Affine.Point.map σ.toAlgHom (f (Additive.ofMul (WithConv.toConv φ))) :=
+  sorry
+
+/-!
+### A step towards the proof, via division polynomials
+
+Mathlib knows the division polynomials of a Weierstrass curve `W` over any commutative
+ring: `W.Φ n` is monic of degree `n²`, and `W.ΨSq n` has degree `n² - 1` with leading
+coefficient `n²` (see `Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/`, in
+particular `natDegree_Φ`, `natDegree_ΨSq` and `leadingCoeff_ΨSq`). What mathlib does not
+yet know is the dictionary between division polynomials and torsion: for a point `P ≠ 0`
+of `E` over a field, `n • P = 0` iff `ΨSq n` vanishes at `x(P)`, and more generally
+`x(n • P) = (Φ n).eval x(P) / (ΨSq n).eval x(P)`.
+
+The two lemmas below isolate the arithmetic input to `torsion_flat_of_good_reduction` as
+a purely polynomial statement: the resultant of `Φ n` and `ΨSq n` is `±Δ ^ ((n⁴ - n²)/6)`;
+in particular the two polynomials are coprime whenever `Δ` is a unit.
+
+Why the identity is true: over a field on which `Δ` is invertible, a common root of `Φ n`
+and `ΨSq n` would — via the dictionary and the definition
+`Φ n = X * ΨSq n - preΨ (n+1) * preΨ (n-1) * (1 or Ψ₂Sq)` — be the `x`-coordinate of a
+nonzero `n`-torsion point which is also `(n+1)`- or `(n-1)`-torsion, hence trivial, a
+contradiction. So over `ℤ[a₁, …, a₆]`, where `Δ` is irreducible, the resultant is forced
+to be `±c * Δ ^ k` with `c` an integer; running the same no-common-root argument over
+`𝔽ₗ` for every prime `ℓ` (it is insensitive to the characteristic) gives `c = ±1`; and
+weights (`aᵢ` has weight `i`, `x` has weight `2`, `Δ` has weight `12`, and the resultant
+is isobaric of weight `2 * n² * (n² - 1)`) pin `k = (n⁴ - n²)/6`. Sanity check for
+`n = 2`, `y² = x³ - x`: `Φ₂ = (x² + 1)²`, `Ψ₂² = 4(x³ - x)`, so the resultant is
+`4⁴ * Φ₂(0) * Φ₂(1) * Φ₂(-1) = 4096 = Δ²`, and `(2⁴ - 2²)/6 = 2`.
+
+Why it is a step towards `torsion_flat_of_good_reduction`:
+
+* For `n` invertible in the residue field of `R`, the leading coefficient `n²` of
+  `ΨSq n` is a unit of `R`, so the `x`-coordinates of the nonzero `n`-torsion points of
+  `E(Kˢᵉᵖ)` (the roots of `ΨSq n`) are integral over `R`, and coprimality of `Φ n` and
+  `ΨSq n` over the residue field (`Δ` is a unit there by good reduction) together with a
+  companion identity for the discriminant of `ΨSq n` (of the same `±nᵃ * Δᵇ` shape) shows
+  that reduction is injective on the `n`-torsion. Since inertia acts trivially on residue
+  fields, it then acts trivially on the torsion: this is the unramifiedness statement of
+  `FLT.KnownIn1980s.EllipticCurves.GoodReduction`, and by the discussion in the module
+  docstring above (an unramified module of order invertible in the residue field prolongs
+  étale-ly), it implies `torsion_flat_of_good_reduction` for all such `n`.
+
+* For `n` divisible by the residue characteristic `p`, division polynomials cannot
+  produce the Hopf algebra `H` by themselves: the leading coefficient `n²` of `ΨSq n`
+  now lies in the maximal ideal, which is the concrete manifestation of the fact that
+  part of the `n`-torsion group scheme sits at the origin, outside the affine chart
+  where the division polynomials live (the torsion in the kernel of reduction has
+  `x`-coordinates of negative valuation). But the identity is still the arithmetic core
+  of the scheme-theoretic proof [Katz–Mazur, *Arithmetic moduli of elliptic curves*,
+  Theorem 2.3.1] that multiplication by `n` on the elliptic scheme `𝓔` is finite locally
+  free of degree `n²`: the polynomial `(Φ n).eval X - ξ * (ΨSq n).eval X` is monic of
+  degree `n²` over `R[ξ]`, where `ξ = x ∘ [n]`, which gives finiteness of `[n]`, and
+  coprimality on each fibre gives the constant fibre degree `n²`. So nothing proved here
+  is wasted on the hard case.
+
+Reference for the resultant identity in short Weierstrass form: M. Ayad, *Points
+S-entiers des courbes elliptiques*, Manuscripta Math. 76 (1992), 305–324.
+-/
+
+/-- The resultant of the division polynomials `Φ n` (taken with degree `n²`) and `ΨSq n`
+(taken with degree `n² - 1`) is `±Δ ^ ((n⁴ - n²)/6)`. The sign presumably depends on `n`
+and on the conventions in `Polynomial.resultant`; whoever proves this should pin it down
+and upgrade the statement. -/
+theorem WeierstrassCurve.resultant_Φ_ΨSq {R₀ : Type*} [CommRing R₀] (W : WeierstrassCurve R₀)
+    {n : ℤ} (hn : n ≠ 0) :
+    (W.Φ n).resultant (W.ΨSq n) (n.natAbs ^ 2) (n.natAbs ^ 2 - 1) =
+        W.Δ ^ ((n.natAbs ^ 4 - n.natAbs ^ 2) / 6) ∨
+      (W.Φ n).resultant (W.ΨSq n) (n.natAbs ^ 2) (n.natAbs ^ 2 - 1) =
+        -W.Δ ^ ((n.natAbs ^ 4 - n.natAbs ^ 2) / 6) :=
+  sorry
+
+/-- If the discriminant of a Weierstrass curve over a commutative ring is a unit then the
+division polynomials `Φ n` and `ΨSq n` are coprime, i.e. there is a Bézout identity
+`F * Φ n + G * ΨSq n = 1`. This is the form of the resultant identity that the
+applications consume. It follows from `resultant_Φ_ΨSq`, because the resultant lies in
+the ideal generated by the two polynomials and is a unit here; note also that it is
+stable under base change, so it suffices to prove it for the universal Weierstrass curve
+over `ℤ[a₁, …, a₆][Δ⁻¹]`. -/
+theorem WeierstrassCurve.isCoprime_Φ_ΨSq {R₀ : Type*} [CommRing R₀] (W : WeierstrassCurve R₀)
+    {n : ℤ} (hn : n ≠ 0) (hΔ : IsUnit W.Δ) :
+    IsCoprime (W.Φ n) (W.ΨSq n) :=
+  sorry

--- a/FLT/KnownIn1980s/EllipticCurves/GoodReduction.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/GoodReduction.lean
@@ -1,0 +1,52 @@
+import Mathlib
+
+/-!
+
+Let E be an elliptic curve over the field of fractions k
+of a DVR, with good reduction. Let n be a positive
+integer which is nonzero in k.
+Then the Galois representation on the n-torsion points
+over k^sep is unramified.
+
+This is the easy direction of the criterion of Néron–Ogg–Shafarevich;
+see for example [Silverman, *The Arithmetic of Elliptic Curves*, VII.7.1]
+or [Serre–Tate, *Good reduction of abelian varieties*, Theorem 1
+for the general abelian variety case].
+
+-/
+
+open scoped WeierstrassCurve.Affine -- `(E⁄K).Point` notation for the group of `K`-points
+
+-- let R be a discrete valuation ring with field of fractions k
+variable (R : Type*) [CommRing R] [IsDomain R] [IsDiscreteValuationRing R]
+variable (k : Type*) [Field k] [Algebra R k] [IsFractionRing R k]
+
+-- Let E/k be an elliptic curve with good reduction over R. Note that mathlib's
+-- `HasGoodReduction` asks that the given Weierstrass equation for E is a minimal
+-- integral equation whose discriminant has valuation 1; this loses no generality
+-- because every elliptic curve over k is isomorphic to one given by a minimal
+-- equation (`WeierstrassCurve.exists_isMinimal`).
+variable (E : WeierstrassCurve k) [E.IsElliptic] [E.HasGoodReduction R]
+
+-- Let n be a natural which is nonzero in k
+variable (n : ℕ) [NeZero (n : k)]
+
+-- Let ksep be a separable closure of k (`DecidableEq` is needed for the group law on points)
+variable (ksep : Type*) [Field ksep] [Algebra k ksep] [IsSepClosure k ksep] [DecidableEq ksep]
+
+-- Let 𝒪 be a valuation subring of ksep. This is arbitrary here; the hypothesis
+-- that it lies above R is `h𝒪` in the theorem below.
+variable (𝒪 : ValuationSubring ksep)
+
+/-- If `E` is an elliptic curve over `k` (given by a minimal Weierstrass equation)
+with good reduction over `R`, and if `𝒪` is a valuation subring of `kˢᵉᵖ` lying above `R`,
+then the inertia subgroup of `Gal(kˢᵉᵖ/k)` at `𝒪` acts trivially on the `n`-torsion
+of `E(kˢᵉᵖ)`. In other words, the Galois representation on the `n`-torsion points
+is unramified. -/
+theorem WeierstrassCurve.torsion_unramified_of_good_reduction
+    -- Assume 𝒪 lies above R, i.e. 𝒪 ∩ k = R
+    (h𝒪 : (𝒪.comap (algebraMap k ksep)).toSubring = (algebraMap R k).range) :
+    -- Then every element of the inertia subgroup at 𝒪 fixes every n-torsion point of E(ksep)
+    ∀ σ ∈ 𝒪.inertiaSubgroup k, ∀ P ∈ AddSubgroup.torsionBy (E⁄ksep).Point (n : ℤ),
+      Affine.Point.map (σ : ksep ≃ₐ[k] ksep).toAlgHom P = P :=
+  sorry

--- a/FLT/KnownIn1980s/EllipticCurves/GoodReduction.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/GoodReduction.lean
@@ -1,4 +1,13 @@
-import Mathlib
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Reduction
+public import Mathlib.RingTheory.Valuation.RamificationGroup
 
 /-!
 
@@ -14,6 +23,8 @@ or [Serre–Tate, *Good reduction of abelian varieties*, Theorem 1
 for the general abelian variety case].
 
 -/
+
+@[expose] public section
 
 open scoped WeierstrassCurve.Affine -- `(E⁄K).Point` notation for the group of `K`-points
 

--- a/FLT/KnownIn1980s/EllipticCurves/QuadraticTwists.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/QuadraticTwists.lean
@@ -439,7 +439,9 @@ end QuadraticTwistBy
 `θ ∈ L ∖ K`. The twist is independent of this choice up to isomorphism over `K`
 (`exists_smul_quadraticTwist_eq_quadraticTwistBy`), that is, up to the action of
 `WeierstrassCurve.VariableChange K`; see `WeierstrassCurve.quadraticTwistOf` for the explicit
-Weierstrass model. -/
+Weierstrass model. (The separability hypothesis is not used to write down the model, but the
+twist is only meaningful for separable extensions — see the module docstring.) -/
+@[nolint unusedArguments]
 noncomputable def quadraticTwist (E : WeierstrassCurve K) (L : Type*) [Field L] [Algebra K L]
     [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L] : WeierstrassCurve K :=
   E.quadraticTwistBy (Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L).choose

--- a/FLT/KnownIn1980s/EllipticCurves/QuadraticTwists.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/QuadraticTwists.lean
@@ -1,4 +1,14 @@
-import Mathlib
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Reduction
+public import Mathlib.RingTheory.Flat.TorsionFree
+public import Mathlib.RingTheory.Norm.Transitivity
 
 /-!
 
@@ -124,6 +134,8 @@ of `E`, and the reduction-theoretic statements — are `sorry`ed targets.
   §5.3 (for the interaction of twists with reduction types)
 
 -/
+
+@[expose] public section
 
 open scoped WeierstrassCurve.Affine -- `(E⁄K).Point` notation for the group of `K`-points
 

--- a/FLT/KnownIn1980s/EllipticCurves/QuadraticTwists.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/QuadraticTwists.lean
@@ -1,0 +1,620 @@
+import Mathlib
+
+/-!
+
+# Quadratic twists of elliptic curves
+
+Let `E` be an elliptic curve over a field `K` and let `L/K` be a separable quadratic extension.
+The *quadratic twist* `Eᴸ` of `E` by `L/K` is an elliptic curve over `K`, well-defined up to
+`K`-isomorphism, characterised by the following two properties:
+
+* `Eᴸ` becomes isomorphic to `E` over `L` (but is not isomorphic to `E` over `K`, at least
+  when `j(E) ∉ {0, 1728}`);
+* the isomorphism `φ : Eᴸ ≅ E` over `L` can be chosen so that the Galois action on the points
+  of `Eᴸ` corresponds, under `φ`, to the Galois action on the points of `E` twisted by the
+  quadratic character `χ` of `L/K`. More precisely, for every field `M` in a tower
+  `K ⊆ L ⊆ M` and every `σ ∈ Aut(M/K)`, we have `φ(σ P) = χ(σ) • σ(φ P)` on `M`-points,
+  where `χ(σ) = 1` if `σ` fixes `L` pointwise and `χ(σ) = -1` otherwise.
+
+Taking `M` to be a separable closure of `K`, the second property says exactly that the Galois
+representations attached to `Eᴸ` (for example on torsion points, via
+`FLT.KnownIn1980s.EllipticCurves.Torsion`) are the twists by `χ` of those attached to `E`.
+Taking `M = L` and `σ` the nontrivial element of `Gal(L/K)`, it says `φ(σ P) = -σ(φ P)`,
+which is the classical description of the twist by Galois descent: `Eᴸ` is the descent to `K`
+of `E ×_K L` along the twisted action `σ ↦ (-1) ∘ σ`.
+
+Concretely, when `char K ≠ 2` we may complete the square and assume
+`E : y² = x³ + a₂x² + a₄x + a₆`, and `L = K(√d)`; then `Eᴸ : y² = x³ + da₂x² + d²a₄x + d³a₆`,
+with isomorphism `φ : (x, y) ↦ (x/d, y/(d√d))` over `L`.
+
+## The generality
+
+Twisting by a separable quadratic extension `L/K` is the right generality for quadratic twists,
+uniformly in all characteristics:
+
+* Quadratic twists of `E/K` are classified by the continuous characters
+  `χ : Gal(Kˢᵉᵖ/K) → {±1} = μ₂ ⊆ Aut(E)`, and by Galois theory the nontrivial such characters
+  correspond exactly to separable quadratic extensions `L/K` (take the fixed field of `ker χ`).
+  In characteristic 2 the separable quadratic extensions are the Artin–Schreier extensions
+  `L = K(℘⁻¹(d))`, which are invisible to the familiar "twist by `d ∈ K^×/(K^×)²`"
+  parametrisation available only when `char K ≠ 2`.
+* Every degree 2 field extension is automatically normal; separability is precisely the
+  condition making `Aut(L/K)` have order 2 rather than 1. An inseparable quadratic extension
+  has trivial automorphism group, hence carries no quadratic character and produces no twist.
+* A mild generalisation, deliberately not adopted here: one can twist by an arbitrary étale
+  quadratic `K`-algebra, allowing the split algebra `K × K` which corresponds to the trivial
+  character and gives back `E` itself. This makes twisting an action of the group
+  `H¹(Gal(Kˢᵉᵖ/K), ℤ/2)` on curves at the cost of formalisation noise; all the content is in
+  the field case.
+* When `j(E) ∈ {0, 1728}` the curve has automorphisms beyond `±1` and hence also quartic,
+  sextic (and, in characteristics 2 and 3, wilder) twists; but the *quadratic* twist by `L/K`,
+  i.e. by the cocycle valued in `{±1} ⊆ Aut(E)`, is defined for every `E`, and everything below
+  except the two classification statements holds with no hypothesis on `j`.
+
+## Main definitions and statements
+
+The basic algebraic theory of the twist is carried out in full: the explicit Weierstrass model
+(`quadraticTwistOf`, `quadraticTwistBy`), its ellipticity, its independence of the choice of
+generator of `L/K` (`exists_smul_quadraticTwistBy_eq`), the invariance of the `j`-invariant
+(`j_quadraticTwist`), and the fact that twisting is an involution up to `K`-isomorphism
+(`exists_smul_quadraticTwist_quadraticTwist_eq`). The Galois-theoretic statements — the
+isomorphism on points over `L` and its `χ`-twisted equivariance, the classification of forms
+of `E`, and the reduction-theoretic statements — are `sorry`ed targets.
+
+* `quadraticCharacter K L M` : the quadratic character `Aut(M/K) →* {±1} = ℤˣ` attached to a
+  separable quadratic subextension `K ⊆ L ⊆ M`.
+* `WeierstrassCurve.quadraticTwistOf`, `WeierstrassCurve.quadraticTwistBy` and
+  `WeierstrassCurve.quadraticTwist E L` : an explicit Weierstrass model of the quadratic twist,
+  uniform in the characteristic — parametrised respectively by a pair `(t, n)`, by a generator
+  `θ` of `L/K` (with `t`, `n` its trace and norm), and by the extension `L/K` itself.
+* `WeierstrassCurve.quadraticTwistPointEquiv E L M` : the isomorphism `Eᴸ(M) ≅ E(M)` of groups
+  of `M`-points, for every field `M` in a tower `K ⊆ L ⊆ M`, natural in `M`
+  (`quadraticTwistPointEquiv_map`).
+* `WeierstrassCurve.quadraticTwistPointEquiv_galois` : the key statement
+  `φ(σ P) = χ(σ) • σ(φ P)` above.
+* `WeierstrassCurve.exists_smul_eq_or_exists_smul_eq_quadraticTwist` : for `j(E) ∉ {0, 1728}`,
+  a curve over `K` becoming isomorphic to `E` over `L` is isomorphic over `K` to `E` or to its
+  quadratic twist.
+* `WeierstrassCurve.exists_quadraticTwist_hasSplitMultiplicativeReduction` : over the fraction
+  field of a discrete valuation ring, an elliptic curve with nonsplit multiplicative reduction
+  has a quadratic twist with split multiplicative reduction.
+
+## Design notes
+
+* "Separable quadratic extension" is spelled as the pair of mathlib typeclasses
+  `[Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L]` (the former is free of rank
+  2, which over a field just means `[L:K] = 2`).
+* A Weierstrass model of the twist is well defined only up to `K`-isomorphism, i.e. up to the
+  action of `WeierstrassCurve.VariableChange K` (over a field, isomorphisms of Weierstrass
+  curves are exactly the admissible changes of variables), and the isomorphism `φ` over `L` is
+  well defined only up to composition with an `L`-automorphism of `E`. Here `quadraticTwist`
+  is an explicit model, depending on a choice of generator of `L/K` which is harmless by
+  `exists_smul_quadraticTwistBy_eq`, while `quadraticTwistPointEquiv` is a `sorry`ed *choice*,
+  pinned down up to exactly this ambiguity by the theorems about it. Note that
+  `quadraticTwistPointEquiv_galois` is insensitive to replacing `φ` by `-φ`, so the sign
+  ambiguity in `φ` (which is the whole ambiguity, generically) is harmless.
+* The isomorphism over `L` is recorded twice: once at the level of Weierstrass equations, as a
+  change of variables over `L` (`exists_smul_quadraticTwist_baseChange_eq`), and once at the
+  level of points, as an `AddEquiv` on `M`-points for every `M` in a tower `K ⊆ L ⊆ M`,
+  natural for `L`-algebra maps (`quadraticTwistPointEquiv_map`). The point-level form is the
+  one consumed by Galois representations.
+
+## TODO
+
+* Explicit Artin–Schreier formulas for the twist in characteristic 2 (twisting
+  `y² + a₁xy + a₃y = x³ + ⋯` by `L = K(℘⁻¹(d))` modifies `a₂` by `d·a₁²`, etc.), analogous to
+  `quadraticTwist_of_two_ne_zero` below.
+* Galois descent for points, `E(K) ≃ E(L)^{Gal(L/K)}`, and the resulting statement that
+  `E(K) × Eᴸ(K) → E(L)` has kernel and cokernel killed by 2; over a number field this gives
+  `rank E(L) = rank E(K) + rank Eᴸ(K)`.
+* Behaviour of reduction types under twisting in general: over the fraction field of a DVR, an
+  unramified quadratic twist preserves good and multiplicative reduction (exchanging split and
+  nonsplit), while a ramified quadratic twist of a curve with good or multiplicative reduction
+  has additive reduction (at least in residue characteristic ≠ 2).
+* Compatibility with the Tate curve (`FLT.KnownIn1980s.EllipticCurves.TateCurve`): for `E` with
+  nonsplit multiplicative reduction over a nonarchimedean local field, the Galois representation
+  of `E` is the unramified quadratic twist of the Tate-curve representation of its split twist.
+  This is the main FLT-facing application of this file together with
+  `exists_quadraticTwist_hasSplitMultiplicativeReduction`.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.§10, X.§2 and X.§5
+* [J.-P. Serre, *Propriétés galoisiennes des points d'ordre fini des courbes elliptiques*],
+  §5.3 (for the interaction of twists with reduction types)
+
+-/
+
+open scoped WeierstrassCurve.Affine -- `(E⁄K).Point` notation for the group of `K`-points
+
+/-! ### Separable quadratic extensions and their quadratic characters
+
+Mathlib's `Algebra.IsQuadraticExtension K L` says that `L` is free of rank 2 over `K`, so for
+field extensions it just means `[L:K] = 2`; we add separability as a further hypothesis
+`Algebra.IsSeparable K L` throughout. -/
+
+section QuadraticCharacter
+
+variable (K L : Type*) [Field K] [Field L] [Algebra K L]
+  [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L]
+
+-- Note that mathlib already knows the basic facts about this situation: `L/K` is
+-- finite (`Module.Finite` from `Algebra.IsQuadraticExtension`), normal
+-- (`Algebra.IsQuadraticExtension.normal`) and hence Galois
+-- (`Algebra.IsQuadraticExtension.isGalois`), with cyclic Galois group
+-- (`Algebra.IsQuadraticExtension.isCyclic`) of order 2 (`IsGalois.card_aut_eq_finrank`
+-- plus `Algebra.IsQuadraticExtension.finrank_eq_two`).
+
+/-- A separable quadratic extension has exactly two automorphisms. -/
+theorem Algebra.IsQuadraticExtension.card_algEquiv : Nat.card (L ≃ₐ[K] L) = 2 := by
+  rw [IsGalois.card_aut_eq_finrank]
+  exact finrank_eq_two K L
+
+/-- A separable quadratic extension has a nontrivial automorphism. -/
+theorem Algebra.IsQuadraticExtension.exists_algEquiv_ne_one : ∃ σ : L ≃ₐ[K] L, σ ≠ 1 :=
+  ((Nat.card_eq_two_iff' 1).mp (card_algEquiv K L)).exists
+
+/-- The only automorphisms of a separable quadratic extension are the identity and any given
+nontrivial automorphism. -/
+theorem Algebra.IsQuadraticExtension.algEquiv_eq_one_or_eq {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1)
+    (φ : L ≃ₐ[K] L) : φ = 1 ∨ φ = σ := by
+  rcases eq_or_ne φ 1 with h1 | h1
+  · exact Or.inl h1
+  · exact Or.inr (((Nat.card_eq_two_iff' 1).mp (card_algEquiv K L)).unique h1 hσ)
+
+omit [Algebra.IsSeparable K L] in
+/-- A quadratic extension contains an element not in the base field. (Used to choose a
+generator of `L/K` in the definition of the quadratic twist below.) -/
+theorem Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap :
+    ∃ θ : L, θ ∉ Set.range (algebraMap K L) := by
+  by_contra! h
+  have hbot : (⊥ : Subalgebra K L) = ⊤ :=
+    Algebra.eq_top_iff.mpr fun x ↦ Algebra.mem_bot.mpr (h x)
+  have h1 := Subalgebra.bot_eq_top_iff_finrank_eq_one.mp hbot
+  have h2 := Algebra.IsQuadraticExtension.finrank_eq_two K L
+  omega
+
+open Classical in
+/-- The automorphism group of a separable quadratic extension consists of the identity and one
+nontrivial element. -/
+theorem Algebra.IsQuadraticExtension.univ_algEquiv {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) :
+    (Finset.univ : Finset (L ≃ₐ[K] L)) = {1, σ} := by
+  symm
+  rw [Finset.eq_univ_iff_forall]
+  intro φ
+  rw [Finset.mem_insert, Finset.mem_singleton]
+  exact algEquiv_eq_one_or_eq K L hσ φ
+
+/-- In a separable quadratic extension, the trace of `x` is `x + σx`, where `σ` is the
+nontrivial automorphism. -/
+theorem Algebra.IsQuadraticExtension.algebraMap_trace_eq_add {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1)
+    (x : L) : algebraMap K L (Algebra.trace K L x) = x + σ x := by
+  classical
+  rw [trace_eq_sum_automorphisms, univ_algEquiv K L hσ, Finset.sum_pair (Ne.symm hσ)]
+  simp
+
+/-- In a separable quadratic extension, the norm of `x` is `x * σx`, where `σ` is the
+nontrivial automorphism. -/
+theorem Algebra.IsQuadraticExtension.algebraMap_norm_eq_mul {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1)
+    (x : L) : algebraMap K L (Algebra.norm K x) = x * σ x := by
+  classical
+  rw [Algebra.norm_eq_prod_automorphisms, univ_algEquiv K L hσ, Finset.prod_pair (Ne.symm hσ)]
+  simp
+
+/-- The nontrivial automorphism of a separable quadratic extension moves every element
+lying outside the base field. -/
+theorem Algebra.IsQuadraticExtension.algEquiv_apply_ne {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {x : L}
+    (hx : x ∉ Set.range (algebraMap K L)) : σ x ≠ x := by
+  intro heq
+  refine hx ((IsGalois.mem_range_algebraMap_iff_fixed x).mpr fun φ ↦ ?_)
+  rcases algEquiv_eq_one_or_eq K L hσ φ with h | h <;> subst h
+  · exact AlgEquiv.one_apply x
+  · exact heq
+
+/-- If `θ` generates a separable quadratic extension of `K` — that is, lies outside `K` — and
+`t`, `n` denote its trace and norm, so that `θ² = tθ - n`, then the discriminant `t² - 4n` of
+the minimal polynomial of `θ` is nonzero. (Over the nontrivial automorphism `σ` it equals
+`(θ - σθ)²` with `σθ ≠ θ`. In characteristic 2 the statement says `t ≠ 0`: separable quadratic
+extensions are Artin–Schreier extensions.) -/
+theorem Algebra.IsQuadraticExtension.discrim_ne_zero {θ : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) :
+    Algebra.trace K L θ ^ 2 - 4 * Algebra.norm K θ ≠ 0 := by
+  obtain ⟨σ, hσ⟩ := exists_algEquiv_ne_one K L
+  intro h0
+  have h1 : (θ - σ θ) ^ 2 = 0 := by
+    have h2 := congrArg (algebraMap K L) h0
+    simp only [map_sub, map_pow, map_mul, map_zero, map_ofNat,
+      algebraMap_trace_eq_add K L hσ, algebraMap_norm_eq_mul K L hσ] at h2
+    linear_combination h2
+  exact algEquiv_apply_ne K L hσ hθ
+    (sub_eq_zero.mp (pow_eq_zero_iff (two_ne_zero) |>.mp h1)).symm
+
+omit [Algebra.IsSeparable K L] in
+/-- Any element of a quadratic extension `L/K` is a `K`-linear combination of `1` and a given
+generator `θ`, and the `θ`-coefficient is nonzero if the element also lies outside `K`. -/
+theorem Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul {θ θ' : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) (hθ' : θ' ∉ Set.range (algebraMap K L)) :
+    ∃ a b : K, a ≠ 0 ∧ θ' = algebraMap K L b + algebraMap K L a * θ := by
+  have hθ0 : θ ≠ 0 := fun h ↦ hθ ⟨0, by rw [map_zero, h]⟩
+  have hli : LinearIndependent K ![(1 : L), θ] := by
+    rw [linearIndependent_fin2]
+    simp only [Matrix.cons_val_one, Matrix.cons_val_zero]
+    refine ⟨hθ0, fun c hc ↦ ?_⟩
+    rcases eq_or_ne c 0 with rfl | hc0
+    · rw [zero_smul] at hc
+      exact one_ne_zero hc.symm
+    · refine hθ ⟨c⁻¹, ?_⟩
+      rw [map_inv₀]
+      rw [Algebra.smul_def] at hc
+      exact (eq_inv_of_mul_eq_one_right hc).symm
+  have hmem : θ' ∈ Submodule.span K (Set.range ![(1 : L), θ]) := by
+    rw [hli.span_eq_top_of_card_eq_finrank
+      (by rw [Fintype.card_fin]; exact (finrank_eq_two K L).symm)]
+    trivial
+  rw [Matrix.range_cons_cons_empty, Submodule.mem_span_pair] at hmem
+  obtain ⟨c, d, hcd⟩ := hmem
+  refine ⟨d, c, fun hd ↦ hθ' ⟨c, ?_⟩, ?_⟩
+  · rw [← hcd, hd, zero_smul, add_zero, Algebra.algebraMap_eq_smul_one]
+  · rw [← hcd, Algebra.smul_def, Algebra.smul_def, mul_one]
+
+-- Let `M` be a field extension of `L`, for example `L` itself or a separable closure of `K`.
+variable (M : Type*) [Field M] [Algebra K M] [Algebra L M] [IsScalarTower K L M]
+
+open Classical in
+/-- The quadratic character of `Aut(M/K)` attached to a separable quadratic subextension
+`K ⊆ L ⊆ M`: it sends `σ` to `1` if `σ` fixes `L` pointwise, and to `-1` otherwise.
+
+Since `L/K` is normal, every `K`-automorphism of `M` maps `L` to `L`, and multiplicativity
+(`map_mul'`) follows because restriction to `L` is a homomorphism to the order 2 group
+`Gal(L/K)`. Taking `M = L` gives the quadratic character of `Gal(L/K)` itself; if `M/K` is
+normal then this character is the composite of the restriction `Aut(M/K) → Gal(L/K)` with the
+unique isomorphism `Gal(L/K) ≃ {±1}`, and in particular is surjective
+(`quadraticCharacter_surjective`). -/
+noncomputable def quadraticCharacter : (M ≃ₐ[K] M) →* ℤˣ where
+  toFun σ := if ∀ x : L, σ (algebraMap L M x) = algebraMap L M x then 1 else -1
+  map_one' := sorry
+  map_mul' := sorry
+
+theorem quadraticCharacter_eq_one_iff (σ : M ≃ₐ[K] M) :
+    quadraticCharacter K L M σ = 1 ↔ ∀ x : L, σ (algebraMap L M x) = algebraMap L M x :=
+  sorry
+
+/-- If `M/K` is normal (for example `M = L`, or `M` a separable closure of `K`) then the
+nontrivial element of `Gal(L/K)` extends to an automorphism of `M`, so the quadratic character
+of `Aut(M/K)` attached to `L/K` is surjective. -/
+theorem quadraticCharacter_surjective [Normal K M] :
+    Function.Surjective (quadraticCharacter K L M) :=
+  sorry
+
+end QuadraticCharacter
+
+/-! ### The quadratic twist -/
+
+namespace WeierstrassCurve
+
+universe u
+
+variable {K : Type u} [Field K]
+
+section QuadraticTwistOf
+
+variable (E : WeierstrassCurve K)
+
+/-- The quadratic twist of a Weierstrass curve `E` over `K` by parameters `t`, `n`, to be
+thought of as the trace and norm of a generator `θ` of a separable quadratic extension `L/K`
+(see `WeierstrassCurve.quadraticTwistBy`), so that `θ² = tθ - n` and `D := t² - 4n` is the
+discriminant of the minimal polynomial of `θ`, nonzero exactly when `θ` is separable.
+
+The construction: writing the equation of `E` as `y² + A(x)y = f(x)` with `A(x) = a₁x + a₃`,
+the functions `x` and `Y := (t - 2θ)y - θ·A(x)` on `E` are invariant under the Galois action
+twisted by the quadratic character of `L/K`, and satisfy
+`Y² + t·A(x)·Y = D·(y² + A(x)y) - n·A(x)²`; clearing denominators via `(x, Y) ↦ (Dx, DY)`
+turns this relation into the Weierstrass model below of the twist:
+
+`y² + ta₁·xy + Dta₃·y = x³ + (Da₂ - na₁²)·x² + (D²a₄ - 2Dna₁a₃)·x + (D³a₆ - D²na₃²)`.
+
+Its discriminant is `D⁶·Δ(E)` (`Δ_quadraticTwistOf`), so the twist of an elliptic curve is
+elliptic when `D ≠ 0` (`isElliptic_quadraticTwistOf`), with the same `j`-invariant
+(`j_quadraticTwistOf`).
+
+Sanity checks. If `char K ≠ 2` we may take `θ = √d`, so `t = 0`, `n = -d`, `D = 4d`; for
+`E : y² = x³ + a₂x² + a₄x + a₆` the model is `y² = x³ + 4da₂x² + 16d²a₄x + 64d³a₆`, the
+classical twist by `4d ≡ d mod (K^×)²`. If `char K = 2` we may take `θ` with `θ² + θ = d`
+(Artin–Schreier), so `t = 1`, `n = -d`, `D = 1`; for ordinary `E : y² + xy = x³ + a₂x² + a₆`
+the model is the classical twist `y² + xy = x³ + (a₂ + d)x² + a₆`, and for supersingular
+`E : y² + a₃y = x³ + a₄x + a₆` it is `y² + a₃y = x³ + a₄x + (a₆ + da₃²)`. -/
+def quadraticTwistOf (t n : K) : WeierstrassCurve K where
+  a₁ := t * E.a₁
+  a₂ := (t ^ 2 - 4 * n) * E.a₂ - n * E.a₁ ^ 2
+  a₃ := (t ^ 2 - 4 * n) * t * E.a₃
+  a₄ := (t ^ 2 - 4 * n) ^ 2 * E.a₄ - 2 * (t ^ 2 - 4 * n) * n * E.a₁ * E.a₃
+  a₆ := (t ^ 2 - 4 * n) ^ 3 * E.a₆ - (t ^ 2 - 4 * n) ^ 2 * n * E.a₃ ^ 2
+
+variable (t n : K)
+
+theorem c₄_quadraticTwistOf : (E.quadraticTwistOf t n).c₄ = (t ^ 2 - 4 * n) ^ 2 * E.c₄ := by
+  simp only [quadraticTwistOf, c₄, b₂, b₄]
+  ring
+
+theorem Δ_quadraticTwistOf : (E.quadraticTwistOf t n).Δ = (t ^ 2 - 4 * n) ^ 6 * E.Δ := by
+  simp only [quadraticTwistOf, Δ, b₂, b₄, b₆, b₈]
+  ring
+
+theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : t ^ 2 - 4 * n ≠ 0) :
+    (E.quadraticTwistOf t n).IsElliptic := by
+  rw [isElliptic_iff, Δ_quadraticTwistOf]
+  exact (isUnit_iff_ne_zero.mpr (pow_ne_zero 6 hD)).mul E.isUnit_Δ
+
+theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
+    (E.quadraticTwistOf t n).j = E.j := by
+  have hD : t ^ 2 - 4 * n ≠ 0 := by
+    intro h0
+    have hu := (E.quadraticTwistOf t n).isUnit_Δ
+    rw [Δ_quadraticTwistOf, h0] at hu
+    simp at hu
+  have hΔ : E.Δ ≠ 0 := E.isUnit_Δ.ne_zero
+  simp only [j, Units.val_inv_eq_inv_val, coe_Δ', Δ_quadraticTwistOf, c₄_quadraticTwistOf]
+  field_simp
+
+/-- Twisting twice by the same parameters `(t, n)` gives a curve isomorphic to `E` over `K`:
+explicitly, the double twist is obtained from `E` by the change of variables
+`(x, y) ↦ (D²x, D³y + 2nD²(a₁x + a₃))`, where `D = t² - 4n`. -/
+theorem exists_smul_eq_quadraticTwistOf_quadraticTwistOf (hD : t ^ 2 - 4 * n ≠ 0) :
+    ∃ C : VariableChange K, C • E = (E.quadraticTwistOf t n).quadraticTwistOf t n := by
+  refine ⟨⟨(Units.mk0 _ hD)⁻¹, 0, 2 * n / (t ^ 2 - 4 * n) * E.a₁,
+    2 * n / (t ^ 2 - 4 * n) * E.a₃⟩, ?_⟩
+  rw [variableChange_def]
+  ext <;> simp only [quadraticTwistOf, inv_inv, Units.val_mk0] <;> field_simp <;> ring
+
+/-- Changing the parameters `(t, n)` — the trace and norm of a generator `θ` of a quadratic
+extension — into the trace and norm `(at + 2b, b² + abt + a²n)` of another generator `aθ + b`
+changes the quadratic twist by an explicit change of variables over `K`. -/
+theorem exists_smul_quadraticTwistOf_eq {a : K} (b : K) (ha : a ≠ 0) :
+    ∃ C : VariableChange K, C • E.quadraticTwistOf t n
+      = E.quadraticTwistOf (a * t + 2 * b) (b ^ 2 + a * b * t + a ^ 2 * n) := by
+  refine ⟨⟨(Units.mk0 a ha)⁻¹, 0, a⁻¹ * b * E.a₁, a⁻¹ * b * (t ^ 2 - 4 * n) * E.a₃⟩, ?_⟩
+  rw [variableChange_def]
+  ext <;> simp only [quadraticTwistOf, inv_inv, Units.val_mk0] <;> field_simp <;> ring
+
+end QuadraticTwistOf
+
+section QuadraticTwistBy
+
+variable {L : Type*} [Field L] [Algebra K L] (E : WeierstrassCurve K)
+
+/-- The quadratic twist of a Weierstrass curve `E` over `K` by an element `θ` of an extension
+`L/K`: the twist `WeierstrassCurve.quadraticTwistOf` by the trace and norm of `θ`. This is "the"
+quadratic twist of `E` by the extension `L/K` whenever `L/K` is separable quadratic and `θ`
+generates it, i.e. `θ ∉ K`; the choice of generator does not matter, up to isomorphism over `K`
+(`exists_smul_quadraticTwistBy_eq`). -/
+noncomputable def quadraticTwistBy (θ : L) : WeierstrassCurve K :=
+  E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)
+
+variable [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L]
+
+theorem isElliptic_quadraticTwistBy [E.IsElliptic] {θ : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) : (E.quadraticTwistBy θ).IsElliptic :=
+  E.isElliptic_quadraticTwistOf _ _ (Algebra.IsQuadraticExtension.discrim_ne_zero K L hθ)
+
+/-- The quadratic twist by a generator `θ` of a separable quadratic extension `L/K` depends on
+the choice of `θ` only up to isomorphism over `K`: all generators give isomorphic twists. -/
+theorem exists_smul_quadraticTwistBy_eq {θ θ' : L} (hθ : θ ∉ Set.range (algebraMap K L))
+    (hθ' : θ' ∉ Set.range (algebraMap K L)) :
+    ∃ C : VariableChange K, C • E.quadraticTwistBy θ = E.quadraticTwistBy θ' := by
+  obtain ⟨a, b, ha, rfl⟩ :=
+    Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul K L hθ hθ'
+  obtain ⟨σ, hσ⟩ := Algebra.IsQuadraticExtension.exists_algEquiv_ne_one K L
+  have ht' : Algebra.trace K L (algebraMap K L b + algebraMap K L a * θ)
+      = a * Algebra.trace K L θ + 2 * b := by
+    apply FaithfulSMul.algebraMap_injective K L
+    simp only [map_add, map_mul, map_ofNat,
+      Algebra.IsQuadraticExtension.algebraMap_trace_eq_add K L hσ, AlgEquiv.commutes]
+    ring
+  have hn' : Algebra.norm K (algebraMap K L b + algebraMap K L a * θ)
+      = b ^ 2 + a * b * Algebra.trace K L θ + a ^ 2 * Algebra.norm K θ := by
+    apply FaithfulSMul.algebraMap_injective K L
+    simp only [map_add, map_mul, map_pow,
+      Algebra.IsQuadraticExtension.algebraMap_trace_eq_add K L hσ,
+      Algebra.IsQuadraticExtension.algebraMap_norm_eq_mul K L hσ, AlgEquiv.commutes]
+    ring
+  simp only [quadraticTwistBy, ht', hn']
+  exact E.exists_smul_quadraticTwistOf_eq _ _ b ha
+
+end QuadraticTwistBy
+
+/-- The quadratic twist of an elliptic curve `E` over `K` by a separable quadratic extension
+`L/K`: the twist `WeierstrassCurve.quadraticTwistBy` by an arbitrarily chosen generator
+`θ ∈ L ∖ K`. The twist is independent of this choice up to isomorphism over `K`
+(`exists_smul_quadraticTwist_eq_quadraticTwistBy`), that is, up to the action of
+`WeierstrassCurve.VariableChange K`; see `WeierstrassCurve.quadraticTwistOf` for the explicit
+Weierstrass model. -/
+noncomputable def quadraticTwist (E : WeierstrassCurve K) (L : Type*) [Field L] [Algebra K L]
+    [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L] : WeierstrassCurve K :=
+  E.quadraticTwistBy (Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L).choose
+
+-- Let `E/K` be an elliptic curve and let `L/K` be a separable quadratic extension.
+variable (E : WeierstrassCurve K) [E.IsElliptic]
+variable (L : Type*) [Field L] [Algebra K L]
+  [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L]
+
+/-- The quadratic twist of an elliptic curve is an elliptic curve: the twisted model has
+discriminant `D⁶·Δ(E)`, and `D ≠ 0` by separability
+(`Algebra.IsQuadraticExtension.discrim_ne_zero`). -/
+instance : (E.quadraticTwist L).IsElliptic :=
+  E.isElliptic_quadraticTwistBy
+    (Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L).choose_spec
+
+omit [E.IsElliptic] in
+/-- The quadratic twist of `E` by `L/K` is isomorphic over `K` to the twist by any given
+generator `θ ∈ L ∖ K`: the arbitrary choice made in its definition is harmless. -/
+theorem exists_smul_quadraticTwist_eq_quadraticTwistBy {θ : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) :
+    ∃ C : VariableChange K, C • E.quadraticTwist L = E.quadraticTwistBy θ :=
+  E.exists_smul_quadraticTwistBy_eq
+    (Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L).choose_spec hθ
+
+/-- The quadratic twist becomes isomorphic to `E` after base change to `L`. (Over a field,
+isomorphisms of Weierstrass curves are exactly the admissible changes of variables
+`WeierstrassCurve.VariableChange`, acting via `•`.) The point-level consequences of this
+isomorphism, which is what most applications need, are recorded separately in
+`quadraticTwistPointEquiv` below. -/
+theorem exists_smul_quadraticTwist_baseChange_eq :
+    ∃ C : VariableChange L, C • (E.quadraticTwist L).baseChange L = E.baseChange L :=
+  sorry
+
+/-- Twisting does not change the `j`-invariant, since the curves become isomorphic over `L`. -/
+theorem j_quadraticTwist : (E.quadraticTwist L).j = E.j :=
+  E.j_quadraticTwistOf _ _ (E.isElliptic_quadraticTwistOf _ _
+    (Algebra.IsQuadraticExtension.discrim_ne_zero K L
+      (Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L).choose_spec))
+
+omit [E.IsElliptic] in
+/-- Twisting twice by the same quadratic extension gives back `E`, up to `K`-isomorphism.
+(Both twists are taken with respect to the same chosen generator of `L/K`, which is harmless
+by `exists_smul_quadraticTwist_eq_quadraticTwistBy`.) -/
+theorem exists_smul_quadraticTwist_quadraticTwist_eq :
+    ∃ C : VariableChange K, C • (E.quadraticTwist L).quadraticTwist L = E := by
+  obtain ⟨C, hC⟩ := E.exists_smul_eq_quadraticTwistOf_quadraticTwistOf _ _
+    (Algebra.IsQuadraticExtension.discrim_ne_zero K L
+      (Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L).choose_spec)
+  refine ⟨C⁻¹, ?_⟩
+  have h2 : C⁻¹ • (C • E) = E := inv_smul_smul C E
+  rw [hC] at h2
+  exact h2
+
+/-- If `j(E) ∉ {0, 1728}` (so that the only automorphisms of `E` are `±1`) then the quadratic
+twist is *not* isomorphic to `E` over `K`: twisting by `L/K` is a nontrivial operation. This can
+fail for `j ∈ {0, 1728}`: e.g. for `E : y² = x³ + x` of `j`-invariant `1728` over `K = ℚ(i)`,
+the quadratic twist by any `L = K(d^{1/2})` with `d ∈ (K^×)⁴ ∖ (K^×)²` is isomorphic to `E`
+over `K`, because `E` admits the automorphism `(x, y) ↦ (-x, iy)` of order 4. -/
+theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728) :
+    ¬∃ C : VariableChange K, C • E.quadraticTwist L = E :=
+  sorry
+
+/-- Classification of the forms of `E` split by `L/K`, for `j(E) ∉ {0, 1728}`: an elliptic curve
+over `K` which becomes isomorphic to `E` over `L` is isomorphic over `K` either to `E` or to its
+quadratic twist by `L`. (Such forms are classified by
+`H¹(Gal(L/K), Aut(E_L)) = Hom(ℤ/2, {±1})`, which has order 2. For `j ∈ {0, 1728}` the
+automorphism group is larger and there can be more forms; the statement including these `j` is
+left as a further target.) Together with `not_exists_smul_quadraticTwist_eq` this pins down
+`E.quadraticTwist L` up to `K`-isomorphism. -/
+theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
+    (E' : WeierstrassCurve K) [E'.IsElliptic]
+    (h : ∃ C : VariableChange L, C • E'.baseChange L = E.baseChange L) :
+    (∃ C : VariableChange K, C • E' = E) ∨ ∃ C : VariableChange K, C • E' = E.quadraticTwist L :=
+  sorry
+
+/-- The classical formula for the quadratic twist away from characteristic 2. Suppose
+`char K ≠ 2`, so that after completing the square we may assume `E` has the form
+`y² = x³ + a₂x² + a₄x + a₆`, and suppose `L = K(α)` where `α² = d` is a nonsquare in `K` (every
+separable quadratic extension arises this way when `char K ≠ 2`). Then the quadratic twist of
+`E` by `L` is `y² = x³ + da₂x² + d²a₄x + d³a₆`, up to `K`-isomorphism. -/
+theorem quadraticTwist_of_two_ne_zero (h2 : (2 : K) ≠ 0) (ha₁ : E.a₁ = 0) (ha₃ : E.a₃ = 0)
+    {d : K} (hd : ¬IsSquare d) {α : L} (hα : α ^ 2 = algebraMap K L d) :
+    ∃ C : VariableChange K, C • E.quadraticTwist L =
+      { a₁ := 0, a₂ := d * E.a₂, a₃ := 0, a₄ := d ^ 2 * E.a₄, a₆ := d ^ 3 * E.a₆ } :=
+  sorry
+
+/-! ### The isomorphism on points and its Galois anti-equivariance -/
+
+section PointEquiv
+
+-- Let `M` be a field extension of `L`, for example `L` itself or a separable closure of `K`.
+-- `DecidableEq` is needed for the group structure on points.
+variable (M : Type*) [Field M] [Algebra K M] [Algebra L M] [IsScalarTower K L M] [DecidableEq M]
+
+/-- The isomorphism `Eᴸ(M) ≅ E(M)` on `M`-points, for any field `M` in a tower `K ⊆ L ⊆ M`:
+the base change to `M` of a choice of isomorphism between `Eᴸ` and `E` over `L`. It is natural
+in `M` (`quadraticTwistPointEquiv_map`) and transforms the Galois action into the Galois action
+twisted by the quadratic character of `L/K` (`quadraticTwistPointEquiv_galois`).
+
+Like the twist itself, this isomorphism is well defined only up to composition with an
+`L`-automorphism of `E` — generically, up to sign — and this definition makes an arbitrary but
+single choice, consistent across all `M`. -/
+noncomputable def quadraticTwistPointEquiv :
+    ((E.quadraticTwist L)⁄M).Point ≃+ (E⁄M).Point :=
+  sorry
+
+/-- Naturality of `quadraticTwistPointEquiv` in `M`: the isomorphisms on `M`-points over varying
+`M ⊇ L` are all induced by a single isomorphism of curves over `L`, so they commute with the
+maps on points induced by any `L`-algebra homomorphism. -/
+theorem quadraticTwistPointEquiv_map {N : Type*} [Field N] [Algebra K N] [Algebra L N]
+    [IsScalarTower K L N] [DecidableEq N] (f : M →ₐ[L] N)
+    (P : ((E.quadraticTwist L)⁄M).Point) :
+    E.quadraticTwistPointEquiv L N (Affine.Point.map f P) =
+      Affine.Point.map f (E.quadraticTwistPointEquiv L M P) :=
+  sorry
+
+/-- **Twisting the Galois action.** The Galois action on the points of the quadratic twist is
+the Galois action on the points of `E`, twisted by the quadratic character of `L/K`: for
+`σ ∈ Aut(M/K)`, transporting the action of `σ` on `Eᴸ(M)` through `Eᴸ(M) ≅ E(M)` gives `χ(σ)`
+times the action of `σ` on `E(M)`.
+
+Taking `M` to be a separable closure of `K`, this says that the Galois representations attached
+to `Eᴸ` (e.g. on torsion points) are those attached to `E`, twisted by `χ`. Taking `M = L` and
+`σ ≠ 1` recovers the classical anti-equivariance of the isomorphism `φ : Eᴸ ≅ E` over `L`
+(see `quadraticTwistPointEquiv_conj`). Note the statement is unchanged under replacing `φ` by
+`-φ`, so it does not depend on the sign choice hidden in `quadraticTwistPointEquiv`. Note also
+that for `σ` fixing `L` pointwise (i.e. `σ ∈ Aut(M/L)`, `χ(σ) = 1`) it is a special case of
+naturality, via the `L`-algebra map underlying `σ`. -/
+theorem quadraticTwistPointEquiv_galois (σ : M ≃ₐ[K] M) (P : ((E.quadraticTwist L)⁄M).Point) :
+    E.quadraticTwistPointEquiv L M (Affine.Point.map σ.toAlgHom P) =
+      (quadraticCharacter K L M σ : ℤ) •
+        Affine.Point.map σ.toAlgHom (E.quadraticTwistPointEquiv L M P) :=
+  sorry
+
+/-- Special case of `quadraticTwistPointEquiv_galois` over `M = L` itself: the isomorphism
+`φ : Eᴸ(L) ≅ E(L)` intertwines the action of the nontrivial element `σ ∈ Gal(L/K)` with `-σ`.
+This is the datum classically used to define the twist by Galois descent. -/
+theorem quadraticTwistPointEquiv_conj [DecidableEq L] {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1)
+    (P : ((E.quadraticTwist L)⁄L).Point) :
+    E.quadraticTwistPointEquiv L L (Affine.Point.map σ.toAlgHom P) =
+      -Affine.Point.map σ.toAlgHom (E.quadraticTwistPointEquiv L L P) :=
+  sorry
+
+/-- The rational points of the quadratic twist, viewed inside `E(L)` via the isomorphism over
+`L`, are exactly the points of `E(L)` on which the nontrivial element of `Gal(L/K)` acts as
+`-1` (just as `E(K)` consists of the points on which it acts as `+1`). Combined with Galois
+descent for points this yields, over a number field, `rank E(L) = rank E(K) + rank Eᴸ(K)`. -/
+theorem exists_quadraticTwistPointEquiv_baseChange_eq_iff [DecidableEq K] [DecidableEq L]
+    {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) (P : (E⁄L).Point) :
+    (∃ Q : ((E.quadraticTwist L)⁄K).Point,
+        E.quadraticTwistPointEquiv L L (Affine.Point.baseChange K L Q) = P) ↔
+      Affine.Point.map σ.toAlgHom P = -P :=
+  sorry
+
+end PointEquiv
+
+/-! ### Multiplicative reduction becomes split after a quadratic twist -/
+
+section Reduction
+
+-- Let `R` be a discrete valuation ring with fraction field `K` (for example the ring of
+-- integers of a nonarchimedean local field).
+variable (R : Type*) [CommRing R] [IsDomain R] [IsDiscreteValuationRing R]
+  [Algebra R K] [IsFractionRing R K]
+
+/-- If `E` has multiplicative reduction which is not split, then `E` has a quadratic twist with
+split multiplicative reduction — namely the twist by the unramified quadratic extension of `K`:
+the reduction of the twist is the same nodal cubic with the Galois action on the two tangent
+directions at the node twisted into triviality.
+
+Mathlib's reduction-type predicates apply to a specific Weierstrass equation and require it to
+be minimal, while our chosen model `E.quadraticTwist L` of the twist need not be; so the
+conclusion is phrased via the minimal model `(E.quadraticTwist L).minimal R`. (Being split
+multiplicative is intrinsic, so any other minimal model would do.)
+
+The nonsplitness hypothesis `h` cannot be dropped: if `E` already has split multiplicative
+reduction then *no* quadratic twist of `E` has split multiplicative reduction, since the
+unramified quadratic twist has nonsplit multiplicative reduction and ramified quadratic twists
+have additive reduction. -/
+theorem exists_quadraticTwist_hasSplitMultiplicativeReduction [E.HasMultiplicativeReduction R]
+    (h : ¬E.HasSplitMultiplicativeReduction R) :
+    ∃ (L : Type u) (_ : Field L) (_ : Algebra K L) (_ : Algebra.IsQuadraticExtension K L)
+      (_ : Algebra.IsSeparable K L),
+      ((E.quadraticTwist L).minimal R).HasSplitMultiplicativeReduction R :=
+  sorry
+
+end Reduction
+
+end WeierstrassCurve

--- a/FLT/KnownIn1980s/EllipticCurves/TateCurve.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/TateCurve.lean
@@ -1,0 +1,324 @@
+import Mathlib
+import FLT.KnownIn1980s.EllipticCurves.WeilPairing
+
+/-!
+
+# The Tate curve
+
+Let `k` be a nonarchimedean local field and let `E/k` be an elliptic curve, given by a
+minimal Weierstrass equation, with split multiplicative reduction. Tate's theory attaches
+to `E` a canonical *Tate parameter*, an element `q = q(E)` of `k` with `0 < |q| < 1`, and
+an isomorphism of groups `E(k) ≅ kˣ/qᶻ` (Tate's uniformisation). The construction is
+functorial: if `k → l` is a valuation-compatible morphism of nonarchimedean local fields
+then the base change of `E` to `l` again has split multiplicative reduction, the Tate
+parameter of the base change is the image of `q`, and the uniformisations over `k` and `l`
+fit into a commutative diagram — in general only up to an unremovable sign, but on the nose
+when the morphism is `k`-linear (see `tateEquiv_baseChange` and `tateEquiv_galois`). The
+`k`-linear case gives the Galois-equivariance needed to compute the Galois representations
+attached to `E`.
+
+These results are due to Tate, in a manuscript which
+circulated from the early 1960s and was eventually published in 1995 as *A review of
+non-Archimedean elliptic curves*. See also Roquette, *Analytic theory of elliptic
+functions over local fields* (1970), and Silverman, *Advanced topics in the arithmetic
+of elliptic curves*, V.3 and V.5, for textbook accounts.
+
+## TODO
+
+* **Rank 1 generality.** Tate's theory works over any field complete with respect to a
+  nontrivial rank 1 (i.e. real-valued) nonarchimedean valuation, for example `ℂ_p` or the
+  completion of the maximal unramified extension of `ℚ_p`: completeness and `|q| < 1` are
+  all that is needed for the relevant power series to converge. But right now we can't
+  talk about an elliptic curve over `ℂ_p` having split multiplicative reduction, so we
+  stick to nonarchimedean local fields: mathlib's
+  `WeierstrassCurve.HasSplitMultiplicativeReduction` is defined via minimal Weierstrass
+  equations, and mathlib's `WeierstrassCurve.IsMinimal` requires
+  `IsDiscreteValuationRing` (its existence theorem `exists_isMinimal` is proved by
+  well-foundedness of the value group, which fails for dense value groups).
+
+  Mathematics question: is there a theory of minimal models for elliptic curves
+  with multiplicative reduction over fields complete wrt an arbitrary rank 1 valuation?
+  For additive reduction you have no chance (consider `y² = x³ + p` over `ℂₚ`).
+
+* **Topology.** `tateEquiv` below should be an isomorphism of *topological* groups, where
+  `kˣ/qᶻ` carries the quotient topology and `E(k)` the topology coming from `k`. This
+  cannot currently be stated: mathlib has no topology on `WeierstrassCurve.Affine.Point`
+  (nor on `Projectivization`, from which it could be induced).
+
+* **Signs.** There is a choice of sign for the Tate uniformisation. I propose that we
+  simply use the definition in e.g. Silverman. One could say explicitly what the sign
+  is by asking what the pullback of the invariant differential `dx/(2y + a₁x + a₃)` to
+  `kˣ` is; it will be some constant times `du/u` (for the Tate curve `E_q` itself, with
+  Silverman's series, it is exactly `du/u`).
+-/
+
+open scoped WeierstrassCurve.Affine -- `(E⁄k).Point` notation for the group of `k`-points
+open ValuativeRel -- `𝒪[k]` notation for the ring of integers of `k`, and `valuation`
+
+-- Can be deleted when mathlib#41391 lands
+set_option linter.overlappingInstances false
+
+/-! ### The Tate curve `E_q`
+
+For `q` with `0 < |q| < 1` there is an explicit Weierstrass curve `E_q`, whose coefficients
+are power series in `q` with integer coefficients, together with a uniformisation
+`kˣ/qᶻ ≅ E_q(k)` given by explicit power series `X(u, q)`, `Y(u, q)` — all of it involving
+no choices whatsoever, and commuting on the nose with every valuative morphism of fields.
+The uniformisation of a general `E` with split multiplicative reduction is obtained by
+transporting this one along an isomorphism `E_{q(E)} ≅ E` of Weierstrass curves
+(`exists_variableChange_tateCurve` below), and *that* is the only choice in the theory:
+there are exactly two such isomorphisms, differing by negation.
+-/
+
+section TateCurve
+
+-- For the defining series we only need a topology on the field: this section makes sense
+-- (and the series converge) over any field complete with respect to a rank 1
+-- nonarchimedean valuation, cf. the TODO above.
+variable {k : Type*} [Field k] [TopologicalSpace k]
+
+/-- The coefficient `a₄(q) = -5s₃(q)` of the Tate curve, where
+`sₖ(q) = ∑_{n≥1} nᵏqⁿ/(1-qⁿ)` (Silverman, ATAEC V.3). -/
+noncomputable def WeierstrassCurve.tateA₄ (q : k) : k :=
+  -5 * ∑' n : ℕ, ((n + 1 : ℕ) : k) ^ 3 * q ^ (n + 1) / (1 - q ^ (n + 1))
+
+/-- The coefficient `a₆(q) = -(5s₃(q) + 7s₅(q))/12` of the Tate curve, where
+`sₖ(q) = ∑_{n≥1} nᵏqⁿ/(1-qⁿ)`; the integrality `12 ∣ 5n³ + 7n⁵` makes sense of the
+division by `12` in every characteristic (Silverman, ATAEC V.3). -/
+noncomputable def WeierstrassCurve.tateA₆ (q : k) : k :=
+  ∑' n : ℕ, -(((5 * (n + 1) ^ 3 + 7 * (n + 1) ^ 5) / 12 : ℤ) : k) * q ^ (n + 1) /
+    (1 - q ^ (n + 1))
+
+/-- The Tate curve `E_q : y² + xy = x³ + a₄(q)x + a₆(q)` (Silverman, ATAEC V.3). -/
+noncomputable def WeierstrassCurve.tateCurve (q : k) : WeierstrassCurve k :=
+  ⟨1, 0, 0, tateA₄ q, tateA₆ q⟩
+
+end TateCurve
+
+-- let k be a nonarchimedean local field
+variable {k : Type*} [Field k] [ValuativeRel k] [TopologicalSpace k]
+  [IsNonarchimedeanLocalField k]
+
+-- `DecidableEq k` is needed for the group law on the points
+variable [DecidableEq k] in
+/-- Tate's uniformisation of the Tate curve `E_q`, given by the explicit power series
+`x = X(u, q)`, `y = Y(u, q)` of Silverman, ATAEC V.3. Unlike `tateEquiv` below, this
+involves no choices at all: it commutes on the nose with every valuative field morphism
+(see `tateCurve_baseChange` for the equation-level statement). -/
+noncomputable def WeierstrassCurve.tateCurveEquiv (q : kˣ) (hq : valuation k (q : k) < 1) :
+    Additive (kˣ ⧸ Subgroup.zpowers q) ≃+ ((tateCurve (q : k))⁄k).Point :=
+  sorry
+
+/-- The Tate parameter of an elliptic curve `E`, given by a minimal Weierstrass equation with
+split multiplicative reduction over a nonarchimedean local field `k`. It is the unique element
+`q` of `k` with `0 < |q| < 1` such that `j(E) = j(q) = q⁻¹ + 744 + 196884q + ⋯`; equivalently,
+the unique `q` such that `E(k̄)` is Galois-equivariantly isomorphic to `k̄ˣ/q^ℤ`. (The bare
+existence of an abstract isomorphism `E(k) ≅ kˣ/q^ℤ` would not pin down `q`: already over
+`ℚ_p` the groups `ℚ_pˣ/p^ℤ` and `ℚ_pˣ/(p(1+p))^ℤ` are isomorphic, even topologically.) -/
+noncomputable def WeierstrassCurve.q (E : WeierstrassCurve k) [E.IsElliptic]
+    [E.IsMinimal 𝒪[k]] [E.HasSplitMultiplicativeReduction 𝒪[k]] : k :=
+  sorry
+
+-- Let E/k be an elliptic curve, given by a minimal Weierstrass equation,
+-- with split multiplicative reduction
+variable (E : WeierstrassCurve k) [E.IsElliptic] [E.IsMinimal 𝒪[k]]
+  [E.HasSplitMultiplicativeReduction 𝒪[k]]
+
+theorem WeierstrassCurve.q_ne_zero : E.q ≠ 0 :=
+  sorry
+
+/-- The Tate parameter has norm less than `1`. -/
+theorem WeierstrassCurve.valuation_q_lt_one : valuation k E.q < 1 :=
+  sorry
+
+/-- The Tate parameter as an element of `kˣ`. -/
+noncomputable def WeierstrassCurve.qUnit : kˣ :=
+  Units.mk0 E.q E.q_ne_zero
+
+-- `DecidableEq k` is needed for the group law on `(E⁄k).Point`
+variable [DecidableEq k] in
+/-- Tate's uniformization theorem: if `E/k` is an elliptic curve with split multiplicative
+reduction then `E(k)` is isomorphic to `kˣ/⟨q⟩`.
+-/
+noncomputable def WeierstrassCurve.tateEquiv :
+    Additive (kˣ ⧸ Subgroup.zpowers E.qUnit) ≃+ (E⁄k).Point :=
+  sorry
+
+-- Tate's theorem (Silverman, ATAEC V.5.3): an elliptic curve with split multiplicative
+-- reduction is isomorphic, by a change of Weierstrass coordinates, to the Tate curve of its
+-- Tate parameter. Since `j(E)` is non-integral, `Aut` of the curve is `{±1}` and there are
+-- exactly *two* such `C`, differing by negation. `tateEquiv` is `tateCurveEquiv` transported
+-- along a choice of one of them; this binary choice, for each `E`, is the only choice in
+-- the whole theory, and it cannot be made functorially in `E` — see `tateEquiv_baseChange`.
+theorem WeierstrassCurve.exists_variableChange_tateCurve :
+    ∃ C : VariableChange k, C • tateCurve E.q = E :=
+  sorry
+
+/-! ### Functoriality
+
+Now let `l` be a second nonarchimedean local field and let `k → l` be a morphism of fields
+inducing the valuative relation on `k` from the one on `l` (the `ValuativeExtension`
+hypothesis). The compatibility hypothesis is what makes the morphism continuous, hence
+commute with the power series defining Tate's theory; it is automatic for `k`-embeddings
+between algebraic extensions of `k` (by uniqueness of extensions of valuations over the
+complete field `k`), but not for arbitrary abstract field morphisms.
+-/
+
+variable {l : Type*} [Field l] [ValuativeRel l] [TopologicalSpace l]
+  [IsNonarchimedeanLocalField l] [Algebra k l] [ValuativeExtension k l]
+
+-- The base change of E is elliptic. (Mathlib has this instance for `E.map f`, but
+-- `WeierstrassCurve.baseChange` is a non-reducible `def`, so instance search cannot
+-- see through it.)
+instance : (E.baseChange l).IsElliptic :=
+  inferInstanceAs (E.map (algebraMap k l)).IsElliptic
+
+-- The construction of the Tate curve commutes on the nose with any valuative morphism:
+-- its coefficients are power series in `q` with *integer* coefficients, and a valuative
+-- morphism is continuous, so preserves the sums. The same is true of the uniformisation
+-- `tateCurveEquiv` (a statement we defer, as it needs transport along this equality).
+theorem WeierstrassCurve.tateCurve_baseChange (q : k) :
+    (tateCurve q)⁄l = tateCurve (algebraMap k l q) :=
+  sorry
+
+-- Claude says that the base change of E to l is still given by a minimal Weierstrass equation.
+-- This uses the multiplicative reduction hypothesis (which makes `c₄` a unit): minimality by
+-- itself is not preserved by ramified base change — `y² = x³ + p` is minimal over `ℚ_p` but not
+-- over `ℚ_p(p^{1/6})`.
+instance : (E.baseChange l).IsMinimal 𝒪[l] :=
+  sorry
+
+-- and it still has split multiplicative reduction. (The `IsMinimal` instance argument of
+-- `HasSplitMultiplicativeReduction` is found from the preceding instance.)
+instance : (E.baseChange l).HasSplitMultiplicativeReduction 𝒪[l] :=
+  sorry
+
+-- The Tate parameter pushes forward under base change.
+theorem WeierstrassCurve.q_baseChange : (E.baseChange l).q = algebraMap k l E.q :=
+  sorry
+
+-- The uniformisations of `E` and of its base change fit into a commutative diagram, but only
+-- up to a sign `ε` which cannot in general be removed, whatever choices are made in
+-- `tateEquiv`. It is tempting to think the diagrams must commute on the nose because the
+-- theory is given by universal power series — and for the curves `tateCurve q` themselves
+-- they do. But `tateEquiv` for a general `E` also involves the choice of one of the two
+-- isomorphisms `C : tateCurve E.q ≅ E`, whose scaling parameter is a square root
+-- `u₀ = ±√(c₆(E_q)c₄(E)/(c₆(E)c₄(E_q)))`, and no choice of square roots is Galois-natural.
+-- Concretely: let `E₀/ℚ_p` have *non-split* multiplicative reduction, let `k := ℚ_{p²}`
+-- (the unramified quadratic extension, which splits the reduction), `E := (E₀)_k`, and let
+-- `σ ∈ Gal(k/ℚ_p)` be Frobenius. Take `l := k` with the `Algebra k l` structure given by
+-- `σ` (legal: `σ` is valuative). Then `E.baseChange l = E` and both routes around the
+-- diagram use the *same* uniformisation `E.tateEquiv` — no choice can distinguish them —
+-- while `u₀² ∈ ℚ_p` is a nonsquare (otherwise `E₀` would be split), so `σ(u₀) = -u₀` and
+-- the diagram anticommutes: `ε = -1` is forced.
+-- (When the morphism is `k`-linear the sign disappears: see `tateEquiv_galois` below.)
+variable [DecidableEq k] [DecidableEq l] in
+theorem WeierstrassCurve.tateEquiv_baseChange :
+    ∃ ε : ℤˣ, ∀ u : kˣ,
+      Affine.Point.baseChange (W' := E) k l (E.tateEquiv (Additive.ofMul ↑u)) =
+        (ε : ℤ) • (E.baseChange l).tateEquiv
+          (Additive.ofMul
+            (Units.map (algebraMap k l).toMonoidHom u :
+              lˣ ⧸ Subgroup.zpowers (E.baseChange l).qUnit)) :=
+  sorry
+
+-- Galois equivariance: for a `k`-*algebra* automorphism `σ` of `l` the diagram commutes
+-- with no sign, because `E` and a choice of uniformisation for it already live over `k`,
+-- and `σ` fixes `k`. This is the statement needed to compute the Galois action on the
+-- torsion of `E`. The continuity hypothesis on `σ` is automatic when `l/k` is algebraic
+-- (e.g. a finite extension), by uniqueness of extensions of valuations.
+variable [DecidableEq l] in
+theorem WeierstrassCurve.tateEquiv_galois (σ : l ≃ₐ[k] l) (hσ : Continuous σ) (u : lˣ) :
+    Affine.Point.map (W' := E) σ.toAlgHom
+        ((E.baseChange l).tateEquiv (Additive.ofMul ↑u) : (E⁄l).Point) =
+      (E.baseChange l).tateEquiv
+        (Additive.ofMul ↑(Units.map σ.toAlgHom.toRingHom.toMonoidHom u)) :=
+  sorry
+
+/-! ### Torsion and the Weil pairing
+
+Passing to the limit over the finite subextensions of a separable closure `Ω` of `k`, the
+uniformisations above glue to a Galois-equivariant uniformisation `E(Ω) ≅ Ωˣ/qᶻ`. The
+`N`-torsion of `Ωˣ/qᶻ` is generated by the `N`-th roots of unity and (the classes of) the
+`N`-th roots of `q`, so the uniformisation identifies the `N`-torsion of `E` explicitly:
+this is how one computes the Galois representations attached to `E`.
+
+The identification is compatible with the Weil pairing: with a suitable sign convention in
+the definition of the Weil pairing `e_N`, we have `e_N(ζ, q^{1/N}) = ζ` for every `N`-th
+root of unity `ζ` and every `N`-th root `q^{1/N}` of `q`, where on the left-hand side units
+are identified with points of `E` via the uniformisation. This is the content of
+`weilPairing_tatePoint` below; see the comment there for exactly what this does and
+does not pin down.
+-/
+
+-- Now let `Ω` be a separable closure of `k`. It is not itself a nonarchimedean local field
+-- (it is not complete), so it does not fit the framework above; but `E(Ω)` is the union of
+-- the `E(l)` over the finite subextensions `l/k` of `Ω`, and Tate's theory applies to each.
+variable (Ω : Type*) [Field Ω] [Algebra k Ω] [IsSepClosed Ω] [Algebra.IsSeparable k Ω]
+
+-- the base change of E to Ω is elliptic (same remark as for `l` above)
+instance : (E.baseChange Ω).IsElliptic :=
+  inferInstanceAs (E.map (algebraMap k Ω)).IsElliptic
+
+/-- The image of the Tate parameter in a separable closure `Ω` of `k`, as a unit. (`Ω` is
+not a nonarchimedean local field, so this is not literally `(E.baseChange Ω).qUnit`.) -/
+noncomputable def WeierstrassCurve.qUnitSepClosure : Ωˣ :=
+  Units.map (algebraMap k Ω).toMonoidHom E.qUnit
+
+-- `DecidableEq Ω` is needed for the group law on `(E⁄Ω).Point`
+variable [DecidableEq Ω]
+
+/-- Tate's uniformisation over a separable closure `Ω` of `k`: the union of the
+uniformisations of the `E(l)` over the finite subextensions `l/k` of `Ω`. Its sign is
+pinned to that of `tateEquiv` by `tatePoint_baseChange`. -/
+noncomputable def WeierstrassCurve.tateEquivSepClosure :
+    Additive (Ωˣ ⧸ Subgroup.zpowers (E.qUnitSepClosure Ω)) ≃+ (E⁄Ω).Point :=
+  sorry
+
+/-- The point of `E(Ω)` corresponding to a unit `x ∈ Ωˣ` under Tate's uniformisation. -/
+noncomputable def WeierstrassCurve.tatePoint (x : Ωˣ) : (E⁄Ω).Point :=
+  E.tateEquivSepClosure Ω (Additive.ofMul ↑x)
+
+-- The uniformisations over `k` and over `Ω` commute on the nose, not merely up to sign:
+-- the inclusion `k → Ω` is a `k`-algebra map, so this is an instance of the same
+-- phenomenon as `tateEquiv_galois`, not of `tateEquiv_baseChange`. This statement is what
+-- pins the sign of `tateEquivSepClosure` to the sign of `tateEquiv`.
+variable [DecidableEq k] in
+theorem WeierstrassCurve.tatePoint_baseChange (u : kˣ) :
+    Affine.Point.baseChange (W' := E) k Ω (E.tateEquiv (Additive.ofMul ↑u)) =
+      E.tatePoint Ω (Units.map (algebraMap k Ω).toMonoidHom u) :=
+  sorry
+
+-- Galois equivariance of the uniformisation over `Ω`: no continuity hypothesis is needed
+-- this time, since `Ω/k` is algebraic.
+theorem WeierstrassCurve.tatePoint_galois (σ : Ω ≃ₐ[k] Ω) (u : Ωˣ) :
+    Affine.Point.map (W' := E) σ.toAlgHom (E.tatePoint Ω u) =
+      E.tatePoint Ω (Units.map σ.toAlgHom.toRingHom.toMonoidHom u) :=
+  sorry
+
+/-- `N`-th roots of unity give `N`-torsion points of `E` under Tate's uniformisation. -/
+theorem WeierstrassCurve.tatePoint_mem_torsionBy_of_mem_rootsOfUnity {N : ℕ} {ζ : Ωˣ}
+    (hζ : ζ ∈ rootsOfUnity N Ω) :
+    E.tatePoint Ω ζ ∈ AddSubgroup.torsionBy (E⁄Ω).Point (N : ℤ) :=
+  sorry
+
+/-- `N`-th roots of the Tate parameter give `N`-torsion points of `E` under Tate's
+uniformisation. -/
+theorem WeierstrassCurve.tatePoint_mem_torsionBy_of_pow_eq {N : ℕ} {r : Ωˣ}
+    (hr : r ^ N = E.qUnitSepClosure Ω) :
+    E.tatePoint Ω r ∈ AddSubgroup.torsionBy (E⁄Ω).Point (N : ℤ) :=
+  sorry
+
+-- `weilPairing` and `tateEquiv`/`tateEquivSepClosure` are all currently `sorry`ed data,
+-- each pinned down mathematically only up to a sign. The following compatibility, due to
+-- Tate, is the demand that these signs be chosen coherently. Note that it constrains the
+-- sign convention in the *Weil pairing* (about which the literature does not agree) in
+-- terms of the uniformisation, and not vice versa: by bilinearity `e_N(-P, -Q) = e_N(P, Q)`,
+-- so the demand is insensitive to negating `tateEquivSepClosure`.
+theorem WeierstrassCurve.weilPairing_tatePoint (N : ℕ) [NeZero (N : Ω)] {ζ r : Ωˣ}
+    (hζ : ζ ∈ rootsOfUnity N Ω) (hr : r ^ N = E.qUnitSepClosure Ω) :
+    (E⁄Ω).weilPairing Ω N
+      ⟨E.tatePoint Ω ζ, E.tatePoint_mem_torsionBy_of_mem_rootsOfUnity Ω hζ⟩
+      ⟨E.tatePoint Ω r, E.tatePoint_mem_torsionBy_of_pow_eq Ω hr⟩ =
+    Additive.ofMul (⟨ζ, hζ⟩ : rootsOfUnity N Ω) :=
+  sorry

--- a/FLT/KnownIn1980s/EllipticCurves/TateCurve.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/TateCurve.lean
@@ -1,5 +1,13 @@
-import Mathlib
-import FLT.KnownIn1980s.EllipticCurves.WeilPairing
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Reduction
+public import Mathlib.NumberTheory.LocalField.Basic
+public import FLT.KnownIn1980s.EllipticCurves.WeilPairing
 
 /-!
 
@@ -51,6 +59,8 @@ of elliptic curves*, V.3 and V.5, for textbook accounts.
   `kˣ` is; it will be some constant times `du/u` (for the Tate curve `E_q` itself, with
   Silverman's series, it is exactly `du/u`).
 -/
+
+@[expose] public section
 
 open scoped WeierstrassCurve.Affine -- `(E⁄k).Point` notation for the group of `k`-points
 open ValuativeRel -- `𝒪[k]` notation for the ring of integers of `k`, and `valuation`

--- a/FLT/KnownIn1980s/EllipticCurves/TateCurveConstruction.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/TateCurveConstruction.lean
@@ -1,0 +1,94 @@
+import Mathlib
+
+/-!
+
+# The power series identity underlying the construction of the Tate curve
+
+If `k` is a nonarchimedean local field and `q ∈ kˣ` has `|q| < 1`, then Tate showed
+that `kˣ/qᶻ` is the group of `k`-points of an elliptic curve `E_q/k` with Weierstrass
+equation `y² + xy = x³ + a₄(q)x + a₆(q)`, for certain explicit power series `a₄` and
+`a₆` in `q` with integer coefficients; the map `kˣ → E_q(k)` is given by explicit
+power series `X(u,q)` and `Y(u,q)` in `q` whose coefficients are Laurent polynomials
+in `u`.
+
+The purely algebraic input to this construction is the identity
+`Y² + XY = X³ + a₄X + a₆` in `ℚ(u)⟦q⟧`, which this file states. The identity can be
+extracted from Theorem V.1.1 of [Silverman, *Advanced topics in the arithmetic of
+elliptic curves*], where it is deduced from the complex-analytic theory of the
+Weierstrass ℘-function. See
+https://mathoverflow.net/questions/469021/low-level-proof-of-identity-related-to-weierstrass-p-function
+
+## Implementation notes
+
+We work in `(RatFunc ℚ)⟦X⟧`, formal power series over the field `ℚ(u)` of rational
+functions. Beware of the clash of notation: the power series variable (written `q`
+above and in the references) is `PowerSeries.X`, whereas the rational function
+variable `u` is `RatFunc.X`, and neither has anything to do with the coordinate `X`
+on the curve, which is the power series `TateCurve.X` defined below.
+
+-/
+
+open scoped PowerSeries -- `R⟦X⟧` notation for `PowerSeries R`
+
+open scoped ArithmeticFunction.sigma -- `σ k n` notation for the sum of the `k`th
+                                     -- powers of the positive divisors of `n`
+
+noncomputable section
+
+namespace TateCurve
+
+/-- The variable `u` of the field `ℚ(u)` of coefficients. -/
+local notation "u" => (RatFunc.X : RatFunc ℚ)
+
+/-- The power series `sₖ = ∑_{n ≥ 1} σₖ(n)qⁿ ∈ ℚ(u)⟦q⟧` (where `σₖ(n)` is the sum of
+the `k`th powers of the positive divisors of `n`). Up to a normalising constant, these
+are the `q`-expansions of the Eisenstein series of weight `k + 1`. -/
+def s (k : ℕ) : (RatFunc ℚ)⟦X⟧ :=
+  .mk fun n ↦ (σ k n : RatFunc ℚ)
+
+/-- The coefficient `a₄ = -5s₃ = -5q - 45q² - ⋯` of the Tate curve
+`y² + xy = x³ + a₄x + a₆`. -/
+def a₄ : (RatFunc ℚ)⟦X⟧ := -5 * s 3
+
+/-- The coefficient `a₆ = -(5s₃ + 7s₅)/12 = -q - 23q² - ⋯` of the Tate curve
+`y² + xy = x³ + a₄x + a₆`. (Division by `12` is implemented as scalar multiplication
+by `12⁻¹ ∈ ℚ(u)`; note that `5σ₃(n) + 7σ₅(n)` is always divisible by `12`, so `a₆`
+in fact has integer coefficients, though we do not need this.) -/
+def a₆ : (RatFunc ℚ)⟦X⟧ := (12 : RatFunc ℚ)⁻¹ • -(5 * s 3 + 7 * s 5)
+
+/-- The power series
+`X(u,q) = u/(1-u)² + ∑_{n ≥ 1} (∑_{d ∣ n} d(uᵈ + u⁻ᵈ - 2)) qⁿ ∈ ℚ(u)⟦q⟧`,
+the `x`-coordinate of the uniformisation `kˣ/qᶻ ≃ E_q(k)` of the Tate curve. -/
+def X : (RatFunc ℚ)⟦X⟧ :=
+  .C (u / (1 - u) ^ 2) +
+    .mk fun n ↦ ∑ d ∈ n.divisors, d * (u ^ d + u⁻¹ ^ d - 2)
+
+/-- The power series
+`Y(u,q) = u²/(1-u)³ + ∑_{n ≥ 1} (∑_{d ∣ n} ((d choose 2)uᵈ - (d+1 choose 2)u⁻ᵈ + d)) qⁿ`
+in `ℚ(u)⟦q⟧`, the `y`-coordinate of the uniformisation `kˣ/qᶻ ≃ E_q(k)` of the
+Tate curve. -/
+def Y : (RatFunc ℚ)⟦X⟧ :=
+  .C (u ^ 2 / (1 - u) ^ 3) +
+    .mk fun n ↦ ∑ d ∈ n.divisors,
+      (d.choose 2 * u ^ d - (d + 1).choose 2 * u⁻¹ ^ d + d)
+
+/-- The point `(X(u,q), Y(u,q))` satisfies the Weierstrass equation
+`y² + xy = x³ + a₄x + a₆` of the Tate curve, as an identity in `ℚ(u)⟦q⟧`.
+-/
+theorem weierstrass_equation : Y ^ 2 + X * Y = X ^ 3 + a₄ * X + a₆ :=
+  sorry
+
+/-
+This is a straightforward calculation using Theorem V.1.1(a) of
+[Silverman, *Advanced topics in the arithmetic of elliptic curves*].
+(see also the proof of V.3.1(c), and in particular the comment
+"In other words, we want to verify that this identity holds in
+the ring ℚ(u)[[q]]".
+
+Note that this identity in ℚ(u)[[X]] is checked modulo X^3 in
+the file `TateCurveConstructionExperiment.lean`, which can be deleted
+when this theorem is proved. This gives us confidence
+that there is no typo here.
+-/
+
+end TateCurve

--- a/FLT/KnownIn1980s/EllipticCurves/TateCurveConstruction.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/TateCurveConstruction.lean
@@ -1,4 +1,13 @@
-import Mathlib
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import Mathlib.FieldTheory.RatFunc.AsPolynomial
+public import Mathlib.NumberTheory.ArithmeticFunction.Misc
+public import Mathlib.RingTheory.PowerSeries.Basic
 
 /-!
 
@@ -27,6 +36,8 @@ variable `u` is `RatFunc.X`, and neither has anything to do with the coordinate 
 on the curve, which is the power series `TateCurve.X` defined below.
 
 -/
+
+@[expose] public section
 
 open scoped PowerSeries -- `R⟦X⟧` notation for `PowerSeries R`
 

--- a/FLT/KnownIn1980s/EllipticCurves/TateCurveConstructionExperiment.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/TateCurveConstructionExperiment.lean
@@ -1,4 +1,11 @@
-import FLT.KnownIn1980s.EllipticCurves.TateCurveConstruction
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import FLT.KnownIn1980s.EllipticCurves.TateCurveConstruction
 
 /-!
 # Low-order checks for the Tate curve identity
@@ -7,6 +14,8 @@ This file checks the identity in `TateCurve.weierstrass_equation` modulo `X ^ 3`
 where `X` is the power series variable, by comparing the coefficients of `1`, `X`
 and `X ^ 2`.
 -/
+
+@[expose] public section
 
 open scoped PowerSeries
 

--- a/FLT/KnownIn1980s/EllipticCurves/TateCurveConstructionExperiment.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/TateCurveConstructionExperiment.lean
@@ -1,0 +1,182 @@
+import FLT.KnownIn1980s.EllipticCurves.TateCurveConstruction
+
+/-!
+# Low-order checks for the Tate curve identity
+
+This file checks the identity in `TateCurve.weierstrass_equation` modulo `X ^ 3`,
+where `X` is the power series variable, by comparing the coefficients of `1`, `X`
+and `X ^ 2`.
+-/
+
+open scoped PowerSeries
+
+open scoped ArithmeticFunction.sigma
+
+noncomputable section
+
+namespace TateCurve
+
+abbrev K := RatFunc ℚ
+
+local notation "u" => (RatFunc.X : K)
+
+private def x0 : K := u / (1 - u) ^ 2
+private def x1 : K := u + u⁻¹ - 2
+private def x2 : K := x1 + 2 * (u ^ 2 + u⁻¹ ^ 2 - 2)
+
+private def y0 : K := u ^ 2 / (1 - u) ^ 3
+private def y1 : K := 1 - u⁻¹
+private def y2 : K := y1 + (u ^ 2 - 3 * u⁻¹ ^ 2 + 2)
+
+private lemma polynomial_one_sub_X_ne_zero : (1 : Polynomial ℚ) - Polynomial.X ≠ 0 := by
+  intro h
+  have h0 := congr_arg (fun p : Polynomial ℚ => p.coeff 1) h
+  norm_num [Polynomial.coeff_sub, Polynomial.coeff_one, Polynomial.coeff_X] at h0
+
+private lemma one_sub_u_ne_zero : (1 : K) - u ≠ 0 := by
+  rw [← RatFunc.algebraMap_X]
+  rw [← map_one (algebraMap (Polynomial ℚ) K), ← map_sub]
+  exact fun h => polynomial_one_sub_X_ne_zero
+    ((IsFractionRing.injective (Polynomial ℚ) K) (by simpa using h))
+
+private lemma coeff_s (k n : ℕ) : (PowerSeries.coeff n) (s k) = ((σ k) n : K) := by
+  simp [s]
+
+private lemma natCast_eq_C (m : ℕ) : (m : K⟦X⟧) = PowerSeries.C (m : K) := by
+  rw [show (m : K⟦X⟧) = algebraMap K K⟦X⟧ (m : K) by
+    exact (map_natCast (algebraMap K K⟦X⟧) m).symm]
+  rw [PowerSeries.algebraMap_apply]
+  simp
+
+private lemma intCast_eq_C (z : ℤ) : (z : K⟦X⟧) = PowerSeries.C (z : K) := by
+  rw [show (z : K⟦X⟧) = algebraMap K K⟦X⟧ (z : K) by
+    exact (map_intCast (algebraMap K K⟦X⟧) z).symm]
+  rw [PowerSeries.algebraMap_apply]
+  simp
+
+private lemma coeff_five_mul_s (k n : ℕ) :
+    (PowerSeries.coeff n) ((5 : K⟦X⟧) * s k) = (5 : K) * ((σ k) n : K) := by
+  rw [show (5 : K⟦X⟧) = PowerSeries.C (5 : K) by exact natCast_eq_C 5]
+  rw [PowerSeries.coeff_C_mul, coeff_s]
+
+private lemma coeff_seven_mul_s (k n : ℕ) :
+    (PowerSeries.coeff n) ((7 : K⟦X⟧) * s k) = (7 : K) * ((σ k) n : K) := by
+  rw [show (7 : K⟦X⟧) = PowerSeries.C (7 : K) by exact natCast_eq_C 7]
+  rw [PowerSeries.coeff_C_mul, coeff_s]
+
+private lemma coeff_neg_five_mul_s (k n : ℕ) :
+    (PowerSeries.coeff n) ((-5 : K⟦X⟧) * s k) = (-5 : K) * ((σ k) n : K) := by
+  rw [show (-5 : K⟦X⟧) = PowerSeries.C (-5 : K) by exact intCast_eq_C (-5)]
+  rw [PowerSeries.coeff_C_mul, coeff_s]
+
+private lemma coeff_X_0 : (PowerSeries.coeff 0) X = x0 := by
+  simp [X, x0]
+
+private lemma coeff_X_1 : (PowerSeries.coeff 1) X = x1 := by
+  simp [X, x1]
+
+private lemma coeff_X_2 : (PowerSeries.coeff 2) X = x2 := by
+  have hdiv : (2 : ℕ).divisors = ({1, 2} : Finset ℕ) := by decide
+  simp [X, x2, x1, hdiv]
+
+private lemma coeff_Y_0 : (PowerSeries.coeff 0) Y = y0 := by
+  simp [Y, y0]
+
+private lemma coeff_Y_1 : (PowerSeries.coeff 1) Y = y1 := by
+  simp [Y, y1]
+  ring_nf
+
+private lemma coeff_Y_2 : (PowerSeries.coeff 2) Y = y2 := by
+  have hdiv : (2 : ℕ).divisors = ({1, 2} : Finset ℕ) := by decide
+  simp [Y, y2, y1, hdiv]
+  ring_nf
+
+private lemma coeff_a₄ (n : ℕ) : (PowerSeries.coeff n) a₄ = (-5 : K) * ((σ 3) n : K) := by
+  rw [a₄, coeff_neg_five_mul_s]
+
+private lemma coeff_a₆ (n : ℕ) :
+    (PowerSeries.coeff n) a₆ =
+      (12 : K)⁻¹ * -((5 : K) * ((σ 3) n : K) + (7 : K) * ((σ 5) n : K)) := by
+  rw [a₆]
+  simp only [PowerSeries.coeff_smul, map_neg, map_add]
+  rw [coeff_five_mul_s, coeff_seven_mul_s]
+  ring
+
+private lemma coeff_a₄_0 : (PowerSeries.coeff 0) a₄ = (0 : K) := by
+  rw [coeff_a₄]
+  simp
+
+private lemma coeff_a₄_1 : (PowerSeries.coeff 1) a₄ = (-5 : K) := by
+  rw [coeff_a₄]
+  simp [ArithmeticFunction.sigma_apply]
+
+private lemma coeff_a₄_2 : (PowerSeries.coeff 2) a₄ = (-45 : K) := by
+  have hdiv : (2 : ℕ).divisors = ({1, 2} : Finset ℕ) := by decide
+  rw [coeff_a₄]
+  simp [ArithmeticFunction.sigma_apply, hdiv]
+  norm_num
+
+private lemma coeff_a₆_0 : (PowerSeries.coeff 0) a₆ = (0 : K) := by
+  rw [coeff_a₆]
+  simp
+
+private lemma coeff_a₆_1 : (PowerSeries.coeff 1) a₆ = (-1 : K) := by
+  rw [coeff_a₆]
+  simp [ArithmeticFunction.sigma_apply]
+  norm_num
+
+private lemma coeff_a₆_2 : (PowerSeries.coeff 2) a₆ = (-23 : K) := by
+  have hdiv : (2 : ℕ).divisors = ({1, 2} : Finset ℕ) := by decide
+  rw [coeff_a₆]
+  simp [ArithmeticFunction.sigma_apply, hdiv]
+  norm_num
+
+private lemma coeff_weierstrass_0 :
+    (PowerSeries.coeff 0) (Y ^ 2 + X * Y) =
+      (PowerSeries.coeff 0) (X ^ 3 + a₄ * X + a₆) := by
+  simp [X, Y, a₄, a₆, s]
+  field_simp
+  ring_nf
+
+private lemma coeff_weierstrass_1 :
+    (PowerSeries.coeff 1) (Y ^ 2 + X * Y) =
+      (PowerSeries.coeff 1) (X ^ 3 + a₄ * X + a₆) := by
+  have hanti0 : Finset.HasAntidiagonal.antidiagonal 0 = ({(0, 0)} : Finset (ℕ × ℕ)) := by
+    decide
+  have hanti1 : Finset.HasAntidiagonal.antidiagonal 1 =
+      ({(0, 1), (1, 0)} : Finset (ℕ × ℕ)) := by
+    decide
+  simp [pow_succ, PowerSeries.coeff_mul, hanti0, hanti1, coeff_X_0, coeff_X_1,
+    coeff_Y_0, coeff_Y_1, coeff_a₄_0, coeff_a₄_1, coeff_a₆_1]
+  simp [x0, x1, y0, y1]
+  field_simp [RatFunc.X_ne_zero, one_sub_u_ne_zero]
+  ring_nf
+
+private lemma coeff_weierstrass_2 :
+    (PowerSeries.coeff 2) (Y ^ 2 + X * Y) =
+      (PowerSeries.coeff 2) (X ^ 3 + a₄ * X + a₆) := by
+  have hanti0 : Finset.HasAntidiagonal.antidiagonal 0 = ({(0, 0)} : Finset (ℕ × ℕ)) := by
+    decide
+  have hanti1 : Finset.HasAntidiagonal.antidiagonal 1 =
+      ({(0, 1), (1, 0)} : Finset (ℕ × ℕ)) := by
+    decide
+  have hanti2 : Finset.HasAntidiagonal.antidiagonal 2 =
+      ({(0, 2), (1, 1), (2, 0)} : Finset (ℕ × ℕ)) := by
+    decide
+  simp [pow_succ, PowerSeries.coeff_mul, hanti0, hanti1, hanti2, coeff_X_0, coeff_X_1,
+    coeff_X_2, coeff_Y_0, coeff_Y_1, coeff_Y_2, coeff_a₄_0, coeff_a₄_1,
+    coeff_a₄_2, coeff_a₆_2]
+  simp [x0, x1, x2, y0, y1, y2]
+  field_simp [RatFunc.X_ne_zero, one_sub_u_ne_zero]
+  ring_nf
+
+/-- The identity `Y ^ 2 + X * Y = X ^ 3 + a₄ * X + a₆` holds modulo `X ^ 3`. -/
+theorem weierstrass_equation_mod_X3 (n : ℕ) (hn : n < 3) :
+    (PowerSeries.coeff n) (Y ^ 2 + X * Y) =
+      (PowerSeries.coeff n) (X ^ 3 + a₄ * X + a₆) := by
+  interval_cases n
+  · exact coeff_weierstrass_0
+  · exact coeff_weierstrass_1
+  · exact coeff_weierstrass_2
+
+end TateCurve

--- a/FLT/KnownIn1980s/EllipticCurves/TateCurveConstructionExperiment.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/TateCurveConstructionExperiment.lean
@@ -25,6 +25,7 @@ noncomputable section
 
 namespace TateCurve
 
+/-- The coefficient field `ℚ(u)`, the field of rational functions in one variable over `ℚ`. -/
 abbrev K := RatFunc ℚ
 
 local notation "u" => (RatFunc.X : K)

--- a/FLT/KnownIn1980s/EllipticCurves/Torsion.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/Torsion.lean
@@ -1,4 +1,25 @@
-import Mathlib
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import Mathlib.Algebra.Module.Torsion.Basic
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+public import Mathlib.FieldTheory.IsSepClosed
+
+/-!
+
+# Torsion of an elliptic curve over a separably closed field
+
+Let `E` be an elliptic curve over a separably closed field `k` and let `n` be a natural
+number which is nonzero in `k`. Then the `n`-torsion subgroup of `E(k)` is free of rank 2
+over `ℤ/nℤ`.
+
+-/
+
+@[expose] public section
 
 open scoped WeierstrassCurve.Affine -- `(E⁄k).Point` notation
 

--- a/FLT/KnownIn1980s/EllipticCurves/Torsion.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/Torsion.lean
@@ -1,0 +1,17 @@
+import Mathlib
+
+open scoped WeierstrassCurve.Affine -- `(E⁄k).Point` notation
+
+-- let k be a separably closed field (`DecidableEq` is needed for the group law on `(E⁄k).Point`)
+variable (k : Type*) [Field k] [IsSepClosed k] [DecidableEq k]
+
+-- Let E/k be an elliptic curve
+variable (E : WeierstrassCurve k) [E.IsElliptic]
+
+-- Let n be a natural which is nonzero in k
+variable (n : ℕ) [NeZero (n : k)]
+
+-- then the n-torsion of E(k) is free rank 2 over ℤ/nℤ
+theorem WeierstrassCurve.torsion_rank_two :
+    Nonempty (AddSubgroup.torsionBy (E⁄k).Point (n : ℤ) ≃+ (ZMod n) × (ZMod n)) :=
+  sorry

--- a/FLT/KnownIn1980s/EllipticCurves/WeilPairing.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/WeilPairing.lean
@@ -1,4 +1,26 @@
-import Mathlib
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import Mathlib.Algebra.Module.Torsion.Basic
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+public import Mathlib.FieldTheory.IsSepClosed
+
+/-!
+
+# The Weil pairing
+
+Let `E` be an elliptic curve over a separably closed field `k` and let `n` be a natural
+number which is nonzero in `k`. This file states the existence of the Weil pairing, a
+bilinear pairing on the `n`-torsion of `E(k)` with values in the `n`-th roots of unity
+of `k`.
+
+-/
+
+@[expose] public section
 
 open scoped WeierstrassCurve.Affine -- `(E⁄k).Point` notation for the group of `k`-points
 

--- a/FLT/KnownIn1980s/EllipticCurves/WeilPairing.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/WeilPairing.lean
@@ -1,0 +1,18 @@
+import Mathlib
+
+open scoped WeierstrassCurve.Affine -- `(E⁄k).Point` notation for the group of `k`-points
+
+-- let k be a separably closed field (`DecidableEq` is needed for the group law on `(E⁄k).Point`)
+variable (k : Type*) [Field k] [IsSepClosed k] [DecidableEq k]
+
+-- Let E/k be an elliptic curve
+variable (E : WeierstrassCurve k) [E.IsElliptic]
+
+-- Let n be a natural which is nonzero in k
+variable (n : ℕ) [NeZero (n : k)]
+
+def WeierstrassCurve.weilPairing :
+    AddSubgroup.torsionBy (E⁄k).Point (n : ℤ) →+
+    AddSubgroup.torsionBy (E⁄k).Point (n : ℤ) →+
+    Additive (rootsOfUnity n k) :=
+  sorry

--- a/FLT/KnownIn1980s/EllipticCurves/WeilPairing.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/WeilPairing.lean
@@ -33,6 +33,8 @@ variable (E : WeierstrassCurve k) [E.IsElliptic]
 -- Let n be a natural which is nonzero in k
 variable (n : ℕ) [NeZero (n : k)]
 
+/-- The Weil pairing on the `n`-torsion of an elliptic curve `E` over a separably closed
+field `k`, a bilinear pairing with values in the `n`-th roots of unity of `k`. -/
 def WeierstrassCurve.weilPairing :
     AddSubgroup.torsionBy (E⁄k).Point (n : ℤ) →+
     AddSubgroup.torsionBy (E⁄k).Point (n : ℤ) →+


### PR DESCRIPTION
Facts about elliptic curves (all proofs and many defs sorried):
1) n-torsion is (Z/nZ)^2 (if k sep closed and n isn't zero in k)
2) Tate curve background and isomorphism k^*/<q>=E(k) (unfortunately only for k discretely-valued)
3) Weil pairing
4) n-torsion is flat (and hence unramified if n isn't 0 in k)
5) Quadratic twists.

All written by fable. Docstrings a bit long for my liking but still.