### PR TITLE
ci: disable documentation compilation

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -94,9 +94,13 @@ jobs:
           relevant-labels: FLT
           include-drafts: true
 
-      - name: Compile documentation
-        uses: leanprover-community/docgen-action@7b5b9a1822650bd45aaeb4182d94bceba2030f89 # 2026-04-14
-        with:
-          # leanblueprint (incl. checkdecls) disabled while migrating to a verso blueprint
-          blueprint: false
-          homepage: docs
+      # Documentation compilation disabled: docgen regularly runs for hours and
+      # then fails at the very end, turning CI red for reasons unrelated to the
+      # actual project. Disabling it until it can be made reliable again.
+      #
+      # - name: Compile documentation
+      #   uses: leanprover-community/docgen-action@7b5b9a1822650bd45aaeb4182d94bceba2030f89 # 2026-04-14
+      #   with:
+      #     # leanblueprint (incl. checkdecls) disabled while migrating to a verso blueprint
+      #     blueprint: false
+      #     homepage: docs


### PR DESCRIPTION
CI is regularly going red because of documentation compilation, not because of anything wrong with the project. The `docgen-action` step in `blueprint.yml` frequently runs for hours and then fails right at the end.

This PR simply comments out the **Compile documentation** step in `.github/workflows/blueprint.yml`, leaving the build/lint/test and upstreaming-dashboard steps untouched. This is the same approach taken previously in #945; the step is commented out (with an explanatory note) rather than deleted so it's trivial to re-enable once docgen is reliable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)