### PR TITLE
refactor: make `Dickson.PGL` an abbreviation for mathlib's `Matrix.ProjGenLinGroup`

### DIFF
--- a/FLT/KnownIn1980s/PGL2/Defs.lean
+++ b/FLT/KnownIn1980s/PGL2/Defs.lean
@@ -11,6 +11,7 @@ public import Mathlib.GroupTheory.SemidirectProduct
 public import Mathlib.GroupTheory.SpecificGroups.Alternating
 public import Mathlib.GroupTheory.SpecificGroups.Dihedral
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Basic
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Projective
 public import Mathlib.LinearAlgebra.Matrix.ProjectiveSpecialLinearGroup
 
 /-!
@@ -31,7 +32,7 @@ variable (p : ℕ) [Fact (Nat.Prime p)]
 noncomputable abbrev K : Type := AlgebraicClosure (ZMod p)
 
 /-- The projective general linear group `PGL₂(K p)`, i.e. `GL₂(K p)` modulo its centre. -/
-abbrev PGL : Type := GL (Fin 2) (K p) ⧸ Subgroup.center (GL (Fin 2) (K p))
+abbrev PGL : Type := Matrix.ProjGenLinGroup (Fin 2) (K p)
 
 /-- The projective special linear group `PSL₂(K p)`. -/
 abbrev PSL : Type := Matrix.ProjectiveSpecialLinearGroup (Fin 2) (K p)

--- a/FLT/KnownIn1980s/PGL2/Proofs.lean
+++ b/FLT/KnownIn1980s/PGL2/Proofs.lean
@@ -40,7 +40,10 @@ theorem classification_tame_proof (G : Subgroup (PGL p)) [Finite G]
     (Nonempty (G ≃* alternatingGroup (Fin 4))) ∨
     (Nonempty (G ≃* Equiv.Perm (Fin 4))) ∨
     (Nonempty (G ≃* alternatingGroup (Fin 5))) :=
-  classification_tame_slop p G hG_tame hG_nontrivial
+  -- `PGL p` is `Matrix.ProjGenLinGroup (Fin 2) (K p)`, which is definitionally but not
+  -- reducibly the quotient `PGLOf (K p)` that the `FLT.Slop.PGL2` development is stated
+  -- in terms of, so the instance arguments have to be supplied by hand.
+  @classification_tame_slop p ‹_› ‹_› G (Fintype.ofFinite G) hG_tame hG_nontrivial
 
 theorem classification_wild_proof (G : Subgroup (PGL p)) [Finite G]
     (hG_p : p ∣ Nat.card G) :
@@ -53,6 +56,6 @@ theorem classification_wild_proof (G : Subgroup (PGL p)) [Finite G]
       Nonempty (G ≃* (GL (Fin 2) (GaloisField p m) ⧸
         Subgroup.center (GL (Fin 2) (GaloisField p m))))) ∨
     (p = 3 ∧ Nonempty (G ≃* alternatingGroup (Fin 5))) :=
-  classification_wild_slop p G hG_p
+  @classification_wild_slop p ‹_› ‹_› G ‹Finite G› hG_p
 
 end Dickson

--- a/FLT/Slop/PGL2/FiniteSubgroups/DicksonClassification.lean
+++ b/FLT/Slop/PGL2/FiniteSubgroups/DicksonClassification.lean
@@ -51,7 +51,7 @@ namespace Dickson
 
 variable (p : ℕ) [Fact (Nat.Prime p)] [h_odd : Fact (p > 2)]
 
-theorem dickson_classification (G : Subgroup (PGL p)) [Finite G] :
+theorem dickson_classification (G : Subgroup (PGLOf (K p))) [Finite G] :
     (IsCyclic G) ∨
     (∃ n : ℕ, n ≥ 2 ∧ Nonempty (G ≃* DihedralGroup n)) ∨
     (Nonempty (G ≃* alternatingGroup (Fin 4))) ∨

--- a/FLT/Slop/PGL2/FiniteSubgroups/FieldReconstruction.lean
+++ b/FLT/Slop/PGL2/FiniteSubgroups/FieldReconstruction.lean
@@ -11,7 +11,7 @@ public import FLT.Slop.PGL2.FiniteSubgroups.PartitionHelpers
 /-!
 # Reconstructing a finite field from a wild subgroup of `PGL₂(𝔽̄_p)`
 
-Let `G` be a finite subgroup of `PGL p = PGL₂(𝔽̄_p)` whose Sylow `p`-subgroup is not
+Let `G` be a finite subgroup of `PGLOf (K p) = PGL₂(𝔽̄_p)` whose Sylow `p`-subgroup is not
 cyclic of order dividing `p`. This file reconstructs a finite subfield `𝔽_q ⊆ 𝔽̄_p`
 (`q = p^m`) from the translations contained in `G`.
 
@@ -19,7 +19,7 @@ We define:
 * `Dickson.FqInK p m`: the subfield `{x | x ^ p ^ m = x}` of `K p = 𝔽̄_p`,
   i.e. the image of the Galois field `𝔽_{p^m}`;
 * `Dickson.translationPGL` and `Dickson.dilationPGL`: the upper-triangular translation
-  `x ↦ x + b` and dilation `x ↦ cx` as elements of `PGL p`;
+  `x ↦ x + b` and dilation `x ↦ cx` as elements of `PGLOf (K p)`;
 * `Dickson.translationSet H`: the set of `b` with `x ↦ x + b` in `H`;
 * `Dickson.galoisFieldRingHom`: an embedding `GaloisField p m →+* K p` with image
   `FqInK p m`.
@@ -131,13 +131,13 @@ noncomputable def dilationGL (c : K p) (hc : c ≠ 0) : GL (Fin 2) (K p) :=
   Matrix.GeneralLinearGroup.mkOfDetNeZero !![c, 0; 0, 1] (by erw [Matrix.det_fin_two, mul_zero, sub_zero, mul_one]; exact hc)
 
 
-/-- The translation `x ↦ x + b` as an element of `PGL p = PGL₂(𝔽̄_p)`. -/
-noncomputable def translationPGL (b : K p) : PGL p :=
+/-- The translation `x ↦ x + b` as an element of `PGLOf (K p) = PGL₂(𝔽̄_p)`. -/
+noncomputable def translationPGL (b : K p) : PGLOf (K p) :=
   QuotientGroup.mk (translationGL p b)
 
 
-/-- The dilation `x ↦ c x` (for `c ≠ 0`) as an element of `PGL p = PGL₂(𝔽̄_p)`. -/
-noncomputable def dilationPGL (c : K p) (hc : c ≠ 0) : PGL p :=
+/-- The dilation `x ↦ c x` (for `c ≠ 0`) as an element of `PGLOf (K p) = PGL₂(𝔽̄_p)`. -/
+noncomputable def dilationPGL (c : K p) (hc : c ≠ 0) : PGLOf (K p) :=
   QuotientGroup.mk (dilationGL p c hc)
 
 omit h_odd in
@@ -167,7 +167,7 @@ theorem translationPGL_inv (b : K p) :
     (translationPGL p b)⁻¹ = translationPGL p (-b) :=
   inv_eq_of_mul_eq_one_right <| by rw [translationPGL_mul, add_neg_cancel, translationPGL_zero]
 
-theorem order_p_fixing_infinity_is_translation (g : PGL p)
+theorem order_p_fixing_infinity_is_translation (g : PGLOf (K p))
     (h_fix : g • infinity p = infinity p) (h_order : orderOf g = p) :
     ∃ b : K p, b ≠ 0 ∧ g = translationPGL p b :=
   let ⟨x, hx⟩ := isUnipotent_of_fixesInfinity_orderOf p g h_fix h_order
@@ -178,7 +178,7 @@ theorem order_p_fixing_infinity_is_translation (g : PGL p)
     exact ne_of_gt (lt_trans (by norm_num : 1 < 2) Fact.out) h_order.symm
   ⟨x, hx_ne_zero, hx⟩
 
-theorem n_p_gt_one_of_pgl_order (G : Subgroup (PGL p)) [Finite G]
+theorem n_p_gt_one_of_pgl_order (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hG : Nat.card G = p ^ m * (p ^ (2 * m) - 1)) :
     Fintype.card (Sylow p G) > 1 := by
@@ -201,7 +201,7 @@ theorem n_p_gt_one_of_pgl_order (G : Subgroup (PGL p)) [Finite G]
     (by rw [tsub_lt_tsub_iff_right (Nat.one_le_pow _ _ (Nat.Prime.pos Fact.out))]
         exact pow_lt_pow_right₀ (Nat.Prime.one_lt Fact.out) (by rw [two_mul]; exact lt_add_of_pos_right m hm))
 
-theorem z1_eq_pm_minus_one (G : Subgroup (PGL p)) [Finite G]
+theorem z1_eq_pm_minus_one (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hG : Nat.card G = p ^ m * (p ^ (2 * m) - 1))
     (P : Sylow p G) (hn_p : Fintype.card (Sylow p G) > 1) :
@@ -219,11 +219,11 @@ theorem z1_eq_pm_minus_one (G : Subgroup (PGL p)) [Finite G]
 
 
 /-- The set of `b : K p` for which the translation `x ↦ x + b` lies in the subgroup `H`. -/
-noncomputable def translationSet (H : Subgroup (PGL p)) : Set (K p) :=
+noncomputable def translationSet (H : Subgroup (PGLOf (K p))) : Set (K p) :=
   {b : K p | translationPGL p b ∈ H}
 
 theorem p_subgroup_fixing_infinity_translations
-    (H : Subgroup (PGL p)) [Finite H]
+    (H : Subgroup (PGLOf (K p))) [Finite H]
     (hH_p : IsPGroup p H) (_hH_nontrivial : Nontrivial H)
     (hH_fix : ∀ g ∈ H, g • infinity p = infinity p) :
     (∀ g ∈ H, ∃ b : K p, g = translationPGL p b) ∧
@@ -233,7 +233,7 @@ theorem p_subgroup_fixing_infinity_translations
     · exact ⟨0, hg_one.trans (translationPGL_zero p).symm⟩
     · exact (order_p_fixing_infinity_is_translation p g (hH_fix g hg)
         (isPGroup_orderOf_eq_prime p H hH_p ⟨g, hg⟩ (fun h ↦ hg_one (congrArg Subtype.val h)))).imp fun b hb ↦ hb.2
-  have h_image : (fun b ↦ translationPGL p b) '' translationSet p H = (H : Set (PGL p)) := by
+  have h_image : (fun b ↦ translationPGL p b) '' translationSet p H = (H : Set (PGLOf (K p))) := by
     ext g
     refine ⟨fun ⟨x, hx, hg⟩ ↦ hg ▸ hx, fun hg ↦ ?_⟩
     obtain ⟨b, hb⟩ := h_translation_set g hg
@@ -257,18 +257,18 @@ theorem p_subgroup_fixing_infinity_translations
     rfl⟩
 
 omit h_odd in
-theorem translationSet_zero (H : Subgroup (PGL p)) :
+theorem translationSet_zero (H : Subgroup (PGLOf (K p))) :
     (0 : K p) ∈ translationSet p H :=
   show translationPGL p 0 ∈ H from (translationPGL_zero p).symm ▸ H.one_mem
 
 omit h_odd in
-theorem translationSet_add (H : Subgroup (PGL p)) (a b : K p)
+theorem translationSet_add (H : Subgroup (PGLOf (K p))) (a b : K p)
     (ha : a ∈ translationSet p H) (hb : b ∈ translationSet p H) :
     a + b ∈ translationSet p H :=
   show translationPGL p (a + b) ∈ H from translationPGL_mul p a b ▸ H.mul_mem ha hb
 
 omit h_odd in
-theorem translationSet_neg (H : Subgroup (PGL p)) (b : K p)
+theorem translationSet_neg (H : Subgroup (PGLOf (K p))) (b : K p)
     (hb : b ∈ translationSet p H) :
     -b ∈ translationSet p H :=
   show translationPGL p (-b) ∈ H from translationPGL_inv p b ▸ H.inv_mem hb
@@ -389,7 +389,7 @@ noncomputable def P1point (c : K p) : ProjectiveLine p :=
 omit h_odd in
 theorem fixes_zero_upper_triangular (a b d : K p) (h_det : a * d ≠ 0) :
     (QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero
-      !![a, b; 0, d] (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h_det)) : PGL p) •
+      !![a, b; 0, d] (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h_det)) : PGLOf (K p)) •
         P1point p 0 = P1point p 0 → b = 0 := fun h_smul ↦ by
   rw [P1point] at h_smul
   erw [Projectivization.smul_mk, Projectivization.mk_eq_mk_iff] at h_smul
@@ -402,10 +402,10 @@ theorem fixes_zero_upper_triangular (a b d : K p) (h_det : a * d ≠ 0) :
 omit h_odd in
 theorem fixes_one_diagonal (a d : K p) (h_det : a * d ≠ 0) :
     (QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero
-      !![a, (0 : K p); 0, d] (by rw [Matrix.det_fin_two]; norm_num; exact mul_ne_zero_iff.mp h_det)) : PGL p) •
+      !![a, (0 : K p); 0, d] (by rw [Matrix.det_fin_two]; norm_num; exact mul_ne_zero_iff.mp h_det)) : PGLOf (K p)) •
         P1point p 1 = P1point p 1 →
     (QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero
-      !![a, (0 : K p); 0, d] (by rw [Matrix.det_fin_two]; norm_num; exact mul_ne_zero_iff.mp h_det)) : PGL p) = 1 := fun h_smul ↦ by
+      !![a, (0 : K p); 0, d] (by rw [Matrix.det_fin_two]; norm_num; exact mul_ne_zero_iff.mp h_det)) : PGLOf (K p)) = 1 := fun h_smul ↦ by
   rw [P1point] at h_smul
   erw [Projectivization.smul_mk, Projectivization.mk_eq_mk_iff] at h_smul
   rcases h_smul with ⟨c, hc⟩
@@ -432,7 +432,7 @@ theorem fixes_one_diagonal (a d : K p) (h_det : a * d ≠ 0) :
     simp only [h_a_eq_d, Matrix.mul_apply, Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.of_apply, zero_mul, zero_add, mul_comm]
 
 omit h_odd in
-theorem pgl_fixes_three_points_eq_one (g : PGL p)
+theorem pgl_fixes_three_points_eq_one (g : PGLOf (K p))
     (h_inf : g • infinity p = infinity p)
     (h_zero : g • P1point p 0 = P1point p 0)
     (h_one : g • P1point p 1 = P1point p 1) :
@@ -446,13 +446,13 @@ omit h_odd in
 theorem upper_triangular_normalizes_translations
     (a b d : K p) (h_det : a * d ≠ 0) (x : K p) :
     (QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero
-      !![a, b; 0, d] (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h_det)) : PGL p) *
+      !![a, b; 0, d] (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h_det)) : PGLOf (K p)) *
       translationPGL p x *
     (QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero
-      !![a, b; 0, d] (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h_det)) : PGL p)⁻¹ =
+      !![a, b; 0, d] (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h_det)) : PGLOf (K p))⁻¹ =
       translationPGL p (a / d * x) := by
   rw [mul_inv_eq_iff_eq_mul, translationPGL, translationGL]
-  apply congr_arg (QuotientGroup.mk : GL (Fin 2) (K p) → PGL p)
+  apply congr_arg (QuotientGroup.mk : GL (Fin 2) (K p) → PGLOf (K p))
   ext i j
   match i, j with
   | 0, 0 =>
@@ -475,7 +475,7 @@ theorem general_matrix_in_pgl_range (m : ℕ) (hm : m ≥ 1) (a b c d : K p)
     (ha : a ∈ FqInK p m) (hb : b ∈ FqInK p m)
     (hc : c ∈ FqInK p m) (hd : d ∈ FqInK p m) :
     (QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero
-        !![a, b; c, d] (by rw [Matrix.det_fin_two]; exact h_det)) : PGL p) ∈
+        !![a, b; c, d] (by rw [Matrix.det_fin_two]; exact h_det)) : PGLOf (K p)) ∈
       (pglMap (galoisFieldRingHom (p := p) m)).range := by
   obtain ⟨a', ha'⟩ := Set.mem_range.mp (galoisFieldRingHom_range_eq_F_q p m hm ▸ ha)
   obtain ⟨b', hb'⟩ := Set.mem_range.mp (galoisFieldRingHom_range_eq_F_q p m hm ▸ hb)
@@ -487,7 +487,7 @@ theorem general_matrix_in_pgl_range (m : ℕ) (hm : m ≥ 1) (a b c d : K p)
     apply h_det
     rw [← ha', ← hb', ← hc', ← hd', ← map_mul, ← map_mul, ← map_sub]
     exact h_zero.symm ▸ map_zero _)), ?_⟩
-  apply congr_arg (QuotientGroup.mk : GL (Fin 2) (K p) → PGL p)
+  apply congr_arg (QuotientGroup.mk : GL (Fin 2) (K p) → PGLOf (K p))
   ext i j
   match i, j with
   | 0, 0 => exact ha'
@@ -519,7 +519,7 @@ theorem F_q_sub_closed (m : ℕ) (x y : K p) (hx : x ∈ FqInK p m) (hy : y ∈ 
 
 theorem three_transitive_case1 (m : ℕ) (hm : m ≥ 1)
     (β γ : K p) (hβ : β ∈ FqInK p m) (hγ : γ ∈ FqInK p m) (hne : β ≠ γ) :
-    ∃ h : PGL p, h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧
+    ∃ h : PGLOf (K p), h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧
       h • infinity p = infinity p ∧
       h • P1point p 0 = P1point p β ∧
       h • P1point p 1 = P1point p γ := by
@@ -550,7 +550,7 @@ theorem three_transitive_case1 (m : ℕ) (hm : m ≥ 1)
 
 theorem three_transitive_case2 (m : ℕ) (hm : m ≥ 1)
     (α γ : K p) (hα : α ∈ FqInK p m) (hγ : γ ∈ FqInK p m) (hne : α ≠ γ) :
-    ∃ h : PGL p, h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧
+    ∃ h : PGLOf (K p), h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧
       h • infinity p = P1point p α ∧
       h • P1point p 0 = infinity p ∧
       h • P1point p 1 = P1point p γ := by
@@ -587,7 +587,7 @@ theorem three_transitive_case2 (m : ℕ) (hm : m ≥ 1)
 
 theorem three_transitive_case3 (m : ℕ) (hm : m ≥ 1)
     (α β : K p) (hα : α ∈ FqInK p m) (hβ : β ∈ FqInK p m) (hne : α ≠ β) :
-    ∃ h : PGL p, h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧
+    ∃ h : PGLOf (K p), h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧
       h • infinity p = P1point p α ∧
       h • P1point p 0 = P1point p β ∧
       h • P1point p 1 = infinity p := by
@@ -625,7 +625,7 @@ theorem three_transitive_case3 (m : ℕ) (hm : m ≥ 1)
 theorem three_transitive_case4 (m : ℕ) (hm : m ≥ 1)
     (α β γ : K p) (hα : α ∈ FqInK p m) (hβ : β ∈ FqInK p m) (hγ : γ ∈ FqInK p m)
     (hαβ : α ≠ β) (hαγ : α ≠ γ) (hβγ : β ≠ γ) :
-    ∃ h : PGL p, h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧
+    ∃ h : PGLOf (K p), h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧
       h • infinity p = P1point p α ∧
       h • P1point p 0 = P1point p β ∧
       h • P1point p 1 = P1point p γ := by
@@ -671,7 +671,7 @@ theorem pgl_Fq_three_transitive (m : ℕ) (hm : m ≥ 1)
     (a b c : ProjectiveLine p)
     (ha : a ∈ P1Fq p m) (hb : b ∈ P1Fq p m) (hc : c ∈ P1Fq p m)
     (hab : a ≠ b) (hac : a ≠ c) (hbc : b ≠ c) :
-    ∃ h : PGL p, h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧
+    ∃ h : PGLOf (K p), h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧
       h • infinity p = a ∧ h • P1point p 0 = b ∧ h • P1point p 1 = c := by
   simp only [P1Fq, Set.mem_union, Set.mem_singleton_iff, Set.mem_image] at ha hb hc
   rcases ha with rfl | ⟨α, hα, rfl⟩
@@ -690,7 +690,7 @@ theorem pgl_Fq_three_transitive (m : ℕ) (hm : m ≥ 1)
           (fun h ↦ hab (congrArg _ h)) (fun h ↦ hac (congrArg _ h)) (fun h ↦ hbc (congrArg _ h))
 
 theorem preserves_P1Fq_in_range (m : ℕ) (hm : m ≥ 1)
-    (g : PGL p) (hg : ∀ x ∈ P1Fq p m, g • x ∈ P1Fq p m) :
+    (g : PGLOf (K p)) (hg : ∀ x ∈ P1Fq p m, g • x ∈ P1Fq p m) :
     g ∈ (pglMap (galoisFieldRingHom (p := p) m)).range := by
   have h_inf_ne_zero : infinity p ≠ P1point p 0 := fun heq ↦ by
     rw [infinity, P1point] at heq
@@ -709,7 +709,7 @@ theorem preserves_P1Fq_in_range (m : ℕ) (hm : m ≥ 1)
     rcases heq with ⟨c, hc⟩
     have h0 : (c : K p) * 1 = 0 := congr_fun hc 0
     rw [mul_one] at h0; exact Units.ne_zero c h0
-  obtain ⟨h, h_range, h_fix⟩ : ∃ h : PGL p, h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧ h • infinity p = g • infinity p ∧ h • P1point p 0 = g • P1point p 0 ∧ h • P1point p 1 = g • P1point p 1 :=
+  obtain ⟨h, h_range, h_fix⟩ : ∃ h : PGLOf (K p), h ∈ (pglMap (galoisFieldRingHom (p := p) m)).range ∧ h • infinity p = g • infinity p ∧ h • P1point p 0 = g • P1point p 0 ∧ h • P1point p 1 = g • P1point p 1 :=
     pgl_Fq_three_transitive p m hm _ _ _ (hg _ (infinity_mem_P1_Fq p m)) (hg _ (P1point_mem_P1_Fq p m 0 (F_q_zero p m))) (hg _ (P1point_mem_P1_Fq p m 1 (F_q_one p m)))
       (fun heq ↦ h_inf_ne_zero (by rw [← inv_smul_eq_iff, inv_smul_smul] at heq; exact heq))
       (fun heq ↦ h_inf_ne_one (by rw [← inv_smul_eq_iff, inv_smul_smul] at heq; exact heq))
@@ -771,7 +771,7 @@ theorem F_q_div (m : ℕ) (x y : K p) (hx : x ∈ FqInK p m) (hy : y ∈ FqInK p
 
 omit h_odd in
 theorem range_preserves_P1Fq (m : ℕ) (hm : m ≥ 1)
-    (g : PGL p) (hg : g ∈ (pglMap (galoisFieldRingHom (p := p) m)).range) :
+    (g : PGLOf (K p)) (hg : g ∈ (pglMap (galoisFieldRingHom (p := p) m)).range) :
     ∀ x ∈ P1Fq p m, g • x ∈ P1Fq p m := by
   rcases hg with ⟨⟨g⟩, rfl⟩
   intro x hx
@@ -887,7 +887,7 @@ theorem range_preserves_P1Fq (m : ℕ) (hm : m ≥ 1)
 
 
 theorem unique_sylow_fixing_infinity
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P Q : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G), g • infinity p = infinity p)
@@ -898,29 +898,29 @@ theorem unique_sylow_fixing_infinity
     (eq_sylow_fixedPoint p G hG_p Q _ (fun _ hg ↦ hQ_fix _ (Subgroup.mem_map_of_mem _ hg))))
 
 theorem fixes_infinity_normalizes_sylow
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G), g • infinity p = infinity p)
-    (g : G) (hg_fix : (g : PGL p) • infinity p = infinity p) :
+    (g : G) (hg_fix : (g : PGLOf (K p)) • infinity p = infinity p) :
     g ∈ (Subgroup.normalizer ((P : Subgroup G) : Set G)) := by
   rw [Sylow.coe_coe, ← Sylow.smul_eq_iff_mem_normalizer]
   apply unique_sylow_fixing_infinity p G hG_p (g • P) P
   · intro g_1 hg_1
     obtain ⟨x, hx_mem, rfl⟩ := Subgroup.mem_map.mp hg_1
     obtain ⟨k, hk_mem, rfl⟩ := hx_mem
-    change ((g : PGL p) * (k : PGL p) * (g : PGL p)⁻¹) • infinity p = infinity p
-    rw [mul_smul, mul_smul, inv_smul_eq_iff.mpr hg_fix.symm, hP_fix (k : PGL p) (Subgroup.mem_map.mpr ⟨k, hk_mem, rfl⟩), hg_fix]
+    change ((g : PGLOf (K p)) * (k : PGLOf (K p)) * (g : PGLOf (K p))⁻¹) • infinity p = infinity p
+    rw [mul_smul, mul_smul, inv_smul_eq_iff.mpr hg_fix.symm, hP_fix (k : PGLOf (K p)) (Subgroup.mem_map.mpr ⟨k, hk_mem, rfl⟩), hg_fix]
   · exact hP_fix
 
 /-- The orbit of `∞` under the subgroup `G'`, i.e. the set of points `g • ∞` for `g ∈ G'`. -/
-def orbitInfty (G' : Subgroup (PGL p)) : Set (ProjectiveLine p) :=
+def orbitInfty (G' : Subgroup (PGLOf (K p))) : Set (ProjectiveLine p) :=
   {x | ∃ g ∈ G', g • infinity p = x}
 
 
 omit h_odd in
-theorem preserves_orbitInfty (G' : Subgroup (PGL p))
-    (h : PGL p) (hh : h ∈ G') (x : ProjectiveLine p)
+theorem preserves_orbitInfty (G' : Subgroup (PGLOf (K p)))
+    (h : PGLOf (K p)) (hh : h ∈ G') (x : ProjectiveLine p)
     (hx : x ∈ orbitInfty p G') :
     h • x ∈ orbitInfty p G' :=
   let ⟨g, hg_mem, hg_eq⟩ := hx
@@ -928,13 +928,13 @@ theorem preserves_orbitInfty (G' : Subgroup (PGL p))
 
 
 omit h_odd in
-theorem infty_mem_orbitInfty (G' : Subgroup (PGL p)) :
+theorem infty_mem_orbitInfty (G' : Subgroup (PGLOf (K p))) :
     infinity p ∈ orbitInfty p G' :=
   ⟨1, G'.one_mem, one_smul _ _⟩
 
 omit h_odd in
 theorem orbit_closed_under_translation
-    (G' : Subgroup (PGL p))
+    (G' : Subgroup (PGLOf (K p)))
     (α : K p) (hα : P1point p α ∈ orbitInfty p G')
     (b : K p) (hb : translationPGL p b ∈ G') :
     P1point p (α + b) ∈ orbitInfty p G' :=
@@ -961,8 +961,8 @@ theorem translationSet_scaled_eq_Fq (m : ℕ) (hm : m ≥ 1)
     exact ⟨c * x, hV_stable c hc hc_ne x hx, mul_left_comm v⁻¹ c x⟩
 
 omit h_odd in
-theorem orbitInfty_conj_of_fixes_infty (G' : Subgroup (PGL p))
-    (g : PGL p) (hg_fix : g • infinity p = infinity p) :
+theorem orbitInfty_conj_of_fixes_infty (G' : Subgroup (PGLOf (K p)))
+    (g : PGLOf (K p)) (hg_fix : g • infinity p = infinity p) :
     orbitInfty p (G'.map (MulEquiv.toMonoidHom (MulAut.conj g))) =
       (fun x ↦ g • x) '' orbitInfty p G' := by
   ext x
@@ -1014,7 +1014,7 @@ theorem projLine_cases (x : ProjectiveLine p) :
 
 omit h_odd in
 theorem orbit_superset_of_translations
-    (G' : Subgroup (PGL p))
+    (G' : Subgroup (PGLOf (K p)))
     (V : Set (K p)) (hV_sub : ∀ b ∈ V, translationPGL p b ∈ G')
     (α₀ : K p) (hα₀ : P1point p α₀ ∈ orbitInfty p G') :
     {infinity p} ∪ P1point p '' ((fun b ↦ α₀ + b) '' V)
@@ -1059,7 +1059,7 @@ theorem finite_subgroup_eq_roots_of_unity
 
 
 omit h_odd in
-theorem dilation_conjugation_formula (g : PGL p) (hg : g • infinity p = infinity p) :
+theorem dilation_conjugation_formula (g : PGLOf (K p)) (hg : g • infinity p = infinity p) :
     ∃ c : K p, c ≠ 0 ∧ ∀ x : K p,
       g * translationPGL p x * g⁻¹ = translationPGL p (c * x) :=
   let ⟨a, b, d, h_det, hg_eq⟩ := (fixesInfinity_iff_upperTriangular p g).mp hg
@@ -1067,14 +1067,14 @@ theorem dilation_conjugation_formula (g : PGL p) (hg : g • infinity p = infini
     fun x ↦ hg_eq ▸ upper_triangular_normalizes_translations p a b d h_det x⟩
 
 omit h_odd in
-theorem dilation_param_mul (g₁ g₂ : PGL p) (c₁ c₂ : K p)
+theorem dilation_param_mul (g₁ g₂ : PGLOf (K p)) (c₁ c₂ : K p)
     (h₁ : ∀ x : K p, g₁ * translationPGL p x * g₁⁻¹ = translationPGL p (c₁ * x))
     (h₂ : ∀ x : K p, g₂ * translationPGL p x * g₂⁻¹ = translationPGL p (c₂ * x)) :
     ∀ x : K p, (g₁ * g₂) * translationPGL p x * (g₁ * g₂)⁻¹ = translationPGL p (c₁ * c₂ * x) :=
   fun x ↦ by rw [mul_inv_rev, ← mul_assoc, mul_assoc g₁, mul_assoc g₁, h₂, h₁, ← mul_assoc]
 
 omit h_odd in
-theorem dilation_param_inv (g : PGL p) (c : K p) (hc : c ≠ 0)
+theorem dilation_param_inv (g : PGLOf (K p)) (c : K p) (hc : c ≠ 0)
     (h : ∀ x : K p, g * translationPGL p x * g⁻¹ = translationPGL p (c * x)) :
     ∀ x : K p, g⁻¹ * translationPGL p x * g⁻¹⁻¹ = translationPGL p (c⁻¹ * x) :=
   fun x ↦ by
@@ -1097,7 +1097,7 @@ theorem translationPGL_injective : Function.Injective (translationPGL p) := fun 
             _ = a := by ring).symm
 
 omit h_odd in
-theorem dilation_param_one_is_translation (g : PGL p)
+theorem dilation_param_one_is_translation (g : PGLOf (K p))
     (hg : g • infinity p = infinity p)
     (h : ∀ x : K p, g * translationPGL p x * g⁻¹ = translationPGL p (1 * x)) :
     ∃ β : K p, g = translationPGL p β := by
@@ -1128,7 +1128,7 @@ theorem dilation_param_one_is_translation (g : PGL p)
     ring
 
 omit h_odd in
-theorem same_dilation_param_diff_translation (g₁ g₂ : PGL p) (c : K p)
+theorem same_dilation_param_diff_translation (g₁ g₂ : PGLOf (K p)) (c : K p)
     (hg₁ : g₁ • infinity p = infinity p)
     (hg₂ : g₂ • infinity p = infinity p)
     (h₁ : ∀ x : K p, g₁ * translationPGL p x * g₁⁻¹ = translationPGL p (c * x))
@@ -1152,21 +1152,21 @@ theorem same_dilation_param_diff_translation (g₁ g₂ : PGL p) (c : K p)
       exact h_translation.imp fun β hβ ↦ by rw [← mul_one g₁, ← inv_mul_cancel g₂, ← mul_assoc, hβ]
 
 /-- For `g` fixing `∞`, the nonzero scalar `c` such that conjugation by `g` sends the translation by `x` to the translation by `c x`. -/
-noncomputable def dilationParam (g : PGL p) (hg : g • infinity p = infinity p) : K p :=
+noncomputable def dilationParam (g : PGLOf (K p)) (hg : g • infinity p = infinity p) : K p :=
   (dilation_conjugation_formula p g hg).choose
 
 omit h_odd in
-theorem dilationParam_ne_zero (g : PGL p) (hg : g • infinity p = infinity p) :
+theorem dilationParam_ne_zero (g : PGLOf (K p)) (hg : g • infinity p = infinity p) :
     dilationParam p g hg ≠ 0 :=
   (dilation_conjugation_formula p g hg).choose_spec.1
 
 omit h_odd in
-theorem dilationParam_action (g : PGL p) (hg : g • infinity p = infinity p) :
+theorem dilationParam_action (g : PGLOf (K p)) (hg : g • infinity p = infinity p) :
     ∀ x : K p, g * translationPGL p x * g⁻¹ = translationPGL p (dilationParam p g hg * x) :=
   (dilation_conjugation_formula p g hg).choose_spec.2
 
 omit h_odd in
-theorem dilationParam_mul_eq (g₁ g₂ : PGL p)
+theorem dilationParam_mul_eq (g₁ g₂ : PGLOf (K p))
     (hg₁ : g₁ • infinity p = infinity p) (hg₂ : g₂ • infinity p = infinity p)
     (hg₁₂ : (g₁ * g₂) • infinity p = infinity p) :
     dilationParam p (g₁ * g₂) hg₁₂ = dilationParam p g₁ hg₁ * dilationParam p g₂ hg₂ := by
@@ -1175,14 +1175,14 @@ theorem dilationParam_mul_eq (g₁ g₂ : PGL p)
   exact (mul_one _).symm.trans ((translationPGL_injective p h1).trans (mul_one _))
 
 omit h_odd in
-theorem dilationParam_one (h1 : (1 : PGL p) • infinity p = infinity p) :
+theorem dilationParam_one (h1 : (1 : PGLOf (K p)) • infinity p = infinity p) :
     dilationParam p 1 h1 = 1 := by
   have h := dilationParam_action p 1 h1 1
   rw [inv_one, mul_one, one_mul] at h
   exact (mul_one _).symm.trans (translationPGL_injective p h.symm)
 
 omit h_odd in
-theorem dilationParam_eq_one_iff (g : PGL p) (hg : g • infinity p = infinity p) :
+theorem dilationParam_eq_one_iff (g : PGLOf (K p)) (hg : g • infinity p = infinity p) :
     dilationParam p g hg = 1 ↔ ∃ β : K p, g = translationPGL p β := by
   refine ⟨fun h ↦ dilation_param_one_is_translation p g hg (fun x ↦ by
     have h1 := dilationParam_action p g hg x
@@ -1195,13 +1195,13 @@ theorem dilationParam_eq_one_iff (g : PGL p) (hg : g • infinity p = infinity p
       exact (mul_one _).symm.trans (translationPGL_injective p h1)⟩
 
 theorem normalizer_element_fixes_infinity
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
       g • infinity p = infinity p)
     (g : G) (hg : g ∈ (Subgroup.normalizer ((P : Subgroup G) : Set G))) :
-    (g : PGL p) • infinity p = infinity p := by
+    (g : PGLOf (K p)) • infinity p = infinity p := by
   have h_inf_eq : infinity p = sylowFixedPoint p G hG_p P :=
     eq_sylow_fixedPoint p G hG_p P _ (fun g hg ↦ hP_fix _ (Subgroup.mem_map_of_mem _ hg))
   rw [h_inf_eq]
@@ -1211,38 +1211,38 @@ theorem normalizer_element_fixes_infinity
     g hg
 
 theorem dilationParam_scales_translationSet
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
       g • infinity p = infinity p)
     (g : G) (hg : g ∈ (Subgroup.normalizer ((P : Subgroup G) : Set G))) :
     ∀ x ∈ translationSet p (Subgroup.map (Subgroup.subtype G) (P : Subgroup G)),
-      dilationParam p (g : PGL p) (normalizer_element_fixes_infinity p G hG_p P hP_fix g hg) * x ∈
+      dilationParam p (g : PGLOf (K p)) (normalizer_element_fixes_infinity p G hG_p P hP_fix g hg) * x ∈
         translationSet p (Subgroup.map (Subgroup.subtype G) (P : Subgroup G)) := by
   intro x hx
   obtain ⟨y, hy, hy_eq⟩ := hx
-  have h_conj : (g : PGL p) * translationPGL p x * (g : PGL p)⁻¹ ∈ Subgroup.map (Subgroup.subtype G) (P : Subgroup G) := by
+  have h_conj : (g : PGLOf (K p)) * translationPGL p x * (g : PGLOf (K p))⁻¹ ∈ Subgroup.map (Subgroup.subtype G) (P : Subgroup G) := by
     refine ⟨g * y * g⁻¹, (hg y).1 hy, ?_⟩
-    change (g : PGL p) * G.subtype y * (g : PGL p)⁻¹ = (g : PGL p) * translationPGL p x * (g : PGL p)⁻¹
+    change (g : PGLOf (K p)) * G.subtype y * (g : PGLOf (K p))⁻¹ = (g : PGLOf (K p)) * translationPGL p x * (g : PGLOf (K p))⁻¹
     rw [hy_eq]
-  have h_action := dilationParam_action p (g : PGL p) (normalizer_element_fixes_infinity p G hG_p P hP_fix g hg) x
+  have h_action := dilationParam_action p (g : PGLOf (K p)) (normalizer_element_fixes_infinity p G hG_p P hP_fix g hg) x
   rw [h_action] at h_conj
   exact h_conj
 
 /-- The dilation parameter of an element `g` of the normalizer of the Sylow `p`-subgroup `P`, as a scalar in `K p`. -/
 noncomputable def normDilationParam
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
       g • infinity p = infinity p)
     (g : (Subgroup.normalizer ((P : Subgroup G) : Set G))) : K p :=
-  dilationParam p (g : PGL p)
+  dilationParam p (g : PGLOf (K p))
     (normalizer_element_fixes_infinity p G hG_p P hP_fix g g.prop)
 
 theorem normDilationParam_of_P
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
@@ -1250,7 +1250,7 @@ theorem normDilationParam_of_P
     (g : (Subgroup.normalizer ((P : Subgroup G) : Set G)))
     (hg : (g : G) ∈ (P : Subgroup G)) :
     normDilationParam p G hG_p P hP_fix g = 1 := by
-  apply (dilationParam_eq_one_iff p (g : PGL p) (normalizer_element_fixes_infinity p G hG_p P hP_fix g g.prop)).mpr
+  apply (dilationParam_eq_one_iff p (g : PGLOf (K p)) (normalizer_element_fixes_infinity p G hG_p P hP_fix g g.prop)).mpr
   haveI h_P_nontrivial : Nontrivial P := Finite.one_lt_card_iff_nontrivial.mp <| by
     have h : Nat.card P = p ^ (Nat.factorization (Nat.card G) p) := by convert P.card_eq_multiplicity
     exact h.symm ▸ one_lt_pow₀ (Nat.Prime.one_lt Fact.out) (Finsupp.mem_support_iff.mp <|
@@ -1260,10 +1260,10 @@ theorem normDilationParam_of_P
   exact (p_subgroup_fixing_infinity_translations p ((P : Subgroup G).map (Subgroup.subtype G))
     (P.2.map G.subtype)
     (Subgroup.equivMapOfInjective (P : Subgroup G) G.subtype (Subgroup.subtype_injective G)).toEquiv.symm.nontrivial
-    hP_fix).1 (g : PGL p) (Subgroup.mem_map_of_mem _ hg)
+    hP_fix).1 (g : PGLOf (K p)) (Subgroup.mem_map_of_mem _ hg)
 
 theorem same_normDilationParam_imp_coset
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
@@ -1272,7 +1272,7 @@ theorem same_normDilationParam_imp_coset
     (heq : normDilationParam p G hG_p P hP_fix g₁ =
            normDilationParam p G hG_p P hP_fix g₂) :
     (g₁ : G) * (g₂ : G)⁻¹ ∈ (P : Subgroup G) := by
-  have h_translation : ∃ β : K p, ((g₁ : G) * (g₂ : G)⁻¹ : PGL p) = translationPGL p β :=
+  have h_translation : ∃ β : K p, ((g₁ : G) * (g₂ : G)⁻¹ : PGLOf (K p)) = translationPGL p β :=
     (same_dilation_param_diff_translation p g₁.val g₂.val
       (normDilationParam p G hG_p P hP_fix g₁)
       (normalizer_element_fixes_infinity p G hG_p P hP_fix g₁ g₁.prop)
@@ -1280,7 +1280,7 @@ theorem same_normDilationParam_imp_coset
       (dilationParam_action p _ (normalizer_element_fixes_infinity p G hG_p P hP_fix g₁ g₁.prop))
       (fun x ↦ by rw [heq]; exact dilationParam_action p _ (normalizer_element_fixes_infinity p G hG_p P hP_fix g₂ g₂.prop) x)).imp
       fun β hβ ↦ mul_inv_eq_of_eq_mul hβ
-  have h_pow : ((g₁ : G) * (g₂ : G)⁻¹ : PGL p) ^ p = 1 := by
+  have h_pow : ((g₁ : G) * (g₂ : G)⁻¹ : PGLOf (K p)) ^ p = 1 := by
     obtain ⟨β, hβ⟩ := h_translation
     have h_translation_pow : ∀ n : ℕ, (translationPGL p β) ^ n = translationPGL p (n • β) := by
       intro n; induction n with
@@ -1292,7 +1292,7 @@ theorem same_normDilationParam_imp_coset
     ((Nat.dvd_prime Fact.out).mp (orderOf_dvd_iff_pow_eq_one.mpr h_pow))
 
 theorem normDilationParam_P_mul
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
@@ -1306,14 +1306,14 @@ theorem normDilationParam_P_mul
   have h_P := normDilationParam_of_P p G hG_p P hP_fix ⟨h, h_norm⟩ hh
   rw [normDilationParam, normDilationParam]
   rw [normDilationParam] at h_P
-  change dilationParam p ((h : PGL p) * (g : PGL p)) _ = _
-  rw [dilationParam_mul_eq p (h : PGL p) (g : PGL p)
+  change dilationParam p ((h : PGLOf (K p)) * (g : PGLOf (K p))) _ = _
+  rw [dilationParam_mul_eq p (h : PGLOf (K p)) (g : PGLOf (K p))
     (normalizer_element_fixes_infinity p G hG_p P hP_fix h h_norm)
     (normalizer_element_fixes_infinity p G hG_p P hP_fix g.val g.prop)]
   rw [h_P, one_mul]
 
 theorem normDilationParam_mul
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
@@ -1326,7 +1326,7 @@ theorem normDilationParam_mul
 
 
 theorem normDilationParam_image_card
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hG : Nat.card G = p ^ m * (p ^ (2 * m) - 1))
     (hG_p : p ∣ Nat.card G)
@@ -1395,7 +1395,7 @@ theorem normDilationParam_image_card
   exact ((Nat.div_eq_of_eq_mul_left Nat.card_pos h_card_S_mul.symm).symm : Set.ncard S = normalizerQuotient p G P).trans (z1_eq_pm_minus_one p G m hm hG P (n_p_gt_one_of_pgl_order p G m hm hG))
 
 theorem dilation_params_cover
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hG : Nat.card G = p ^ m * (p ^ (2 * m) - 1))
     (P : Sylow p G)
@@ -1455,7 +1455,7 @@ theorem dilation_params_cover
 
 
 theorem translationSet_card_eq_P
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (_hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
@@ -1478,7 +1478,7 @@ theorem translationSet_card_eq_P
     exact (p_subgroup_fixing_infinity_translations p H (P.2.map (Subgroup.subtype G)) h_nontrivial hP_fix).2.trans h_card_eq
 
 theorem orbitInfty_ncard
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
@@ -1493,7 +1493,7 @@ theorem orbitInfty_ncard
   rfl
 
 theorem orbit_eq_infty_union_translations
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hG : Nat.card G = p ^ m * (p ^ (2 * m) - 1))
     (hG_p : p ∣ Nat.card G)
@@ -1553,7 +1553,7 @@ theorem orbit_eq_infty_union_translations
   exact Eq.symm <| Set.eq_of_subset_of_ncard_le h_sub h_card_eq.le h_fin_A
 
 omit h_odd in
-theorem orbit_translate_conj (G' : Subgroup (PGL p))
+theorem orbit_translate_conj (G' : Subgroup (PGLOf (K p)))
     (α₀ : K p)
     (V : Set (K p))
     (hOrb : orbitInfty p G' =
@@ -1571,7 +1571,7 @@ theorem orbit_translate_conj (G' : Subgroup (PGL p))
     (congrArg (v + ·) (add_neg_cancel α₀)).trans (add_zero v)
 
 omit h_odd in
-theorem orbit_dilation_conj (G' : Subgroup (PGL p))
+theorem orbit_dilation_conj (G' : Subgroup (PGLOf (K p)))
     (c : K p) (hc : c ≠ 0)
     (V : Set (K p))
     (hOrb : orbitInfty p G' = {infinity p} ∪ P1point p '' V) :
@@ -1585,14 +1585,14 @@ theorem orbit_dilation_conj (G' : Subgroup (PGL p))
 
 
 theorem orbit_infty_eq_P1Fq_core
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hG : Nat.card G = p ^ m * (p ^ (2 * m) - 1))
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
       g • infinity p = infinity p) :
-    ∃ g : PGL p,
+    ∃ g : PGLOf (K p),
       g • infinity p = infinity p ∧
       orbitInfty p (G.map (MulEquiv.toMonoidHom (MulAut.conj g))) = P1Fq p m := by
   set H := Subgroup.map (Subgroup.subtype G) (P : Subgroup G)
@@ -1648,14 +1648,14 @@ theorem orbit_infty_eq_P1Fq_core
     rfl
 
 /-- The multiplicative isomorphism between `G` and its image `k₀ G k₀⁻¹` under conjugation by `k₀`. -/
-def conjEquiv (G : Subgroup (PGL p)) (k₀ : PGL p) :
+def conjEquiv (G : Subgroup (PGLOf (K p))) (k₀ : PGLOf (K p)) :
     G ≃* (G.map (MulEquiv.toMonoidHom (MulAut.conj k₀))) :=
   G.equivMapOfInjective _ (MulEquiv.injective _)
 
 
 /-- The image of the Sylow `p`-subgroup `P` under conjugation by `k₀`, as a Sylow `p`-subgroup of the conjugate group `k₀ G k₀⁻¹`. -/
 @[nolint unusedArguments]
-def sylowMap (G : Subgroup (PGL p)) [Finite G] (P : Sylow p G) (k₀ : PGL p) :
+def sylowMap (G : Subgroup (PGLOf (K p))) [Finite G] (P : Sylow p G) (k₀ : PGLOf (K p)) :
     Sylow p (G.map (MulEquiv.toMonoidHom (MulAut.conj k₀))) :=
   let e := conjEquiv p G k₀
   ⟨(P : Subgroup G).map e.toMonoidHom, P.isPGroup'.map e.toMonoidHom, fun {Q} hQ hle ↦ by
@@ -1666,9 +1666,9 @@ def sylowMap (G : Subgroup (PGL p)) [Finite G] (P : Sylow p G) (k₀ : PGL p) :
 
 
 theorem exists_conj_sylow_fixing_infty
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (_hG_p : p ∣ Nat.card G) :
-    ∃ (k₀ : PGL p) (P₁ : Sylow p (G.map (MulEquiv.toMonoidHom (MulAut.conj k₀)))),
+    ∃ (k₀ : PGLOf (K p)) (P₁ : Sylow p (G.map (MulEquiv.toMonoidHom (MulAut.conj k₀)))),
       ∀ g ∈ (P₁ : Subgroup (G.map (MulEquiv.toMonoidHom (MulAut.conj k₀)))).map
         (Subgroup.subtype _), g • infinity p = infinity p := by
   let P := Classical.arbitrary (Sylow p G)
@@ -1690,10 +1690,10 @@ theorem exists_conj_sylow_fixing_infty
     _ = infinity p := hk₀
 
 theorem orbit_infty_eq_P1Fq
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hG : Nat.card G = p ^ m * (p ^ (2 * m) - 1)) :
-    ∃ g : PGL p,
+    ∃ g : PGLOf (K p),
       orbitInfty p (G.map (MulEquiv.toMonoidHom (MulAut.conj g))) = P1Fq p m := by
   have hG_p : p ∣ Nat.card G :=
     hG.symm ▸ dvd_mul_of_dvd_left (dvd_pow_self p (ne_of_gt hm)) _
@@ -1722,10 +1722,10 @@ theorem orbit_infty_eq_P1Fq
 
 
 theorem pgl_conjugate_to_standard
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hG : Nat.card G = p ^ m * (p ^ (2 * m) - 1)) :
-    ∃ g : PGL p, G.map (MulEquiv.toMonoidHom (MulAut.conj g)) =
+    ∃ g : PGLOf (K p), G.map (MulEquiv.toMonoidHom (MulAut.conj g)) =
       (pglMap (galoisFieldRingHom (p := p) m)).range := by
   obtain ⟨g, hg⟩ := orbit_infty_eq_P1Fq p G m hm hG
   use g
@@ -1738,19 +1738,19 @@ theorem pgl_conjugate_to_standard
   have h_card_eq : Nat.card (G.map (MulEquiv.toMonoidHom (MulAut.conj g))) = Nat.card ((pglMap (galoisFieldRingHom (p := p) m)).range) :=
     h_card_Gmap.trans h_card_range.symm
   by_contra h_neq
-  have h_ssubset : (G.map (MulEquiv.toMonoidHom (MulAut.conj g)) : Set (PGL p)) ⊂ ((pglMap (galoisFieldRingHom (p := p) m)).range : Set (PGL p)) :=
+  have h_ssubset : (G.map (MulEquiv.toMonoidHom (MulAut.conj g)) : Set (PGLOf (K p))) ⊂ ((pglMap (galoisFieldRingHom (p := p) m)).range : Set (PGLOf (K p))) :=
     Set.ssubset_iff_subset_ne.mpr ⟨h_le, fun h_set_eq ↦ h_neq (Subgroup.ext (Set.ext_iff.mp h_set_eq))⟩
   have h_lt : Nat.card (G.map (MulEquiv.toMonoidHom (MulAut.conj g))) < Nat.card ((pglMap (galoisFieldRingHom (p := p) m)).range) :=
     Set.ncard_lt_ncard h_ssubset (Set.finite_range _)
   exact (ne_of_lt h_lt) h_card_eq
 
 theorem pgl_subgroups_conjugate
-    (G H : Subgroup (PGL p))
+    (G H : Subgroup (PGLOf (K p)))
     [Finite G] [Finite H]
     (m : ℕ) (hm : m ≥ 1)
     (hG : Nat.card G = p ^ m * (p ^ (2 * m) - 1))
     (hH : Nat.card H = p ^ m * (p ^ (2 * m) - 1)) :
-    ∃ g : PGL p, G.map (MulEquiv.toMonoidHom (MulAut.conj g)) = H := by
+    ∃ g : PGLOf (K p), G.map (MulEquiv.toMonoidHom (MulAut.conj g)) = H := by
   obtain ⟨g₁, hg₁⟩ := pgl_conjugate_to_standard p G m hm hG
   obtain ⟨g₂, hg₂⟩ := pgl_conjugate_to_standard p H m hm hH
   use g₂⁻¹ * g₁

--- a/FLT/Slop/PGL2/FiniteSubgroups/PGLBasic.lean
+++ b/FLT/Slop/PGL2/FiniteSubgroups/PGLBasic.lean
@@ -22,17 +22,19 @@ public import Mathlib.LinearAlgebra.Projectivization.Action
 This file sets up the basic objects used in the proof of Dickson's classification
 of the finite subgroups of `PGL₂(𝔽̄_p)` for `p` an odd prime.
 
-We define `K p` to be an algebraic closure of `𝔽_p`, the group `PGL p := PGL₂(K p)`
-(as the quotient of `GL₂(K p)` by its centre), the group `PSL p := PSL₂(K p)`, and the
-projective line `ProjectiveLine p := ℙ¹(K p)` together with its natural `PGL p`-action.
+We define the group `PGLOf F := PGL₂(F)` for a field `F` (as the quotient of `GL₂(F)` by its
+centre) and the projective line `ProjectiveLine p := ℙ¹(K p)` together with its natural
+`PGLOf (K p)`-action, where `K p` is the algebraic closure of `𝔽_p` from
+`FLT.KnownIn1980s.PGL2.Defs`. The whole `FLT.Slop.PGL2` development is stated in terms of
+`PGLOf (K p)`, which is definitionally (but not reducibly) equal to the public `Dickson.PGL p`.
 
 The main results are:
 * `Dickson.pgl_mulEquiv_psl`: over the algebraically closed field `K p`, the natural
   map `PSL₂(K p) → PGL₂(K p)` is an isomorphism.
-* `Dickson.exists_finite_subfield_conjugate`: every finite subgroup of `PGL p` can be
+* `Dickson.exists_finite_subfield_conjugate`: every finite subgroup of `PGLOf (K p)` can be
   conjugated into the image of `PGL₂(F)` for some finite subfield `F` of `K p`.
 * `Dickson.card_eigenvalues` and `Dickson.fixedPoints_card`: a nontrivial element of
-  `PGL p` fixes either one or two points of the projective line, according to whether
+  `PGLOf (K p)` fixes either one or two points of the projective line, according to whether
   its lift to `GL₂` has one or two eigenvalues.
 -/
 
@@ -95,12 +97,19 @@ lemma Nat.factorization_eq_two {n m p : ℕ}
 
 variable (p : ℕ) [Fact (Nat.Prime p)]
 
-theorem pgl_mulEquiv_psl : Nonempty (PGL p ≃* PSL p) := by
+/-- The projective general linear group `PGL₂(F)` over a field `F`, i.e. `GL₂(F)` modulo its
+centre. The development in `FLT.Slop.PGL2` works with this explicit quotient model throughout;
+it is definitionally equal to `Matrix.ProjGenLinGroup (Fin 2) F` (and hence, over `F = K p`, to
+the public `Dickson.PGL p`), but not reducibly so, which is why the proofs below are stated in
+terms of `PGLOf` rather than `Dickson.PGL`. -/
+abbrev PGLOf (F : Type*) [Field F] := GL (Fin 2) F ⧸ Subgroup.center (GL (Fin 2) F)
+
+theorem pgl_mulEquiv_psl : Nonempty (PGLOf (K p) ≃* PSL p) := by
   have h_sqrt : ∀ x : K p, ∃ c : K p, c ^ 2 = x := fun x ↦
     let ⟨y, hy⟩ := IsAlgClosed.exists_root (Polynomial.X ^ 2 - Polynomial.C x) (fun h ↦ by rw [Polynomial.degree_X_pow_sub_C (by norm_num)] at h; norm_num at h)
     ⟨y, by rw [Polynomial.IsRoot.def, Polynomial.eval_sub, Polynomial.eval_pow, Polynomial.eval_X, Polynomial.eval_C, sub_eq_zero] at hy; exact hy⟩
 
-  let f : PSL p →* PGL p := QuotientGroup.lift (Subgroup.center _)
+  let f : PSL p →* PGLOf (K p) := QuotientGroup.lift (Subgroup.center _)
     (MonoidHom.comp (QuotientGroup.mk' _) Matrix.SpecialLinearGroup.toGL) (by
       intro x hx
       change QuotientGroup.mk (Matrix.SpecialLinearGroup.toGL x) = 1
@@ -170,7 +179,7 @@ abbrev ProjectiveLine : Type := Projectivization (K p) (Fin 2 → K p)
 @[reducible] def glActionProjectiveLine : MulAction (GL (Fin 2) (K p)) (ProjectiveLine p) :=
   Projectivization.instMulAction
 
-instance : SMul (PGL p) (ProjectiveLine p) where
+instance : SMul (PGLOf (K p)) (ProjectiveLine p) where
   smul := Quotient.lift (fun g x ↦ g • x) (by
     intro g₁ g₂ h
     funext x
@@ -188,17 +197,12 @@ instance : SMul (PGL p) (ProjectiveLine p) where
       rw [show (g₁⁻¹ * g₂).val = algebraMap (K p) (Matrix (Fin 2) (Fin 2) (K p)) (↑u : K p) from congr_arg Units.val hu.symm]
       rw [Algebra.algebraMap_eq_smul_one, Matrix.smul_mulVec, Matrix.one_mulVec])
 
-instance : MulAction (PGL p) (ProjectiveLine p) where
+instance : MulAction (PGLOf (K p)) (ProjectiveLine p) where
   one_smul x := (glActionProjectiveLine p).one_smul x
   mul_smul g₁ g₂ x := by
     induction g₁ using QuotientGroup.induction_on
     induction g₂ using QuotientGroup.induction_on
     exact (glActionProjectiveLine p).mul_smul _ _ x
-
-/-- The projective general linear group `PGL₂(F)` over a field `F`, i.e. `GL₂(F)` modulo its
-centre. -/
-abbrev PGLOf (F : Type*) [Field F] := GL (Fin 2) F ⧸ Subgroup.center (GL (Fin 2) F)
-
 
 /-- The group homomorphism `PGL₂(F) → PGL₂(L)` induced by a ring homomorphism `f : F →+* L`. -/
 def pglMap {F L : Type*} [Field F] [Field L] (f : F →+* L) : PGLOf F →* PGLOf L :=
@@ -264,10 +268,10 @@ theorem finite_of_closure_finite (S : Set (K p)) (hS : S.Finite) : Finite (Subfi
     change (f x).val = (f y).val
     rw [h]))
 
-theorem exists_finite_subfield_conjugate (G : Subgroup (PGL p)) [Finite G] :
-    ∃ (L : Subfield (K p)) (g : PGL p),
+theorem exists_finite_subfield_conjugate (G : Subgroup (PGLOf (K p))) [Finite G] :
+    ∃ (L : Subfield (K p)) (g : PGLOf (K p)),
       Subgroup.map (MulAut.conj g) G ≤ (pglMap (Subfield.subtype L)).range := by
-  choose f hf using fun g : PGL p ↦ QuotientGroup.mk_surjective g
+  choose f hf using fun g : PGLOf (K p) ↦ QuotientGroup.mk_surjective g
   haveI : Fintype G := Fintype.ofFinite G
   let S : Finset (GL (Fin 2) (K p)) := Finset.univ.image (fun x : G ↦ f x.val)
 
@@ -280,9 +284,9 @@ theorem exists_finite_subfield_conjugate (G : Subgroup (PGL p)) [Finite G] :
   have hL_mem : ∀ g ∈ S, ∀ i j, g.val i j ∈ L := fun g hg i j ↦
     Subfield.subset_closure (Set.mem_iUnion₂.mpr ⟨g, hg, Set.mem_range_self (i, j)⟩)
 
-  refine ⟨L, (1 : PGL p), ?_⟩
+  refine ⟨L, (1 : PGLOf (K p)), ?_⟩
   rintro _ ⟨x, hx, rfl⟩
-  erw [show (MulAut.conj (1 : PGL p)) x = x by rw [MulAut.conj_apply, inv_one, mul_one, one_mul]]
+  erw [show (MulAut.conj (1 : PGLOf (K p))) x = x by rw [MulAut.conj_apply, inv_one, mul_one, one_mul]]
 
   have h_range : f x ∈ (Matrix.GeneralLinearGroup.map (Subfield.subtype L)).range := by
     have hf_in : f x ∈ S := Finset.mem_image.mpr ⟨⟨x, hx⟩, Finset.mem_univ _, rfl⟩
@@ -299,8 +303,8 @@ theorem exists_finite_subfield_conjugate (G : Subgroup (PGL p)) [Finite G] :
   obtain ⟨y', hy'⟩ := h_range
   exact ⟨QuotientGroup.mk y', (congr_arg QuotientGroup.mk hy').trans (hf x)⟩
 
-/-- The set of fixed points of the action of `g : PGL p` on the projective line `ℙ¹(K p)`. -/
-def fixedPoints (g : PGL p) : Set (ProjectiveLine p) := Function.fixedPoints (fun x ↦ g • x)
+/-- The set of fixed points of the action of `g : PGLOf (K p)` on the projective line `ℙ¹(K p)`. -/
+def fixedPoints (g : PGLOf (K p)) : Set (ProjectiveLine p) := Function.fixedPoints (fun x ↦ g • x)
 
 theorem fixedPoints_lift (g : GL (Fin 2) (K p)) (x : ProjectiveLine p) :
     x ∈ fixedPoints p (QuotientGroup.mk g) ↔ ∃ c : K p, g.val.mulVec x.rep = c • x.rep := by
@@ -628,8 +632,8 @@ theorem ncard_fixedPoints_eq_one_of_discrim_zero (g : GL (Fin 2) (K p)) (hg : ¬
 
 theorem orderOf_coprime_of_discrim_ne_zero (g : GL (Fin 2) (K p))
     (h_discr : (g.val.trace)^2 ≠ 4 * g.val.det)
-        (h_fin : IsOfFinOrder (QuotientGroup.mk g : PGL p)) :
-    p.Coprime (orderOf (QuotientGroup.mk g : PGL p)) := by
+        (h_fin : IsOfFinOrder (QuotientGroup.mk g : PGLOf (K p))) :
+    p.Coprime (orderOf (QuotientGroup.mk g : PGLOf (K p))) := by
   let f : Polynomial (K p) := Polynomial.X^2 - Polynomial.C g.val.trace * Polynomial.X + Polynomial.C g.val.det
   have h_deg : f.degree ≠ 0 := fun h ↦ by
     have h1 : f.coeff 2 = 1 := by
@@ -786,9 +790,9 @@ theorem orderOf_coprime_of_discrim_ne_zero (g : GL (Fin 2) (K p))
       _ = (P.val * Y.val) * (P⁻¹).val := by rw [h_diag]
       _ = (P * Y * P⁻¹).val := rfl
 
-  have h_order_eq : orderOf (QuotientGroup.mk g : PGL p) = orderOf (QuotientGroup.mk Y : PGL p) := by
-    have h_semi : SemiconjBy (QuotientGroup.mk P : PGL p) (QuotientGroup.mk Y : PGL p) (QuotientGroup.mk g : PGL p) := by
-      change (QuotientGroup.mk (P * Y) : PGL p) = QuotientGroup.mk (g * P)
+  have h_order_eq : orderOf (QuotientGroup.mk g : PGLOf (K p)) = orderOf (QuotientGroup.mk Y : PGLOf (K p)) := by
+    have h_semi : SemiconjBy (QuotientGroup.mk P : PGLOf (K p)) (QuotientGroup.mk Y : PGLOf (K p)) (QuotientGroup.mk g : PGLOf (K p)) := by
+      change (QuotientGroup.mk (P * Y) : PGLOf (K p)) = QuotientGroup.mk (g * P)
       have h_eq : P * Y = g * P := by
         calc P * Y = P * Y * 1 := by rw [mul_one]
           _ = P * Y * (P⁻¹ * P) := by rw [inv_mul_cancel]
@@ -797,10 +801,10 @@ theorem orderOf_coprime_of_discrim_ne_zero (g : GL (Fin 2) (K p))
       rw [h_eq]
     exact h_semi.orderOf_eq.symm
 
-  have h_order_eq2 : orderOf (QuotientGroup.mk Y : PGL p) = orderOf (lambda1 / lambda2 : K p) := by
+  have h_order_eq2 : orderOf (QuotientGroup.mk Y : PGLOf (K p)) = orderOf (lambda1 / lambda2 : K p) := by
     rw [orderOf_eq_orderOf_iff]
     intro n
-    rw [show (QuotientGroup.mk Y : PGL p) ^ n = QuotientGroup.mk (Y ^ n) from rfl, QuotientGroup.eq_one_iff, Subgroup.mem_center_iff]
+    rw [show (QuotientGroup.mk Y : PGLOf (K p)) ^ n = QuotientGroup.mk (Y ^ n) from rfl, QuotientGroup.eq_one_iff, Subgroup.mem_center_iff]
     have hl2_ne : lambda2 ≠ 0 := by
       intro hc
       exact g.isUnit.map Matrix.detMonoidHom |>.ne_zero (show g.val.det = 0 by rw [← hlambda2.2, hc, mul_zero])
@@ -885,7 +889,7 @@ theorem orderOf_coprime_of_discrim_ne_zero (g : GL (Fin 2) (K p))
 variable [h_odd : Fact (p > 2)]
 
 theorem orderOf_eq_prime_of_discrim_zero (g : GL (Fin 2) (K p)) (hg : ¬ ∃ c : K p, g.val = c • 1)
-    (h_discr : (g.val.trace)^2 = 4 * g.val.det) : orderOf (QuotientGroup.mk g : PGL p) = p := by
+    (h_discr : (g.val.trace)^2 = 4 * g.val.det) : orderOf (QuotientGroup.mk g : PGLOf (K p)) = p := by
   let eig := g.val.trace / 2
   let N := g.val - eig • 1
 
@@ -981,7 +985,7 @@ theorem orderOf_eq_prime_of_discrim_zero (g : GL (Fin 2) (K p)) (hg : ¬ ∃ c :
     · rw [smul_pow, one_pow, pow_eq_zero_of_le (Fact.out : p.Prime).two_le hN2, add_zero]
     · rw [← Algebra.algebraMap_eq_smul_one]
       exact Algebra.commute_algebraMap_left eig N
-  have h_ne_one : (QuotientGroup.mk g : PGL p) ≠ 1 := by
+  have h_ne_one : (QuotientGroup.mk g : PGLOf (K p)) ≠ 1 := by
     rw [Ne, QuotientGroup.eq_one_iff, Subgroup.mem_center_iff]
     contrapose! hg; refine ⟨g.val 0 0, Matrix.ext fun i j ↦ ?_⟩
     let E1 := Matrix.GeneralLinearGroup.mkOfDetNeZero (!![1, 1; 0,
@@ -1038,7 +1042,7 @@ theorem orderOf_eq_prime_of_discrim_zero (g : GL (Fin 2) (K p)) (hg : ¬ ∃ c :
       calc g.val 1 1 = g.val 0 0 := h00_11
         _ = g.val 0 0 * 1 := by ring
         _ = g.val 0 0 * (1 : Matrix (Fin 2) (Fin 2) (K p)) 1 1 := rfl
-  have h_pow_one : (QuotientGroup.mk g : PGL p) ^ p = 1 := by
+  have h_pow_one : (QuotientGroup.mk g : PGLOf (K p)) ^ p = 1 := by
     rw [← QuotientGroup.mk_pow, QuotientGroup.eq_one_iff, Subgroup.mem_center_iff]
     intro x
     apply Units.ext
@@ -1047,7 +1051,7 @@ theorem orderOf_eq_prime_of_discrim_zero (g : GL (Fin 2) (K p)) (hg : ¬ ∃ c :
 
   exact orderOf_eq_prime h_pow_one h_ne_one
 
-theorem fixedPoints_dichotomy (s : PGL p) (hs_ne_one : s ≠ 1) (hs_fin : IsOfFinOrder s) :
+theorem fixedPoints_dichotomy (s : PGLOf (K p)) (hs_ne_one : s ≠ 1) (hs_fin : IsOfFinOrder s) :
     (Set.ncard (fixedPoints p s) = 1 ↔ orderOf s = p) ∧
     (Set.ncard (fixedPoints p s) = 2 ↔ p.Coprime (orderOf s)) := by
   obtain ⟨g, rfl⟩ := QuotientGroup.mk_surjective s
@@ -1084,16 +1088,16 @@ theorem fixedPoints_dichotomy (s : PGL p) (hs_ne_one : s ≠ 1) (hs_fin : IsOfFi
       exact h_not_coprime ho
 
 omit h_odd in
-theorem fixedPoint_of_center_unique (P : Subgroup (PGL p)) (z : P) (x : ProjectiveLine p)
+theorem fixedPoint_of_center_unique (P : Subgroup (PGLOf (K p))) (z : P) (x : ProjectiveLine p)
     (hz_center : z ∈ Subgroup.center P) (hz_fix : z • x = x)
     (hz_unique : ∀ y : ProjectiveLine p, z • y = y → y = x) :
     ∀ g : P, g • x = x := fun g ↦
   hz_unique _ <| by rw [← mul_smul, ← Subgroup.mem_center_iff.mp hz_center g, mul_smul, hz_fix]
 
-theorem isPGroup_exists_common_fixedPoint (P : Subgroup (PGL p)) (hP_fin : Finite P)
+theorem isPGroup_exists_common_fixedPoint (P : Subgroup (PGLOf (K p))) (hP_fin : Finite P)
     (hP_p : IsPGroup p P) :
     ∃ x : ProjectiveLine p, ∀ g ∈ P, g • x = x := by
-  by_cases h_trivial : ∀ g ∈ P, g = (1 : PGL p)
+  by_cases h_trivial : ∀ g ∈ P, g = (1 : PGLOf (K p))
   · exact ⟨Classical.arbitrary _, fun g hg ↦ by rw [h_trivial g hg, one_smul]⟩
   · push Not at h_trivial
     obtain ⟨g_ne, hg_mem, hg_ne_one⟩ := h_trivial
@@ -1114,36 +1118,36 @@ theorem isPGroup_exists_common_fixedPoint (P : Subgroup (PGL p)) (hP_fin : Finit
       rw [orderOf_pow, hk, Nat.gcd_eq_right (pow_dvd_pow p (Nat.le_succ m)), pow_add, pow_one]
       exact Nat.mul_div_cancel_left _ (pow_pos (Nat.Prime.pos Fact.out) m)
 
-    have hz_val_order : orderOf (z_p : PGL p) = p :=
+    have hz_val_order : orderOf (z_p : PGLOf (K p)) = p :=
       (Subgroup.orderOf_coe z_p).trans hz_p_order
 
-    have hz_ne_one_val : (z_p : PGL p) ≠ 1 := fun h ↦
+    have hz_ne_one_val : (z_p : PGLOf (K p)) ≠ 1 := fun h ↦
       (Fact.out : Nat.Prime p).ne_one <| by
         rw [h, orderOf_one] at hz_val_order
         exact hz_val_order.symm
 
-    have hz_fin_order : IsOfFinOrder (z_p : PGL p) :=
+    have hz_fin_order : IsOfFinOrder (z_p : PGLOf (K p)) :=
       orderOf_pos_iff.mp <| by
         rw [hz_val_order]
         exact (Fact.out : Nat.Prime p).pos
 
     obtain ⟨x, hx_eq⟩ := Set.ncard_eq_one.mp <|
-      (fixedPoints_dichotomy p (z_p : PGL p) hz_ne_one_val hz_fin_order).1.mpr hz_val_order
+      (fixedPoints_dichotomy p (z_p : PGLOf (K p)) hz_ne_one_val hz_fin_order).1.mpr hz_val_order
 
     exact ⟨x, fun g hg ↦
       fixedPoint_of_center_unique p P z_p x
         (Subgroup.pow_mem _ hz_center _)
-        (hx_eq.symm ▸ Set.mem_singleton x : x ∈ fixedPoints p (z_p : PGL p))
-        (fun y hy ↦ Set.mem_singleton_iff.mp (hx_eq ▸ (hy : y ∈ fixedPoints p (z_p : PGL p))))
+        (hx_eq.symm ▸ Set.mem_singleton x : x ∈ fixedPoints p (z_p : PGLOf (K p)))
+        (fun y hy ↦ Set.mem_singleton_iff.mp (hx_eq ▸ (hy : y ∈ fixedPoints p (z_p : PGLOf (K p)))))
         ⟨g, hg⟩⟩
 
-theorem orderOf_eq_prime_of_prime_pow (g : PGL p) (k : ℕ) (hk : k ≥ 1)
+theorem orderOf_eq_prime_of_prime_pow (g : PGLOf (K p)) (k : ℕ) (hk : k ≥ 1)
     (hg : orderOf g = p ^ k) : orderOf g = p := by
   obtain ⟨g', rfl⟩ := QuotientGroup.mk_surjective g
 
   have h_non_scalar : ¬∃ c : K p, g'.val = c • 1 := by
     rintro ⟨c, hc⟩
-    have h_one : (QuotientGroup.mk g' : PGL p) = 1 := (QuotientGroup.eq_one_iff g').mpr
+    have h_one : (QuotientGroup.mk g' : PGLOf (K p)) = 1 := (QuotientGroup.eq_one_iff g').mpr
       (Subgroup.mem_center_iff.mpr fun x ↦ Units.ext <| by
         change x.val * g'.val = g'.val * x.val
         rw [hc, mul_smul_comm, smul_mul_assoc, mul_one, one_mul])
@@ -1159,8 +1163,8 @@ theorem orderOf_eq_prime_of_prime_pow (g : PGL p) (k : ℕ) (hk : k ≥ 1)
     exact absurd (h_gcd_eq_p.symm.trans <| hg ▸ h_coprime) (Fact.out : Nat.Prime p).ne_one
 
 @[nolint unusedArguments]
-theorem isPGroup_orderOf_eq_prime (P : Subgroup (PGL p)) [Finite P] (hP_p : IsPGroup p P) (g : P)
-    (hg : g ≠ 1) : orderOf (g : PGL p) = p := by
+theorem isPGroup_orderOf_eq_prime (P : Subgroup (PGLOf (K p))) [Finite P] (hP_p : IsPGroup p P) (g : P)
+    (hg : g ≠ 1) : orderOf (g : PGLOf (K p)) = p := by
   obtain ⟨_, hk_orig⟩ := hP_p g
   obtain ⟨k, -, hk⟩ := (Nat.dvd_prime_pow Fact.out).mp (orderOf_dvd_iff_pow_eq_one.mpr hk_orig)
 
@@ -1170,13 +1174,13 @@ theorem isPGroup_orderOf_eq_prime (P : Subgroup (PGL p)) [Finite P] (hP_p : IsPG
     rw [h_zero, pow_zero] at hk
     exact hg (orderOf_eq_one_iff.mp hk)
 
-  have hg_val_order : orderOf (g : PGL p) = p ^ k := by
+  have hg_val_order : orderOf (g : PGLOf (K p)) = p ^ k := by
     rw [Subgroup.orderOf_coe]
     exact hk
 
-  exact orderOf_eq_prime_of_prime_pow p (g : PGL p) k hk_pos hg_val_order
+  exact orderOf_eq_prime_of_prime_pow p (g : PGLOf (K p)) k hk_pos hg_val_order
 
-theorem isPGroup_exponent_dvd_prime (P : Subgroup (PGL p)) [Finite P] (hP_p : IsPGroup p P) :
+theorem isPGroup_exponent_dvd_prime (P : Subgroup (PGLOf (K p))) [Finite P] (hP_p : IsPGroup p P) :
     Monoid.exponent P ∣ p := by
   refine Monoid.exponent_dvd_of_forall_pow_eq_one fun g ↦ ?_
   by_cases hg : g = 1
@@ -1195,7 +1199,7 @@ def infinity : ProjectiveLine p := Projectivization.mk (K p) ![1,
     0] (fun h ↦ one_ne_zero (congr_fun h 0))
 
 omit h_odd in
-theorem fixesInfinity_iff_upperTriangular (g : PGL p) :
+theorem fixesInfinity_iff_upperTriangular (g : PGLOf (K p)) :
     g • (infinity p) = (infinity p) ↔ ∃ (a b d : K p) (h : a * d ≠ 0),
         g = QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero !![a, b; 0,
             d] (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h)) := by
@@ -1250,7 +1254,7 @@ omit h_odd in
 theorem upper_triangular_ratio_unique
     (a₁ b₁ d₁ a₂ b₂ d₂ : K p) (h₁ : a₁ * d₁ ≠ 0) (h₂ : a₂ * d₂ ≠ 0)
     (heq : (QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero !![a₁, b₁; 0, d₁]
-      (by rw [Matrix.det_fin_two]; change a₁ * d₁ - b₁ * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h₁)) : PGL p) =
+      (by rw [Matrix.det_fin_two]; change a₁ * d₁ - b₁ * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h₁)) : PGLOf (K p)) =
      QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero !![a₂, b₂; 0, d₂]
       (by rw [Matrix.det_fin_two]; change a₂ * d₂ - b₂ * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h₂))) :
     a₁ * d₁⁻¹ = a₂ * d₂⁻¹ := by
@@ -1286,12 +1290,12 @@ omit h_odd in
 theorem upper_triangular_mul_ratio
     (a₁ b₁ d₁ a₂ b₂ d₂ : K p) (h₁ : a₁ * d₁ ≠ 0) (h₂ : a₂ * d₂ ≠ 0) :
     (QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero !![a₁, b₁; 0, d₁]
-      (by rw [Matrix.det_fin_two]; change a₁ * d₁ - b₁ * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h₁)) : PGL p) *
+      (by rw [Matrix.det_fin_two]; change a₁ * d₁ - b₁ * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h₁)) : PGLOf (K p)) *
      QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero !![a₂, b₂; 0, d₂]
       (by rw [Matrix.det_fin_two]; change a₂ * d₂ - b₂ * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h₂)) =
      QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero !![a₁ * a₂, a₁ * b₂ + b₁ * d₂; 0, d₁ * d₂]
       (by rw [Matrix.det_fin_two]; change (a₁ * a₂) * (d₁ * d₂) - (a₁ * b₂ + b₁ * d₂) * 0 ≠ 0; rw [mul_zero, sub_zero]; rw [show (a₁ * a₂) * (d₁ * d₂) = (a₁ * d₁) * (a₂ * d₂) by ring]; exact mul_ne_zero h₁ h₂)) := by
-  refine congr_arg (fun x ↦ (QuotientGroup.mk x : PGL p)) ?_
+  refine congr_arg (fun x ↦ (QuotientGroup.mk x : PGLOf (K p))) ?_
   ext i j
   change ( !![a₁, b₁; 0, d₁] * !![a₂, b₂; 0, d₂] ) i j = _
   rw [Matrix.mul_apply, Fin.sum_univ_two]
@@ -1305,14 +1309,14 @@ theorem upper_triangular_mul_ratio
 theorem ratio_one_imp_unipotent
     (a b d : K p) (h : a * d ≠ 0) (hr : a * d⁻¹ = 1) :
     orderOf (QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero !![a, b; 0, d]
-      (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h)) : PGL p) = 1 ∨
+      (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h)) : PGLOf (K p)) = 1 ∨
     orderOf (QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero !![a, b; 0, d]
-      (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h)) : PGL p) = p := by
+      (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h)) : PGLOf (K p)) = p := by
   have ha : a ≠ 0 := fun ha_eq ↦ h (by rw [ha_eq, zero_mul])
   have h_eq : a = d := eq_of_div_eq_one hr
   let Y := Matrix.GeneralLinearGroup.mkOfDetNeZero !![a, b; 0, d] (by rw [Matrix.det_fin_two]; change a * d - b * 0 ≠ 0; rw [mul_zero, sub_zero]; exact h)
   let X := Matrix.GeneralLinearGroup.mkOfDetNeZero !![1, b * a⁻¹; 0, 1] (by rw [Matrix.det_fin_two]; change 1 * 1 - (b * a⁻¹) * 0 ≠ 0; rw [mul_zero, sub_zero, mul_one]; exact one_ne_zero)
-  have h_simplified : (QuotientGroup.mk Y : PGL p) = QuotientGroup.mk X := by
+  have h_simplified : (QuotientGroup.mk Y : PGLOf (K p)) = QuotientGroup.mk X := by
     rw [QuotientGroup.eq, Matrix.GeneralLinearGroup.mem_center_iff_val_mem_range_scalar]
     use a⁻¹
     have h_mat : X.val = Y.val * Matrix.scalar (Fin 2) a⁻¹ := by
@@ -1346,7 +1350,7 @@ theorem ratio_one_imp_unipotent
       change (1 + 1 : K p)^2 = 4 * (1 * 1 - (b * a⁻¹) * 0)
       ring
 
-theorem isUnipotent_of_fixesInfinity_orderOf (g : PGL p) (h_fix : g • (infinity p) = (infinity p))
+theorem isUnipotent_of_fixesInfinity_orderOf (g : PGLOf (K p)) (h_fix : g • (infinity p) = (infinity p))
     (h_order : orderOf g = p) :
   ∃ x : K p, g = QuotientGroup.mk (Matrix.GeneralLinearGroup.mkOfDetNeZero !![1, x; 0,
       1] (by rw [Matrix.det_fin_two]; change (1 : K p) * 1 - x * 0 ≠ 0; rw [mul_one, mul_zero,
@@ -1427,7 +1431,7 @@ theorem isUnipotent_of_fixesInfinity_orderOf (g : PGL p) (h_fix : g • (infinit
 
 omit h_odd in
 theorem exists_smul_eq_infinity (x : ProjectiveLine p) :
-    ∃ k : PGL p, k • x = infinity p := by
+    ∃ k : PGLOf (K p), k • x = infinity p := by
   set v := x.rep
   obtain ⟨A, hAdet, hAv⟩ : ∃ A : Matrix (Fin 2) (Fin 2) (K p), A.det ≠ 0 ∧ A.mulVec v = ![1, 0] := by
     by_cases hv0 : v 0 = 0
@@ -1466,7 +1470,7 @@ theorem exists_smul_eq_infinity (x : ProjectiveLine p) :
   rw [← Projectivization.mk_rep x]
   exact (Projectivization.mk_eq_mk_iff (K p) _ _ _ _).mpr ⟨1, by rw [one_smul]; exact hAv.symm⟩
 
-theorem commute_of_orderOf_prime_fixesInfinity (g h : PGL p) (hg_order : orderOf g = p)
+theorem commute_of_orderOf_prime_fixesInfinity (g h : PGLOf (K p)) (hg_order : orderOf g = p)
     (hh_order : orderOf h = p) (hg_fix : g • (infinity p) = (infinity p))
         (hh_fix : h • (infinity p) = (infinity p)) :
     g * h = h * g := by
@@ -1486,12 +1490,12 @@ theorem commute_of_orderOf_prime_fixesInfinity (g h : PGL p) (hg_order : orderOf
   | 1, 0 => change (0 * 1 + 1 * 0 : K p) = 0 * 1 + 1 * 0; ring
   | 1, 1 => change (0 * y + 1 * 1 : K p) = 0 * x + 1 * 1; ring
 
-theorem commute_of_orderOf_prime_common_fixedPoint (g h : PGL p) (x : ProjectiveLine p)
+theorem commute_of_orderOf_prime_common_fixedPoint (g h : PGLOf (K p)) (x : ProjectiveLine p)
     (hg_order : orderOf g = p) (hh_order : orderOf h = p) (hg_fix : g • x = x)
         (hh_fix : h • x = x) :
     g * h = h * g := by
   obtain ⟨k, hk⟩ := exists_smul_eq_infinity p x
-  have order_conj_eq : ∀ y : PGL p, orderOf (k * y * k⁻¹) = orderOf y := fun y ↦
+  have order_conj_eq : ∀ y : PGLOf (K p), orderOf (k * y * k⁻¹) = orderOf y := fun y ↦
     SemiconjBy.orderOf_eq k⁻¹
         (show SemiconjBy k⁻¹ (k * y * k⁻¹) y by change k⁻¹ * (k * y * k⁻¹) = y * k⁻¹; group)
   have h_comm := commute_of_orderOf_prime_fixesInfinity p (k * g * k⁻¹) (k * h * k⁻¹)
@@ -1503,7 +1507,7 @@ theorem commute_of_orderOf_prime_common_fixedPoint (g h : PGL p) (x : Projective
     _ = k⁻¹ * ((k * h * k⁻¹) * (k * g * k⁻¹)) * k := by rw [h_comm]
     _ = h * g := by group
 
-theorem isPGroup_comm_exponent_fixedPoint (P : Subgroup (PGL p)) [Finite P] (hP_p : IsPGroup p P)
+theorem isPGroup_comm_exponent_fixedPoint (P : Subgroup (PGLOf (K p))) [Finite P] (hP_p : IsPGroup p P)
     (hP_nontriv : Nontrivial P) :
     (∀ g h : P, g * h = h * g) ∧
     (Monoid.exponent P ∣ p) ∧

--- a/FLT/Slop/PGL2/FiniteSubgroups/PSLRecognition.lean
+++ b/FLT/Slop/PGL2/FiniteSubgroups/PSLRecognition.lean
@@ -10,7 +10,7 @@ public import FLT.Slop.PGL2.FiniteSubgroups.FieldReconstruction
 /-!
 # Recognising `PSL₂(𝔽_q)` inside `PGL₂(𝔽̄_p)`
 
-Let `G` be a finite subgroup of `PGL p = PGL₂(𝔽̄_p)` of order `(q² - 1) * q / 2`
+Let `G` be a finite subgroup of `PGLOf (K p) = PGL₂(𝔽̄_p)` of order `(q² - 1) * q / 2`
 (`q = p^m`) arising in the wild case of Dickson's classification. This file shows that
 after conjugation `G` lies in the image of `PGL₂(𝔽_q) → PGL₂(𝔽̄_p)`
 (`Dickson.psl_G_le_pgl_range_from_orbit`), the key step in identifying `G` with
@@ -132,7 +132,7 @@ theorem additive_subgroup_eq_F_q_from_squares (m : ℕ) (hm : m ≥ 1) (hpm : p 
 
 
 
-theorem sylow_order_of_psl_order (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_order_of_psl_order (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2)
     (P : Sylow p G) :
@@ -146,7 +146,7 @@ theorem sylow_order_of_psl_order (G : Subgroup (PGL p)) [Finite G]
   rw [h_two, Nat.sub_zero]
   exact congrArg (p ^ ·) (factorization_pgl_order p m hm)
 
-theorem n_p_gt_one_of_psl_order (G : Subgroup (PGL p)) [Finite G]
+theorem n_p_gt_one_of_psl_order (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1) (hpm : p ^ m ≥ 5)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2) :
     Fintype.card (Sylow p G) > 1 := by
@@ -180,7 +180,7 @@ variable (p : ℕ) [Fact (Nat.Prime p)] [h_odd : Fact (p > 2)]
 
 
 
-theorem n_p_eq_psl (G : Subgroup (PGL p)) [Finite G]
+theorem n_p_eq_psl (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2)
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :
@@ -226,7 +226,7 @@ theorem n_p_eq_psl (G : Subgroup (PGL p)) [Finite G]
       nlinarith only [ha, h_sub, hp_gt_one, h_a_bound]
 
 
-theorem z1_eq_psl (G : Subgroup (PGL p)) [Finite G]
+theorem z1_eq_psl (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1) (hpm : p ^ m ≥ 5)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2)
     (P : Sylow p G) (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :
@@ -250,7 +250,7 @@ theorem z1_eq_psl (G : Subgroup (PGL p)) [Finite G]
 
 
 theorem normDilationParam_image_card_eq_normalizerQuotient
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
@@ -288,7 +288,7 @@ theorem normDilationParam_image_card_eq_normalizerQuotient
 
 
 theorem normalizer_dilation_params_cover_nq_roots
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
@@ -324,7 +324,7 @@ theorem normalizer_dilation_params_cover_nq_roots
 
 
 theorem translationSet_stable_under_half_roots
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1) (hpm : p ^ m ≥ 5)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2)
     (hG_p : p ∣ Nat.card G)
@@ -362,7 +362,7 @@ theorem translationSet_scaled_eq_Fq_psl (m : ℕ) (hm : m ≥ 1) (hpm : p ^ m �
 
 
 theorem orbit_eq_infty_union_translations_psl
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1) (hpm : p ^ m ≥ 5)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2)
     (hG_p : p ∣ Nat.card G)
@@ -404,14 +404,14 @@ theorem orbit_eq_infty_union_translations_psl
 
 
 theorem orbit_infty_eq_P1Fq_psl_core
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1) (hpm : p ^ m ≥ 5)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2)
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hP_fix : ∀ g ∈ (P : Subgroup G).map (Subgroup.subtype G),
       g • infinity p = infinity p) :
-    ∃ g : PGL p,
+    ∃ g : PGLOf (K p),
       g • infinity p = infinity p ∧
       orbitInfty p (G.map (MulEquiv.toMonoidHom (MulAut.conj g))) = P1Fq p m := by
   have h_card : Set.ncard (orbitInfty p G) = Fintype.card (Sylow p G) := orbitInfty_ncard p G hG_p P hP_fix
@@ -459,10 +459,10 @@ theorem orbit_infty_eq_P1Fq_psl_core
 
 
 theorem orbit_infty_eq_P1Fq_psl
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1) (hpm : p ^ m ≥ 5)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2) :
-    ∃ g : PGL p,
+    ∃ g : PGLOf (K p),
       orbitInfty p (G.map (MulEquiv.toMonoidHom (MulAut.conj g))) = P1Fq p m := by
   have h_even : 2 ∣ p ^ (2 * m) - 1 := by
     rw [← even_iff_two_dvd, Nat.even_sub (Nat.one_le_pow _ _ (Nat.le_trans (by norm_num : 1 ≤ 2) (Fact.out : p > 2).le))]
@@ -496,10 +496,10 @@ theorem orbit_infty_eq_P1Fq_psl
 
 
 theorem G_preserves_P1Fq_psl
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1) (hpm : p ^ m ≥ 5)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2) :
-    ∃ g : PGL p,
+    ∃ g : PGLOf (K p),
       ∀ h ∈ G.map (MulEquiv.toMonoidHom (MulAut.conj g)),
         ∀ x ∈ P1Fq p m, h • x ∈ P1Fq p m := by
   obtain ⟨g, hg⟩ := orbit_infty_eq_P1Fq_psl p G m hm hpm hn
@@ -507,10 +507,10 @@ theorem G_preserves_P1Fq_psl
 
 
 theorem psl_G_le_pgl_range_from_orbit
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1) (hpm : p ^ m ≥ 5)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2) :
-    ∃ g : PGL p, G.map (MulEquiv.toMonoidHom (MulAut.conj g)) ≤
+    ∃ g : PGLOf (K p), G.map (MulEquiv.toMonoidHom (MulAut.conj g)) ≤
       (pglMap (galoisFieldRingHom (p := p) m)).range := by
   obtain ⟨g, hg⟩ := G_preserves_P1Fq_psl p G m hm hpm hn
   exact ⟨g, fun h hh ↦ preserves_P1Fq_in_range p m hm h (hg h hh)⟩

--- a/FLT/Slop/PGL2/FiniteSubgroups/PartitionHelpers.lean
+++ b/FLT/Slop/PGL2/FiniteSubgroups/PartitionHelpers.lean
@@ -12,10 +12,10 @@ public import FLT.Slop.PGL2.FiniteSubgroups.PGLBasic
 # Sylow `p`-subgroup lemmas for finite subgroups of `PGL₂(𝔽̄_p)`
 
 This file proves the basic facts about Sylow `p`-subgroups of a finite subgroup `G` of
-`PGL p = PGL₂(𝔽̄_p)` whose order is divisible by `p` (the *wild* case of Dickson's
+`PGLOf (K p) = PGL₂(𝔽̄_p)` whose order is divisible by `p` (the *wild* case of Dickson's
 classification).
 
-The key geometric input is that an element of order `p` in `PGL p` fixes exactly one
+The key geometric input is that an element of order `p` in `PGLOf (K p)` fixes exactly one
 point of the projective line. From this we deduce:
 * each Sylow `p`-subgroup `P` of `G` fixes a unique point `sylowFixedPoint`
   of `ℙ¹(𝔽̄_p)`, and distinct Sylow `p`-subgroups have distinct fixed points
@@ -53,14 +53,14 @@ noncomputable section PartitionHelpers
 variable (p : ℕ) [Fact (Nat.Prime p)] [h_odd : Fact (p > 2)]
 
 omit h_odd in
-theorem sylow_card_prime_pow (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_card_prime_pow (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     ∃ k : ℕ, k ≥ 1 ∧ Nat.card P = p ^ k :=
   ⟨(Nat.card G).factorization p,
     Nat.pos_of_ne_zero (Finsupp.mem_support_iff.mp <| Nat.mem_primeFactors.mpr ⟨Fact.out, hG_p, Nat.card_pos.ne'⟩),
     P.card_eq_multiplicity⟩
 
-theorem sylow_card_ge_3 (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_card_ge_3 (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     Nat.card P ≥ 3 := by
   obtain ⟨k, hk, hk_eq⟩ := sylow_card_prime_pow p G hG_p P
@@ -68,11 +68,11 @@ theorem sylow_card_ge_3 (G : Subgroup (PGL p)) [Finite G]
   exact (Nat.succ_le_of_lt (Fact.out : p > 2)).trans (Nat.le_self_pow (by omega) p)
 
 
-theorem sylow_unique_fixedPoint (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_unique_fixedPoint (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     ∃! x : ProjectiveLine p,
-      ∀ g : PGL p, g ∈ (P : Subgroup G).map (Subgroup.subtype G) → g • x = x := by
-  let P' : Subgroup (PGL p) := Subgroup.map (Subgroup.subtype G) (P : Subgroup G)
+      ∀ g : PGLOf (K p), g ∈ (P : Subgroup G).map (Subgroup.subtype G) → g • x = x := by
+  let P' : Subgroup (PGLOf (K p)) := Subgroup.map (Subgroup.subtype G) (P : Subgroup G)
   let e : (P : Subgroup G) ≃ P' := (Subgroup.equivMapOfInjective _ _ Subtype.coe_injective).toEquiv
   haveI : Finite P' := Finite.of_equiv _ e
 
@@ -85,64 +85,64 @@ theorem sylow_unique_fixedPoint (G : Subgroup (PGL p)) [Finite G]
 
 omit h_odd in
 @[nolint unusedArguments]
-theorem normalizer_stabilizes_fixedPoint (G : Subgroup (PGL p)) [Finite G]
+theorem normalizer_stabilizes_fixedPoint (G : Subgroup (PGLOf (K p))) [Finite G]
     (P : Sylow p G) (x : ProjectiveLine p)
-    (hx : ∀ g ∈ (P : Subgroup G), (g : PGL p) • x = x)
-    (hx_unique : ∀ y, (∀ g ∈ (P : Subgroup G), (g : PGL p) • y = y) → y = x) :
-    ∀ g ∈ Subgroup.normalizer ((P : Subgroup G) : Set G), (g : PGL p) • x = x := fun g hg ↦
-  have h_inv : (g⁻¹ : PGL p) • x = x := hx_unique _ fun h hh ↦ by
-    rw [← mul_smul, (show (h : PGL p) * (g⁻¹ : PGL p) = (g⁻¹ : PGL p) * (g * h * g⁻¹ : G) by
+    (hx : ∀ g ∈ (P : Subgroup G), (g : PGLOf (K p)) • x = x)
+    (hx_unique : ∀ y, (∀ g ∈ (P : Subgroup G), (g : PGLOf (K p)) • y = y) → y = x) :
+    ∀ g ∈ Subgroup.normalizer ((P : Subgroup G) : Set G), (g : PGLOf (K p)) • x = x := fun g hg ↦
+  have h_inv : (g⁻¹ : PGLOf (K p)) • x = x := hx_unique _ fun h hh ↦ by
+    rw [← mul_smul, (show (h : PGLOf (K p)) * (g⁻¹ : PGLOf (K p)) = (g⁻¹ : PGLOf (K p)) * (g * h * g⁻¹ : G) by
         simp only [Subgroup.coe_mul, Subgroup.coe_inv, ← mul_assoc, inv_mul_cancel, one_mul]),
       mul_smul, hx (g * h * g⁻¹) ((hg h).mp hh)]
-  (congr_arg (fun y ↦ (g : PGL p) • y) h_inv.symm).trans (smul_inv_smul (g : PGL p) x)
+  (congr_arg (fun y ↦ (g : PGLOf (K p)) • y) h_inv.symm).trans (smul_inv_smul (g : PGLOf (K p)) x)
 
-theorem sylow_element_order_p (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_element_order_p (G : Subgroup (PGLOf (K p))) [Finite G]
     (P : Sylow p G)
     (g : G) (hg : g ∈ (P : Subgroup G)) (hg_ne : g ≠ 1) :
-    orderOf (g : PGL p) = p := by
-  let P' : Subgroup (PGL p) := (P : Subgroup G).map (Subgroup.subtype G)
+    orderOf (g : PGLOf (K p)) = p := by
+  let P' : Subgroup (PGLOf (K p)) := (P : Subgroup G).map (Subgroup.subtype G)
   haveI : Finite P' := Finite.of_equiv P (Subgroup.equivMapOfInjective _ _ Subtype.coe_injective).toEquiv
   exact isPGroup_orderOf_eq_prime p P' (P.2.map (Subgroup.subtype G))
-    ⟨(g : PGL p), Subgroup.mem_map_of_mem (Subgroup.subtype G) hg⟩
+    ⟨(g : PGLOf (K p)), Subgroup.mem_map_of_mem (Subgroup.subtype G) hg⟩
     (fun h ↦ hg_ne <| Subtype.ext <| congr_arg (fun x : P' ↦ x.1) h)
 
-theorem order_p_one_fixedPoint (g : PGL p) (hg : orderOf g = p) :
+theorem order_p_one_fixedPoint (g : PGLOf (K p)) (hg : orderOf g = p) :
     Set.ncard (fixedPoints p g) = 1 :=
   (fixedPoints_dichotomy p g
     (fun h ↦ Nat.Prime.ne_one Fact.out (hg.symm.trans ((congr_arg orderOf h).trans orderOf_one)))
     (orderOf_pos_iff.mp (hg.symm ▸ Nat.Prime.pos Fact.out))).1.mpr hg
 
 /-- The unique fixed point on the projective line `ℙ¹(𝔽̄_p)` of a Sylow `p`-subgroup `P`. -/
-noncomputable def sylowFixedPoint (G : Subgroup (PGL p)) [Finite G]
+noncomputable def sylowFixedPoint (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) : ProjectiveLine p :=
   (sylow_unique_fixedPoint p G hG_p P).choose
 
-theorem sylow_element_fixes (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_element_fixes (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (g : G) (hg : g ∈ (P : Subgroup G)) :
-    (g : PGL p) • sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p P :=
+    (g : PGLOf (K p)) • sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p P :=
   (sylow_unique_fixedPoint p G hG_p P).choose_spec.1 g (Subgroup.mem_map_of_mem _ hg)
 
-theorem eq_sylow_fixedPoint (G : Subgroup (PGL p)) [Finite G]
+theorem eq_sylow_fixedPoint (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) (y : ProjectiveLine p)
-    (hy : ∀ g : G, g ∈ (P : Subgroup G) → (g : PGL p) • y = y) :
+    (hy : ∀ g : G, g ∈ (P : Subgroup G) → (g : PGLOf (K p)) • y = y) :
     y = sylowFixedPoint p G hG_p P :=
   (sylow_unique_fixedPoint p G hG_p P).choose_spec.2 y fun _ hg ↦ by
     obtain ⟨g', hg', rfl⟩ := Subgroup.mem_map.mp hg
     exact hy g' hg'
 
-theorem shared_element_shared_fixedPoint (G : Subgroup (PGL p)) [Finite G]
+theorem shared_element_shared_fixedPoint (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P Q : Sylow p G)
     (g : G) (hgP : g ∈ (P : Subgroup G)) (hgQ : g ∈ (Q : Subgroup G)) (hg_ne : g ≠ 1) :
     sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p Q := by
   obtain ⟨a, ha⟩ := Set.ncard_eq_one.mp <|
-    order_p_one_fixedPoint p (g : PGL p) (sylow_element_order_p p G P g hgP hg_ne)
+    order_p_one_fixedPoint p (g : PGLOf (K p)) (sylow_element_order_p p G P g hgP hg_ne)
   exact ((Set.ext_iff.mp ha _).mp (sylow_element_fixes p G hG_p P g hgP)).trans
     ((Set.ext_iff.mp ha _).mp (sylow_element_fixes p G hG_p Q g hgQ)).symm
 
 
 
-theorem sylow_pairwise_trivial_intersection (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_pairwise_trivial_intersection (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P Q : Sylow p G) (hPQ : P ≠ Q) :
     (P : Subgroup G) ⊓ (Q : Subgroup G) = ⊥ := by
   by_contra h_int
@@ -155,7 +155,7 @@ theorem sylow_pairwise_trivial_intersection (G : Subgroup (PGL p)) [Finite G]
   have h_comm_G : ∀ a ∈ P, ∀ b ∈ Q, a * b = b * a := fun a ha b hb ↦ by
     by_cases ha1 : a = 1; · rw [ha1, one_mul, mul_one]
     by_cases hb1 : b = 1; · rw [hb1, mul_one, one_mul]
-    exact Subtype.ext <| commute_of_orderOf_prime_common_fixedPoint p (a : PGL p) (b : PGL p)
+    exact Subtype.ext <| commute_of_orderOf_prime_common_fixedPoint p (a : PGLOf (K p)) (b : PGLOf (K p))
       (sylowFixedPoint p G hG_p P)
       (sylow_element_order_p p G P a ha ha1)
       (sylow_element_order_p p G Q b hb hb1)
@@ -195,7 +195,7 @@ theorem sylow_pairwise_trivial_intersection (G : Subgroup (PGL p)) [Finite G]
     (P.is_maximal' h_p_group le_sup_left) ▸ le_sup_right
 
 
-theorem count_order_p_elements (G : Subgroup (PGL p)) [Finite G]
+theorem count_order_p_elements (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     Nat.card {g : G | orderOf g = p} =
       Fintype.card (Sylow p G) * (Nat.card P - 1) := by
@@ -259,7 +259,7 @@ noncomputable section Borel
 variable (p : ℕ) [Fact (Nat.Prime p)] [h_odd : Fact (p > 2)]
 
 theorem fixes_infinity_commutes_order_p
-    (g h : PGL p)
+    (g h : PGLOf (K p))
     (hg_fix : g • infinity p = infinity p)
     (hh_fix : h • infinity p = infinity p)
     (hh_order : orderOf h = p)
@@ -350,7 +350,7 @@ theorem fixes_infinity_commutes_order_p
 
 
 theorem common_fixedPoint_commutes_order_p
-    (g h : PGL p) (x : ProjectiveLine p)
+    (g h : PGLOf (K p)) (x : ProjectiveLine p)
     (hg_fix : g • x = x) (hh_fix : h • x = x)
     (hh_order : orderOf h = p) (h_comm : g * h = h * g) :
     orderOf g = 1 ∨ orderOf g = p := by
@@ -362,7 +362,7 @@ theorem common_fixedPoint_commutes_order_p
   have h_comm' : (k * g * k⁻¹) * (k * h * k⁻¹) = (k * h * k⁻¹) * (k * g * k⁻¹) := by
     change (MulAut.conj k) g * (MulAut.conj k) h = (MulAut.conj k) h * (MulAut.conj k) g
     rw [← map_mul, ← map_mul, h_comm]
-  have ord_eq (z : PGL p) : orderOf (k * z * k⁻¹) = orderOf z :=
+  have ord_eq (z : PGLOf (K p)) : orderOf (k * z * k⁻¹) = orderOf z :=
     orderOf_injective (MulAut.conj k).toMonoidHom (MulAut.conj k).injective z
   rw [← ord_eq g]
   exact fixes_infinity_commutes_order_p p (k * g * k⁻¹) (k * h * k⁻¹)
@@ -370,10 +370,10 @@ theorem common_fixedPoint_commutes_order_p
 
 
 omit h_odd in
-theorem order_one_or_p_in_sylow (G : Subgroup (PGL p)) [Finite G]
+theorem order_one_or_p_in_sylow (G : Subgroup (PGLOf (K p))) [Finite G]
     (_hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (g : G) (hg_norm : g ∈ Subgroup.normalizer ((P : Subgroup G) : Set G))
-    (h_order : orderOf (g : PGL p) = 1 ∨ orderOf (g : PGL p) = p) :
+    (h_order : orderOf (g : PGLOf (K p)) = 1 ∨ orderOf (g : PGLOf (K p)) = p) :
     g ∈ (P : Subgroup G) := by
   have h_cyclic : IsPGroup p (Subgroup.zpowers g) := by
     rw [IsPGroup.iff_card, Nat.card_zpowers, ← Subgroup.orderOf_coe g]
@@ -383,7 +383,7 @@ theorem order_one_or_p_in_sylow (G : Subgroup (PGL p)) [Finite G]
     le_sup_right) ▸ Subgroup.mem_sup_left (Subgroup.mem_zpowers g)
 
 
-theorem normalizer_fixes_element_in_sylow (G : Subgroup (PGL p)) [Finite G]
+theorem normalizer_fixes_element_in_sylow (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (g : G) (hg_norm : g ∈ Subgroup.normalizer ((P : Subgroup G) : Set G))
     (h : G) (hh_in_P : h ∈ (P : Subgroup G)) (hh_ne : h ≠ 1)
@@ -391,12 +391,12 @@ theorem normalizer_fixes_element_in_sylow (G : Subgroup (PGL p)) [Finite G]
     g ∈ (P : Subgroup G) := by
   have h_comm_G : g * h = h * g := by
     rw [← mul_one (g * h), ← inv_mul_cancel g, ← mul_assoc, h_conj_eq]
-  have h_fixed : (g : PGL p) • sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p P :=
+  have h_fixed : (g : PGLOf (K p)) • sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p P :=
     normalizer_stabilizes_fixedPoint p G P (sylowFixedPoint p G hG_p P)
       (sylow_element_fixes p G hG_p P)
       (eq_sylow_fixedPoint p G hG_p P)
       g hg_norm
-  have h_order := common_fixedPoint_commutes_order_p p (g : PGL p) (h : PGL p)
+  have h_order := common_fixedPoint_commutes_order_p p (g : PGLOf (K p)) (h : PGLOf (K p))
     (sylowFixedPoint p G hG_p P) h_fixed
     (sylow_element_fixes p G hG_p P h hh_in_P)
     (sylow_element_order_p p G P h hh_in_P hh_ne)
@@ -404,7 +404,7 @@ theorem normalizer_fixes_element_in_sylow (G : Subgroup (PGL p)) [Finite G]
   exact order_one_or_p_in_sylow p G hG_p P g hg_norm h_order
 
 
-noncomputable instance conjOnP (G : Subgroup (PGL p)) (P : Sylow p G) :
+noncomputable instance conjOnP (G : Subgroup (PGLOf (K p))) (P : Sylow p G) :
     MulAction (↑(Subgroup.normalizer ((P : Subgroup G) : Set G))) (↑(P : Subgroup G)) where
   smul g h := ⟨g.val * h.val * g.val⁻¹, (g.prop h.val).1 h.prop⟩
   one_smul h := by
@@ -417,7 +417,7 @@ noncomputable instance conjOnP (G : Subgroup (PGL p)) (P : Sylow p G) :
     rw [mul_inv_rev, mul_assoc g₁.val, mul_assoc g₁.val, ← mul_assoc (g₂.val * h.val), ← mul_assoc g₁.val]
 
 
-theorem stabilizer_conj_eq_P (G : Subgroup (PGL p)) [Finite G]
+theorem stabilizer_conj_eq_P (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (h : ↑(P : Subgroup G)) (hh_ne : h ≠ 1) :
     MulAction.stabilizer (↑(Subgroup.normalizer ((P : Subgroup G) : Set G))) h =
@@ -438,7 +438,7 @@ theorem stabilizer_conj_eq_P (G : Subgroup (PGL p)) [Finite G]
   · exact Subtype.ext <| h_abelian g hg'
 
 
-theorem normalizer_complement_divides_main (G : Subgroup (PGL p)) [Finite G]
+theorem normalizer_complement_divides_main (G : Subgroup (PGLOf (K p))) [Finite G]
     (P : Sylow p G) (hG_p : p ∣ Nat.card G) :
     Nat.card (Subgroup.normalizer ((P : Subgroup G) : Set G)) / Nat.card P ∣
       Nat.card P - 1 := by
@@ -490,14 +490,14 @@ theorem normalizer_complement_divides_main (G : Subgroup (PGL p)) [Finite G]
 
 /-- The index `|N_G(P)| / |P|` of a Sylow `p`-subgroup `P` in its normalizer in `G`. -/
 @[nolint unusedArguments]
-def normalizerQuotient (G : Subgroup (PGL p)) [Finite G]
+def normalizerQuotient (G : Subgroup (PGLOf (K p))) [Finite G]
     (P : Sylow p G) : ℕ :=
   Nat.card (Subgroup.normalizer ((P : Subgroup G) : Set G)) / Nat.card P
 
 
 
 omit h_odd in
-theorem group_order_gt_normalizer (G : Subgroup (PGL p)) [Finite G]
+theorem group_order_gt_normalizer (G : Subgroup (PGLOf (K p))) [Finite G]
     (P : Sylow p G) (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :
     Nat.card G > Nat.card P * normalizerQuotient p G P := by
   have e : Nat.card (G ⧸ Subgroup.normalizer ((P : Subgroup G) : Set G)) =
@@ -545,14 +545,14 @@ theorem factorization_pgl_order (m : ℕ) (hm : m ≥ 1) :
 
 
 omit h_odd in
-theorem sylow_order_of_pgl_order (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_order_of_pgl_order (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1))
     (P : Sylow p G) :
     Nat.card P = p ^ m := by
   rw [P.card_eq_multiplicity, hn, factorization_pgl_order p m hm]
 
-theorem sylow_fixedPoint_injective (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_fixedPoint_injective (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) :
     Function.Injective (sylowFixedPoint p G hG_p) := by
   intro P Q hPQ
@@ -560,9 +560,9 @@ theorem sylow_fixedPoint_injective (G : Subgroup (PGL p)) [Finite G]
   have h_comm_G : ∀ (g : G) (_ : g ∈ (P : Subgroup G)) (h : G) (_ : h ∈ (Q : Subgroup G)), g * h = h * g := by
     intro g hg h hh
     refine Subtype.ext ?_
-    by_cases hg1 : g = 1; · rw [hg1]; exact Commute.one_left (h : PGL p)
-    by_cases hh1 : h = 1; · rw [hh1]; exact Commute.one_right (g : PGL p)
-    exact commute_of_orderOf_prime_common_fixedPoint p (g : PGL p) (h : PGL p) (sylowFixedPoint p G hG_p P)
+    by_cases hg1 : g = 1; · rw [hg1]; exact Commute.one_left (h : PGLOf (K p))
+    by_cases hh1 : h = 1; · rw [hh1]; exact Commute.one_right (g : PGLOf (K p))
+    exact commute_of_orderOf_prime_common_fixedPoint p (g : PGLOf (K p)) (h : PGLOf (K p)) (sylowFixedPoint p G hG_p P)
       (sylow_element_order_p p G P g hg hg1) (sylow_element_order_p p G Q h hh hh1)
       (sylow_element_fixes p G hG_p P g hg) (hPQ.symm ▸ sylow_element_fixes p G hG_p Q h hh)
 
@@ -591,8 +591,8 @@ theorem sylow_fixedPoint_injective (G : Subgroup (PGL p)) [Finite G]
       obtain ⟨n, hn⟩ := IsPGroup.iff_card.mp Q.2
       intro g
       obtain ⟨a, ha, b, hb, hg_eq⟩ := h_pq g g.2
-      have h_ord_div {H : Subgroup G} (x : G) (hx : x ∈ H) : orderOf (x : PGL p) ∣ Nat.card H :=
-        (show orderOf (x : PGL p) ∣ Nat.card (Subgroup.zpowers x) by simp only [orderOf_submonoid, Nat.card_zpowers, dvd_refl]).trans
+      have h_ord_div {H : Subgroup G} (x : G) (hx : x ∈ H) : orderOf (x : PGLOf (K p)) ∣ Nat.card H :=
+        (show orderOf (x : PGLOf (K p)) ∣ Nat.card (Subgroup.zpowers x) by simp only [orderOf_submonoid, Nat.card_zpowers, dvd_refl]).trans
           (Subgroup.card_dvd_of_le (Subgroup.zpowers_le.mpr hx))
       use m + n
       ext
@@ -607,12 +607,12 @@ theorem sylow_fixedPoint_injective (G : Subgroup (PGL p)) [Finite G]
   have h_card : Nat.card (Q : Subgroup G) = Nat.card (P : Subgroup G) := by rw [P.card_eq_multiplicity, Q.card_eq_multiplicity]
   exact h_contra <| Sylow.ext <| SetLike.ext' <| (Set.eq_of_subset_of_ncard_le h_eq h_card.ge).symm
 
-theorem sylow_free_action (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_free_action (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P Q : Sylow p G) (hPQ : P ≠ Q)
     (g : G) (hg : g ∈ (P : Subgroup G)) (hg_ne : g ≠ 1) :
-    (g : PGL p) • sylowFixedPoint p G hG_p Q ≠ sylowFixedPoint p G hG_p Q := by
+    (g : PGLOf (K p)) • sylowFixedPoint p G hG_p Q ≠ sylowFixedPoint p G hG_p Q := by
   intro h_fix
-  obtain ⟨x, hx⟩ := Set.ncard_eq_one.mp <| order_p_one_fixedPoint p (g : PGL p) (sylow_element_order_p p G P g hg hg_ne)
+  obtain ⟨x, hx⟩ := Set.ncard_eq_one.mp <| order_p_one_fixedPoint p (g : PGLOf (K p)) (sylow_element_order_p p G P g hg hg_ne)
   have hP_mem : sylowFixedPoint p G hG_p P ∈ fixedPoints p ↑g := sylow_element_fixes p G hG_p P g hg
   have hQ_mem : sylowFixedPoint p G hG_p Q ∈ fixedPoints p ↑g := h_fix
   rw [hx, Set.mem_singleton_iff] at hP_mem hQ_mem
@@ -620,7 +620,7 @@ theorem sylow_free_action (G : Subgroup (PGL p)) [Finite G]
 
 
 
-theorem card_sylow_mod_card (G : Subgroup (PGL p)) [Finite G]
+theorem card_sylow_mod_card (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     Nat.card P ∣ (Fintype.card (Sylow p G) - 1) := by
   set S : Finset (Sylow p G) := Finset.univ \ {P} with hS_def
@@ -667,7 +667,7 @@ theorem card_sylow_mod_card (G : Subgroup (PGL p)) [Finite G]
     obtain ⟨Q, hQ, rfl⟩ := Finset.mem_image.mp ho
     exact h_orbit_size Q hQ ▸ dvd_rfl
 
-theorem n_p_eq_pgl (G : Subgroup (PGL p)) [Finite G]
+theorem n_p_eq_pgl (G : Subgroup (PGLOf (K p))) [Finite G]
     (m : ℕ) (hm : m ≥ 1)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1))
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :

--- a/FLT/Slop/PGL2/FiniteSubgroups/PartitionProof.lean
+++ b/FLT/Slop/PGL2/FiniteSubgroups/PartitionProof.lean
@@ -13,7 +13,7 @@ public import FLT.Slop.PGL2.FiniteSubgroups.RecognitionA5
 /-!
 # The partition equation for wild finite subgroups of `PGL₂(𝔽̄_p)`
 
-Let `G` be a finite subgroup of `PGL p = PGL₂(𝔽̄_p)` with `p` dividing `|G|`. This file
+Let `G` be a finite subgroup of `PGLOf (K p) = PGL₂(𝔽̄_p)` with `p` dividing `|G|`. This file
 studies the set `Dickson.Phi G ⊆ ℙ¹(𝔽̄_p)` of fixed points of nontrivial elements
 of `G`, via a double-counting (Burnside/orbit-counting) argument on the action of `G`
 on `Phi G`.
@@ -53,18 +53,18 @@ variable (p : ℕ) [Fact (Nat.Prime p)] [h_odd : Fact (p > 2)]
 
 
 /-- The set of points on the projective line fixed by some non-identity element of `G`. -/
-def Phi (G : Subgroup (PGL p)) : Set (ProjectiveLine p) :=
-  ⋃ (g : G) (_ : g ≠ 1), {x : ProjectiveLine p | (g : PGL p) • x = x}
+def Phi (G : Subgroup (PGLOf (K p))) : Set (ProjectiveLine p) :=
+  ⋃ (g : G) (_ : g ≠ 1), {x : ProjectiveLine p | (g : PGLOf (K p)) • x = x}
 
 
-lemma Phi_finite (G : Subgroup (PGL p)) [Finite G] : (Phi p G).Finite := by
+lemma Phi_finite (G : Subgroup (PGLOf (K p))) [Finite G] : (Phi p G).Finite := by
   refine' Set.Finite.biUnion (Set.toFinite _) fun g hg ↦ _
-  have h_order : IsOfFinOrder (g : PGL p) := by
+  have h_order : IsOfFinOrder (g : PGLOf (K p)) := by
     obtain ⟨n, hn_pos, hn_eq⟩ := isOfFinOrder_iff_pow_eq_one.mp (isOfFinOrder_of_finite g)
     exact isOfFinOrder_iff_pow_eq_one.mpr ⟨n, hn_pos, Subtype.ext_iff.mp hn_eq⟩
-  have h_dichotomy := fixedPoints_dichotomy p (g : PGL p) (fun h ↦ hg (Subtype.ext h)) h_order
-  have h_ncard_pos : 0 < Set.ncard {x : ProjectiveLine p | (g : PGL p) • x = x} := by
-    change 0 < Set.ncard (fixedPoints p (g : PGL p))
+  have h_dichotomy := fixedPoints_dichotomy p (g : PGLOf (K p)) (fun h ↦ hg (Subtype.ext h)) h_order
+  have h_ncard_pos : 0 < Set.ncard {x : ProjectiveLine p | (g : PGLOf (K p)) • x = x} := by
+    change 0 < Set.ncard (fixedPoints p (g : PGLOf (K p)))
     rcases element_dichotomy p G g with hp | hcoprime
     · rw [h_dichotomy.1.mpr hp]
       norm_num
@@ -73,8 +73,8 @@ lemma Phi_finite (G : Subgroup (PGL p)) [Finite G] : (Phi p G).Finite := by
   exact Set.finite_of_ncard_pos h_ncard_pos
 
 omit h_odd in
-lemma Phi_smul_mem (G : Subgroup (PGL p)) (h : G) {x : ProjectiveLine p}
-    (hx : x ∈ Phi p G) : (h : PGL p) • x ∈ Phi p G := by
+lemma Phi_smul_mem (G : Subgroup (PGLOf (K p))) (h : G) {x : ProjectiveLine p}
+    (hx : x ∈ Phi p G) : (h : PGLOf (K p)) • x ∈ Phi p G := by
   simp only [Phi, Set.mem_iUnion, Set.mem_setOf_eq] at hx ⊢
   obtain ⟨g, hg_ne, hgx⟩ := hx
   exact ⟨h * g * h⁻¹,
@@ -85,19 +85,19 @@ lemma Phi_smul_mem (G : Subgroup (PGL p)) (h : G) {x : ProjectiveLine p}
 
 
 /-- The subtype of points on the projective line fixed by some non-identity element of `G`. -/
-abbrev PhiType (G : Subgroup (PGL p)) := ↥(Phi p G)
+abbrev PhiType (G : Subgroup (PGLOf (K p))) := ↥(Phi p G)
 
-noncomputable instance phiFintype (G : Subgroup (PGL p)) [Finite G] :
+noncomputable instance phiFintype (G : Subgroup (PGLOf (K p))) [Finite G] :
     Fintype (PhiType p G) := (Phi_finite p G).fintype
 
 
-instance phiMulAction (G : Subgroup (PGL p)) : MulAction G (PhiType p G) where
-  smul h x := ⟨(h : PGL p) • x.val, Phi_smul_mem p G h x.prop⟩
-  one_smul x := Subtype.ext (one_smul (PGL p) x.val)
-  mul_smul g₁ g₂ x := Subtype.ext (mul_smul (g₁ : PGL p) (g₂ : PGL p) x.val)
+instance phiMulAction (G : Subgroup (PGLOf (K p))) : MulAction G (PhiType p G) where
+  smul h x := ⟨(h : PGLOf (K p)) • x.val, Phi_smul_mem p G h x.prop⟩
+  one_smul x := Subtype.ext (one_smul (PGLOf (K p)) x.val)
+  mul_smul g₁ g₂ x := Subtype.ext (mul_smul (g₁ : PGLOf (K p)) (g₂ : PGLOf (K p)) x.val)
 
 
-lemma sylow_fixedPt_mem_Phi (G : Subgroup (PGL p)) [Finite G]
+lemma sylow_fixedPt_mem_Phi (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     sylowFixedPoint p G hG_p P ∈ Phi p G := by
   obtain ⟨g, hg_mem, hg_ne⟩ : ∃ g : G, g ∈ (P : Subgroup G) ∧ g ≠ 1 := by
@@ -108,18 +108,18 @@ lemma sylow_fixedPt_mem_Phi (G : Subgroup (PGL p)) [Finite G]
   exact Set.mem_iUnion₂.mpr ⟨g, hg_ne, sylow_element_fixes p G hG_p P g hg_mem⟩
 
 
-lemma Phi_card_le (G : Subgroup (PGL p)) [Finite G] :
+lemma Phi_card_le (G : Subgroup (PGLOf (K p))) [Finite G] :
     Fintype.card (PhiType p G) ≤ 2 * (Nat.card G - 1) := by
 
-  have h_fixed : ∀ (g : G), g ≠ 1 → Set.ncard {x : ProjectiveLine p | (g : PGL p) • x = x} ≤ 2 := by
+  have h_fixed : ∀ (g : G), g ≠ 1 → Set.ncard {x : ProjectiveLine p | (g : PGLOf (K p)) • x = x} ≤ 2 := by
     intro g hg
-    have h_dich := fixedPoints_dichotomy p (g : PGL p) (fun h ↦ hg (Subtype.ext h)) (Submonoid.isOfFinOrder_coe.mpr (isOfFinOrder_of_finite g))
+    have h_dich := fixedPoints_dichotomy p (g : PGLOf (K p)) (fun h ↦ hg (Subtype.ext h)) (Submonoid.isOfFinOrder_coe.mpr (isOfFinOrder_of_finite g))
     rcases element_dichotomy p G g with hp | hcop
     · exact (h_dich.1.mpr hp).symm ▸ by norm_num
     · exact (h_dich.2.mpr hcop.symm).symm ▸ le_rfl
 
   have h_card : ∀ s : Finset G, 1 ∉ s →
-      Set.ncard (⋃ g ∈ (s : Set G), {x : ProjectiveLine p | (g : PGL p) • x = x}) ≤ 2 * s.card := by
+      Set.ncard (⋃ g ∈ (s : Set G), {x : ProjectiveLine p | (g : PGLOf (K p)) • x = x}) ≤ 2 * s.card := by
     intro s
     induction s using Finset.induction with
     | empty =>
@@ -133,7 +133,7 @@ lemma Phi_card_le (G : Subgroup (PGL p)) [Finite G] :
 
   rw [← Nat.card_eq_fintype_card]
   change Set.ncard (Phi p G) ≤ _
-  have h_phi : Phi p G = ⋃ g ∈ (Finset.univ.erase (1 : G) : Set G), {x | (g : PGL p) • x = x} := by
+  have h_phi : Phi p G = ⋃ g ∈ (Finset.univ.erase (1 : G) : Set G), {x | (g : PGLOf (K p)) • x = x} := by
     ext x
     simp only [Phi, Set.mem_iUnion, Set.mem_setOf_eq, Finset.mem_coe, Finset.mem_erase, Finset.mem_univ, and_true, exists_prop]
   rw [h_phi]
@@ -142,7 +142,7 @@ lemma Phi_card_le (G : Subgroup (PGL p)) [Finite G] :
   rw [Finset.card_erase_of_mem (Finset.mem_univ (1 : G)), Finset.card_univ, ← Nat.card_eq_fintype_card] at h_bound
   exact h_bound
 
-theorem sylow_distinct_fixedPoints (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_distinct_fixedPoints (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P Q : Sylow p G) (hPQ : P ≠ Q) :
     sylowFixedPoint p G hG_p P ≠ sylowFixedPoint p G hG_p Q := by
   intro h_eq
@@ -194,9 +194,9 @@ theorem sylow_distinct_fixedPoints (G : Subgroup (PGL p)) [Finite G]
 
   exact hPQ (Sylow.ext hQ_eq_P.symm)
 
-theorem fixes_sylowPoint_normalizes (G : Subgroup (PGL p)) [Finite G]
+theorem fixes_sylowPoint_normalizes (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
-    (g : G) (hg : (g : PGL p) • sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p P) :
+    (g : G) (hg : (g : PGLOf (K p)) • sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p P) :
     g ∈ Subgroup.normalizer ((P : Subgroup G) : Set G) := by
   rw [Subgroup.mem_normalizer_iff]
   have h_map : Subgroup.map (MulAut.conj g) (P : Subgroup G) = (P : Subgroup G) :=
@@ -223,9 +223,9 @@ theorem fixes_sylowPoint_normalizes (G : Subgroup (PGL p)) [Finite G]
     _ = y := by group]
   exact hy
 
-theorem stabilizer_sylowFixedPoint_eq_normalizer (G : Subgroup (PGL p)) [Finite G]
+theorem stabilizer_sylowFixedPoint_eq_normalizer (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
-    {g : G | (g : PGL p) • sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p P} =
+    {g : G | (g : PGLOf (K p)) • sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p P} =
     (Subgroup.normalizer ((P : Subgroup G) : Set G) : Set G) := by
   have h_norm := normalizer_stabilizes_fixedPoint p G P _
     (sylow_element_fixes p G hG_p P)
@@ -233,7 +233,7 @@ theorem stabilizer_sylowFixedPoint_eq_normalizer (G : Subgroup (PGL p)) [Finite 
   exact Set.ext fun g ↦ ⟨fixes_sylowPoint_normalizes p G hG_p P g, h_norm g⟩
 
 
-lemma sylow_fixedPt_injective (G : Subgroup (PGL p)) [Finite G]
+lemma sylow_fixedPt_injective (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) :
     Function.Injective (fun P : Sylow p G ↦
       (⟨sylowFixedPoint p G hG_p P, sylow_fixedPt_mem_Phi p G hG_p P⟩ : PhiType p G)) := by
@@ -242,10 +242,10 @@ lemma sylow_fixedPt_injective (G : Subgroup (PGL p)) [Finite G]
 
 
 
-lemma fixedBy_eq_fixedPoints (G : Subgroup (PGL p)) [Finite G]
+lemma fixedBy_eq_fixedPoints (G : Subgroup (PGLOf (K p))) [Finite G]
     (g : G) (hg : g ≠ 1) :
     Fintype.card (MulAction.fixedBy (PhiType p G) g) =
-    Set.ncard (fixedPoints p (g : PGL p)) := by
+    Set.ncard (fixedPoints p (g : PGLOf (K p))) := by
   rw [← Nat.card_eq_fintype_card, ← Nat.card_coe_set_eq]
   exact Nat.card_congr {
     toFun := fun x ↦ ⟨x.1.1, Subtype.ext_iff.mp x.2⟩
@@ -254,9 +254,9 @@ lemma fixedBy_eq_fixedPoints (G : Subgroup (PGL p)) [Finite G]
     right_inv := fun _ ↦ Subtype.ext rfl
   }
 
-theorem count_elements_order_p (G : Subgroup (PGL p)) [Finite G]
+theorem count_elements_order_p (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
-    Nat.card {g : G | g ≠ 1 ∧ orderOf (g : PGL p) = p} =
+    Nat.card {g : G | g ≠ 1 ∧ orderOf (g : PGLOf (K p)) = p} =
       Fintype.card (Sylow p G) * (Nat.card P - 1) := by
   rw [← count_order_p_elements p G hG_p P]
   congr with g
@@ -266,31 +266,31 @@ theorem count_elements_order_p (G : Subgroup (PGL p)) [Finite G]
   rw [orderOf_one] at h
   exact Nat.Prime.ne_one Fact.out h.symm
 
-lemma element_fixedPt_sum (G : Subgroup (PGL p)) [Finite G]
+lemma element_fixedPt_sum (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     let _ : Fintype G := Fintype.ofFinite G
     ∑ g ∈ (Finset.univ : Finset G).erase 1,
-      Set.ncard (fixedPoints p ((g : G) : PGL p)) =
+      Set.ncard (fixedPoints p ((g : G) : PGLOf (K p))) =
     2 * (Nat.card G - 1) -
       Fintype.card (Sylow p G) * (Nat.card P - 1) := by
   intro _
   refine' eq_tsub_of_add_eq _
-  have h_eq : ∀ g ∈ (Finset.univ : Finset G).erase 1, Set.ncard (fixedPoints p (g : PGL p)) = if orderOf (g : PGL p) = p then 1 else 2 := fun g hg ↦ by
+  have h_eq : ∀ g ∈ (Finset.univ : Finset G).erase 1, Set.ncard (fixedPoints p (g : PGLOf (K p))) = if orderOf (g : PGLOf (K p)) = p then 1 else 2 := fun g hg ↦ by
     have hg_ne : g ≠ 1 := Finset.ne_of_mem_erase hg
-    have h_dich := fixedPoints_dichotomy p (g : PGL p) (fun h ↦ hg_ne (Subtype.ext h)) (Submonoid.isOfFinOrder_coe.mpr (isOfFinOrder_of_finite g))
+    have h_dich := fixedPoints_dichotomy p (g : PGLOf (K p)) (fun h ↦ hg_ne (Subtype.ext h)) (Submonoid.isOfFinOrder_coe.mpr (isOfFinOrder_of_finite g))
     split_ifs with h_p
     · exact h_dich.1.mpr h_p
     · exact h_dich.2.mpr ((element_dichotomy p G g).resolve_left h_p).symm
   rw [Finset.sum_congr rfl h_eq, Finset.sum_ite, Finset.sum_const, Finset.sum_const]
   simp only [smul_eq_mul, mul_one]
-  have h_card_p : Nat.card ↥(((Finset.univ : Finset G).erase 1).filter (fun (x : G) ↦ orderOf (x : PGL p) = p)) = Nat.card {g : G | g ≠ 1 ∧ orderOf (g : PGL p) = p} := by
-    have h_set : ((((Finset.univ : Finset G).erase 1).filter (fun (x : G) ↦ orderOf (x : PGL p) = p)) : Set G) = {g : G | g ≠ 1 ∧ orderOf (g : PGL p) = p} := by
+  have h_card_p : Nat.card ↥(((Finset.univ : Finset G).erase 1).filter (fun (x : G) ↦ orderOf (x : PGLOf (K p)) = p)) = Nat.card {g : G | g ≠ 1 ∧ orderOf (g : PGLOf (K p)) = p} := by
+    have h_set : ((((Finset.univ : Finset G).erase 1).filter (fun (x : G) ↦ orderOf (x : PGLOf (K p)) = p)) : Set G) = {g : G | g ≠ 1 ∧ orderOf (g : PGLOf (K p)) = p} := by
       ext g
       simp only [Finset.mem_coe, Finset.mem_filter, Set.mem_setOf_eq, Finset.mem_erase]
       exact ⟨fun h ↦ ⟨h.1.1, h.2⟩, fun h ↦ ⟨⟨h.1, Finset.mem_univ g⟩, h.2⟩⟩
     exact congrArg (fun (s : Set G) ↦ Nat.card ↥s) h_set
-  have h_card_cop : Nat.card ↥(((Finset.univ : Finset G).erase 1).filter (fun (x : G) ↦ ¬orderOf (x : PGL p) = p)) = Nat.card {g : G | g ≠ 1 ∧ Nat.Coprime (orderOf (g : PGL p)) p} := by
-    have h_set : ((((Finset.univ : Finset G).erase 1).filter (fun (x : G) ↦ ¬orderOf (x : PGL p) = p)) : Set G) = {g : G | g ≠ 1 ∧ Nat.Coprime (orderOf (g : PGL p)) p} := by
+  have h_card_cop : Nat.card ↥(((Finset.univ : Finset G).erase 1).filter (fun (x : G) ↦ ¬orderOf (x : PGLOf (K p)) = p)) = Nat.card {g : G | g ≠ 1 ∧ Nat.Coprime (orderOf (g : PGLOf (K p))) p} := by
+    have h_set : ((((Finset.univ : Finset G).erase 1).filter (fun (x : G) ↦ ¬orderOf (x : PGLOf (K p)) = p)) : Set G) = {g : G | g ≠ 1 ∧ Nat.Coprime (orderOf (g : PGLOf (K p))) p} := by
       ext g
       simp only [Finset.mem_coe, Finset.mem_filter, Set.mem_setOf_eq, Finset.mem_erase]
       exact ⟨fun h ↦ ⟨h.1.1, (element_dichotomy p G g).resolve_left h.2⟩,
@@ -308,7 +308,7 @@ lemma element_fixedPt_sum (G : Subgroup (PGL p)) [Finite G]
 
 
 omit h_odd in
-lemma phi_stab_card_ge_two (G : Subgroup (PGL p)) [Finite G]
+lemma phi_stab_card_ge_two (G : Subgroup (PGLOf (K p))) [Finite G]
     (x : PhiType p G) :
     2 ≤ Nat.card (MulAction.stabilizer G x) := by
   obtain ⟨g, hg_ne, hgx⟩ := Set.mem_iUnion₂.mp x.prop
@@ -321,7 +321,7 @@ lemma phi_stab_card_ge_two (G : Subgroup (PGL p)) [Finite G]
 
 
 
-lemma orbit_count_mul_card (G : Subgroup (PGL p)) [Finite G] :
+lemma orbit_count_mul_card (G : Subgroup (PGLOf (K p))) [Finite G] :
     Fintype.card (Quotient (MulAction.orbitRel G (PhiType p G))) * Nat.card G =
     ∑ x : PhiType p G, Nat.card (MulAction.stabilizer G x) := by
   simp only [Nat.card_eq_fintype_card]
@@ -330,7 +330,7 @@ lemma orbit_count_mul_card (G : Subgroup (PGL p)) [Finite G] :
   exact (Finset.sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow fun x g ↦ g • x = x).symm
 
 
-lemma nonsplit_D_lt_n (G : Subgroup (PGL p)) [Finite G]
+lemma nonsplit_D_lt_n (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :
     (Nat.card P - 2) * Fintype.card (Sylow p G) + 2 < Nat.card G := by
@@ -354,7 +354,7 @@ lemma nonsplit_D_lt_n (G : Subgroup (PGL p)) [Finite G]
     Nat.le_of_dvd Nat.card_pos (Nat.Coprime.mul_dvd_of_dvd_of_dvd h_coprime_full h_dvd_both.1 h_dvd_both.2)
   nlinarith only [h_n_gt_pm, h_n_gt_2p, h_mul_le_card, Nat.sub_add_cancel (by omega : 2 ≤ Nat.card P)]
 
-lemma fixedBy_sum_eq (G : Subgroup (PGL p)) [Finite G]
+lemma fixedBy_sum_eq (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     let _ : Fintype G := Fintype.ofFinite G
     ∑ g : G, Fintype.card (MulAction.fixedBy (PhiType p G) g) =
@@ -370,7 +370,7 @@ lemma fixedBy_sum_eq (G : Subgroup (PGL p)) [Finite G]
       Finset.sum_congr rfl fun g hg ↦ fixedBy_eq_fixedPoints p G g (Finset.ne_of_mem_erase hg),
       element_fixedPt_sum p G hG_p P]
 
-lemma stab_sum_eq_phi_plus_element (G : Subgroup (PGL p)) [Finite G]
+lemma stab_sum_eq_phi_plus_element (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     ∑ x : PhiType p G, Nat.card (MulAction.stabilizer G x) =
     Fintype.card (PhiType p G) +
@@ -384,7 +384,7 @@ lemma stab_sum_eq_phi_plus_element (G : Subgroup (PGL p)) [Finite G]
       fixedBy_sum_eq p G hG_p P]
 
 
-lemma sylow_orbit_size (G : Subgroup (PGL p)) [Finite G]
+lemma sylow_orbit_size (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     Fintype.card (MulAction.orbit G
       (⟨sylowFixedPoint p G hG_p P,
@@ -397,7 +397,7 @@ lemma sylow_orbit_size (G : Subgroup (PGL p)) [Finite G]
     Nat.card_congr (MulAction.orbitEquivQuotientStabilizer G x), h_stab]
   exact (Nat.card_congr (Sylow.equivQuotientNormalizer P)).symm
 
-lemma sylow_fixedPt_phiStab (G : Subgroup (PGL p)) [Finite G]
+lemma sylow_fixedPt_phiStab (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (Q : Sylow p G) :
     let x : PhiType p G := ⟨sylowFixedPoint p G hG_p Q, sylow_fixedPt_mem_Phi p G hG_p Q⟩
     Nat.card (MulAction.stabilizer G x) = Nat.card G / Fintype.card (Sylow p G) := by
@@ -408,7 +408,7 @@ lemma sylow_fixedPt_phiStab (G : Subgroup (PGL p)) [Finite G]
     exact (MulAction.card_orbit_mul_card_stabilizer_eq_card_group G x).symm
 
 
-lemma stab_sum_lower_bound (G : Subgroup (PGL p)) [Finite G]
+lemma stab_sum_lower_bound (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) :
     ∑ x : PhiType p G, Nat.card (MulAction.stabilizer G x) ≥
     Nat.card G + 2 * (Fintype.card (PhiType p G) - Fintype.card (Sylow p G)) := by
@@ -444,7 +444,7 @@ lemma stab_sum_lower_bound (G : Subgroup (PGL p)) [Finite G]
   rw [h_split, h_S]
   exact Nat.add_le_add_left h_Sc _
 
-lemma num_orbits_eq_two (G : Subgroup (PGL p)) [Finite G]
+lemma num_orbits_eq_two (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :
     Fintype.card (Quotient (MulAction.orbitRel G (PhiType p G))) = 2 := by
@@ -490,7 +490,7 @@ noncomputable section PartitionProof
 variable (p : ℕ) [Fact (Nat.Prime p)] [h_odd : Fact (p > 2)]
 
 omit h_odd in
-theorem card_eq_pm_z1_np' (G : Subgroup (PGL p)) [Finite G]
+theorem card_eq_pm_z1_np' (G : Subgroup (PGLOf (K p))) [Finite G]
     (P : Sylow p G) :
     Nat.card G = Nat.card P * normalizerQuotient p G P *
       Fintype.card (Sylow p G) := by
@@ -580,7 +580,7 @@ theorem branch2_params_of_divisibility
     · exfalso; revert h_div; norm_num
     · right; right; right; exact ⟨rfl, rfl, rfl⟩
 
-theorem nonsplit_torus_divides_geo (G : Subgroup (PGL p)) [Finite G]
+theorem nonsplit_torus_divides_geo (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :
     ((Nat.card P - 2) * Fintype.card (Sylow p G) + 2) ∣ Nat.card G := by
@@ -670,7 +670,7 @@ theorem nonsplit_torus_ge_two_arith
       omega
   · exact Nat.le_add_left 2 k
 
-theorem branch2_params (G : Subgroup (PGL p)) [Finite G]
+theorem branch2_params (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :
     let pm := Nat.card P
@@ -704,7 +704,7 @@ theorem branch2_params (G : Subgroup (PGL p)) [Finite G]
   exact branch2_params_of_divisibility pm z₁ n_p hpm_ge3 hpm_odd hz₁_ge1 hz₁_dvd
     hn_p_gt1 hn_p_cong hD_dvd (nonsplit_torus_ge_two_arith pm z₁ n_p hpm_ge3 hz₁_ge1 (by omega) hD_dvd)
 
-theorem nonsplit_torus_ge_two (G : Subgroup (PGL p)) [Finite G]
+theorem nonsplit_torus_ge_two (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :
     Nat.card G / ((Nat.card P - 2) * Fintype.card (Sylow p G) + 2) ≥ 2 := by

--- a/FLT/Slop/PGL2/FiniteSubgroups/RecognitionA5.lean
+++ b/FLT/Slop/PGL2/FiniteSubgroups/RecognitionA5.lean
@@ -13,13 +13,13 @@ public import FLT.Slop.PGL2.FiniteSubgroups.PGLBasic
 # Recognition of `A₅` inside `PGL₂(𝔽̄_p)`
 
 This file proves `Dickson.recognition_A5`-style results: a finite subgroup of
-`PGL p = PGL₂(𝔽̄_p)` of order 60 satisfying the constraints arising in the wild case
+`PGLOf (K p) = PGL₂(𝔽̄_p)` of order 60 satisfying the constraints arising in the wild case
 of Dickson's classification is isomorphic to the alternating group `A₅`.
 
 The proof is the classical Sylow-theoretic argument that a group of order 60 with no
 normal Sylow subgroups is simple, hence isomorphic to `A₅` (via the action on the five
 Sylow 2-subgroups / cosets argument), combined with the dichotomy
-`Dickson.element_dichotomy` for elements of a finite subgroup of `PGL p`: every
+`Dickson.element_dichotomy` for elements of a finite subgroup of `PGLOf (K p)`: every
 element either has order `p` or has order coprime to `p`.
 -/
 
@@ -75,23 +75,23 @@ variable (p : ℕ) [Fact (Nat.Prime p)] [h_odd : Fact (p > 2)]
 
 
 omit h_odd in
-lemma commute_preserves_fixedPoint (g h : PGL p) (x : ProjectiveLine p)
+lemma commute_preserves_fixedPoint (g h : PGLOf (K p)) (x : ProjectiveLine p)
     (hcomm : g * h = h * g) (hfx : h • x = x) :
     h • (g • x) = g • x := by
   rw [← mul_smul, ← hcomm, mul_smul, hfx]
 
-lemma order_p_one_fixed_point (g : PGL p) (hg : orderOf g = p) :
+lemma order_p_one_fixed_point (g : PGLOf (K p)) (hg : orderOf g = p) :
     Set.ncard (fixedPoints p g) = 1 :=
   (fixedPoints_dichotomy p g
     (fun h ↦ Nat.Prime.ne_one Fact.out (hg.symm.trans ((congrArg orderOf h).trans orderOf_one)))
     (orderOf_pos_iff.mp (hg.symm ▸ Nat.Prime.pos Fact.out))).1.mpr hg
 
-lemma coprime_order_two_fixed_points (h : PGL p) (hh_ne : h ≠ 1)
+lemma coprime_order_two_fixed_points (h : PGLOf (K p)) (hh_ne : h ≠ 1)
     (hh_fin : IsOfFinOrder h) (hh_cop : Nat.Coprime (orderOf h) p) :
     Set.ncard (fixedPoints p h) = 2 :=
   (fixedPoints_dichotomy p h hh_ne hh_fin).2.mpr hh_cop.symm
 
-lemma two_fixed_points_contradicts_order_p (g : PGL p) (x y : ProjectiveLine p)
+lemma two_fixed_points_contradicts_order_p (g : PGLOf (K p)) (x y : ProjectiveLine p)
     (hg_order : orderOf g = p)
     (hxy : x ≠ y) (hfx : g • x = x) (hfy : g • y = y) : False :=
   let ⟨_, ha⟩ := Set.ncard_eq_one.mp (order_p_one_fixed_point p g hg_order)
@@ -99,7 +99,7 @@ lemma two_fixed_points_contradicts_order_p (g : PGL p) (x y : ProjectiveLine p)
     ((Set.eq_singleton_iff_unique_mem.mp ha).2 x hfx).trans
     ((Set.eq_singleton_iff_unique_mem.mp ha).2 y hfy).symm
 
-lemma swap_contradicts_odd_order (g : PGL p) (x y : ProjectiveLine p)
+lemma swap_contradicts_odd_order (g : PGLOf (K p)) (x y : ProjectiveLine p)
     (hg_order : orderOf g = p)
     (hxy : x ≠ y) (hswap_x : g • x = y) (hswap_y : g • y = x) : False :=
   two_fixed_points_contradicts_order_p p (g^2) x y
@@ -112,7 +112,7 @@ lemma swap_contradicts_odd_order (g : PGL p) (x y : ProjectiveLine p)
     (by rw [sq, mul_smul, hswap_x, hswap_y])
     (by rw [sq, mul_smul, hswap_y, hswap_x])
 
-theorem no_commute_p_coprime (g h : PGL p) (_ : g ≠ 1) (hh_ne : h ≠ 1)
+theorem no_commute_p_coprime (g h : PGLOf (K p)) (_ : g ≠ 1) (hh_ne : h ≠ 1)
     (hg_order : orderOf g = p) (hh_fin : IsOfFinOrder h)
     (hh_coprime : Nat.Coprime (orderOf h) p)
     (hcomm : g * h = h * g) :
@@ -127,15 +127,15 @@ theorem no_commute_p_coprime (g h : PGL p) (_ : g ≠ 1) (hh_ne : h ≠ 1)
   | Or.inr hgx, Or.inl hgy => exact swap_contradicts_odd_order p g x y hg_order hxy hgx hgy
   | Or.inr hgx, Or.inr hgy => exact absurd (MulAction.injective g (hgx.trans hgy.symm)) hxy
 
-theorem element_dichotomy (G : Subgroup (PGL p)) [Finite G]
+theorem element_dichotomy (G : Subgroup (PGLOf (K p))) [Finite G]
     (g : G) :
-    orderOf (g : PGL p) = p ∨ Nat.Coprime (orderOf (g : PGL p)) p := by
-  have hn : orderOf (g : PGL p) ≠ 0 := (isOfFinOrder_iff_pow_eq_one.mpr ⟨orderOf g,
+    orderOf (g : PGLOf (K p)) = p ∨ Nat.Coprime (orderOf (g : PGLOf (K p))) p := by
+  have hn : orderOf (g : PGLOf (K p)) ≠ 0 := (isOfFinOrder_iff_pow_eq_one.mpr ⟨orderOf g,
     orderOf_pos _, by rw [← Subgroup.coe_pow, pow_orderOf_eq_one, Subgroup.coe_one]⟩).orderOf_pos.ne'
-  obtain ⟨a, ha⟩ : ∃ a : ℕ, p ^ a ∣ orderOf (g : PGL p) ∧ ¬p ^ (a + 1) ∣ orderOf (g : PGL p) :=
+  obtain ⟨a, ha⟩ : ∃ a : ℕ, p ^ a ∣ orderOf (g : PGLOf (K p)) ∧ ¬p ^ (a + 1) ∣ orderOf (g : PGLOf (K p)) :=
     ⟨_, Nat.ordProj_dvd _ _, Nat.pow_succ_factorization_not_dvd hn Fact.out⟩
-  set b := orderOf (g : PGL p) / p ^ a
-  have hab : orderOf (g : PGL p) = p ^ a * b := (Nat.mul_div_cancel' ha.1).symm
+  set b := orderOf (g : PGLOf (K p)) / p ^ a
+  have hab : orderOf (g : PGLOf (K p)) = p ^ a * b := (Nat.mul_div_cancel' ha.1).symm
   have hb_pos : 0 < b := Nat.pos_of_ne_zero (fun h ↦ hn (by rw [hab, h, mul_zero]))
   have hb : b.Coprime p := Nat.Coprime.symm ((Fact.out : Nat.Prime p).coprime_iff_not_dvd.mpr
     (fun h ↦ ha.2 (by rw [hab, pow_succ]; exact mul_dvd_mul_left (p ^ a) h)))
@@ -146,41 +146,41 @@ theorem element_dichotomy (G : Subgroup (PGL p)) [Finite G]
   · by_cases hb_one : b = 1
     · left
       rw [hab, hb_one, pow_one, mul_one]
-    · have hgb_ord : orderOf ((g : PGL p) ^ b) = p := by
+    · have hgb_ord : orderOf ((g : PGLOf (K p)) ^ b) = p := by
         rw [orderOf_pow' _ hb_pos.ne', hab, pow_one, Nat.gcd_eq_right ⟨p, mul_comm p b⟩, Nat.mul_div_cancel _ hb_pos]
-      have hgp_ord : orderOf ((g : PGL p) ^ p) = b := by
+      have hgp_ord : orderOf ((g : PGLOf (K p)) ^ p) = b := by
         rw [orderOf_pow' _ (Fact.out : Nat.Prime p).ne_zero, hab, pow_one, Nat.gcd_eq_right ⟨b, rfl⟩, mul_comm p b, Nat.mul_div_cancel _ (Nat.Prime.pos Fact.out)]
       exfalso
-      exact no_commute_p_coprime p ((g : PGL p) ^ b) ((g : PGL p) ^ p)
+      exact no_commute_p_coprime p ((g : PGLOf (K p)) ^ b) ((g : PGLOf (K p)) ^ p)
         (fun h ↦ by rw [h, orderOf_one] at hgb_ord; exact (Fact.out : Nat.Prime p).ne_one hgb_ord.symm)
         (fun h ↦ by rw [h, orderOf_one] at hgp_ord; exact hb_one hgp_ord.symm)
         hgb_ord
         (isOfFinOrder_iff_pow_eq_one.mpr ⟨b, hb_pos, by rw [← hgp_ord, pow_orderOf_eq_one]⟩)
         (by rw [hgp_ord]; exact hb)
         (by rw [← pow_add, add_comm, pow_add])
-  · have hgb_ord : orderOf ((g : PGL p) ^ b) = p ^ (a + 2) := by
+  · have hgb_ord : orderOf ((g : PGLOf (K p)) ^ b) = p ^ (a + 2) := by
       rw [orderOf_pow' _ hb_pos.ne', hab, Nat.gcd_eq_right ⟨p ^ (a + 2), mul_comm (p ^ (a + 2)) b⟩, Nat.mul_div_cancel _ hb_pos]
-    haveI : Finite (Subgroup.zpowers ((g : PGL p) ^ b)) :=
+    haveI : Finite (Subgroup.zpowers ((g : PGLOf (K p)) ^ b)) :=
       Nat.finite_of_card_ne_zero (by rw [Nat.card_zpowers, hgb_ord]; exact (pow_pos (Nat.Prime.pos Fact.out) _).ne')
-    haveI : IsCyclic (Subgroup.zpowers ((g : PGL p) ^ b)) :=
-      ⟨⟨⟨(g : PGL p) ^ b, Subgroup.mem_zpowers _⟩, fun ⟨x, hx⟩ ↦ by
+    haveI : IsCyclic (Subgroup.zpowers ((g : PGLOf (K p)) ^ b)) :=
+      ⟨⟨⟨(g : PGLOf (K p)) ^ b, Subgroup.mem_zpowers _⟩, fun ⟨x, hx⟩ ↦ by
         obtain ⟨k, hk⟩ := Subgroup.mem_zpowers_iff.mp hx; exact ⟨k, Subtype.ext hk⟩⟩⟩
-    have hpgrp : IsPGroup p (Subgroup.zpowers ((g : PGL p) ^ b)) := fun ⟨x, hx⟩ ↦
+    have hpgrp : IsPGroup p (Subgroup.zpowers ((g : PGLOf (K p)) ^ b)) := fun ⟨x, hx⟩ ↦
       ⟨a + 2, Subtype.ext (orderOf_dvd_iff_pow_eq_one.mp (hgb_ord ▸ orderOf_dvd_of_mem_zpowers hx))⟩
     have hdvd : p ^ (a + 2) ∣ p := by
       rw [← hgb_ord, ← Nat.card_zpowers, ← IsCyclic.exponent_eq_card]
-      exact isPGroup_exponent_dvd_prime p (Subgroup.zpowers ((g : PGL p) ^ b)) hpgrp
+      exact isPGroup_exponent_dvd_prime p (Subgroup.zpowers ((g : PGLOf (K p)) ^ b)) hpgrp
     have h_p_lt_pa : p < p ^ (a + 2) := by
       calc p = p ^ 1 := (pow_one p).symm
            _ < p ^ (a + 2) := Nat.pow_lt_pow_right (Fact.out : Nat.Prime p).one_lt (Nat.succ_lt_succ (Nat.zero_lt_succ a))
     exact absurd (Nat.le_of_dvd (Nat.Prime.pos Fact.out) hdvd) (not_le_of_gt h_p_lt_pa)
 
-theorem element_partition_count (G : Subgroup (PGL p)) [Finite G] :
+theorem element_partition_count (G : Subgroup (PGLOf (K p))) [Finite G] :
     Nat.card G - 1 =
-      Nat.card {g : G | g ≠ 1 ∧ orderOf (g : PGL p) = p} +
-      Nat.card {g : G | g ≠ 1 ∧ Nat.Coprime (orderOf (g : PGL p)) p} := by
-  have h_disj : Disjoint {g : G | g ≠ 1 ∧ orderOf (g : PGL p) = p}
-                         {g : G | g ≠ 1 ∧ Nat.Coprime (orderOf (g : PGL p)) p} := by
+      Nat.card {g : G | g ≠ 1 ∧ orderOf (g : PGLOf (K p)) = p} +
+      Nat.card {g : G | g ≠ 1 ∧ Nat.Coprime (orderOf (g : PGLOf (K p))) p} := by
+  have h_disj : Disjoint {g : G | g ≠ 1 ∧ orderOf (g : PGLOf (K p)) = p}
+                         {g : G | g ≠ 1 ∧ Nat.Coprime (orderOf (g : PGLOf (K p))) p} := by
     simp only [Set.disjoint_left, Set.mem_setOf_eq]
     rintro g ⟨_, h1⟩ ⟨_, h2⟩
     rw [h1] at h2
@@ -189,8 +189,8 @@ theorem element_partition_count (G : Subgroup (PGL p)) [Finite G] :
     let e : {g : G | g = 1} ⊕ {g : G | g ≠ 1} ≃ G := Equiv.sumCompl (fun g ↦ g = 1)
     haveI : Unique {g : G | g = 1} := ⟨⟨⟨1, rfl⟩⟩, fun ⟨g, hg⟩ ↦ Subtype.ext hg⟩
     rw [← Nat.card_congr e, Nat.card_sum, Nat.card_unique]
-  have h_set : {g : G | g ≠ 1} = {g : G | g ≠ 1 ∧ orderOf (g : PGL p) = p} ∪
-                                 {g : G | g ≠ 1 ∧ Nat.Coprime (orderOf (g : PGL p)) p} := by
+  have h_set : {g : G | g ≠ 1} = {g : G | g ≠ 1 ∧ orderOf (g : PGLOf (K p)) = p} ∪
+                                 {g : G | g ≠ 1 ∧ Nat.Coprime (orderOf (g : PGLOf (K p))) p} := by
     ext g
     simp only [Set.mem_setOf_eq, Set.mem_union, ← and_or_left]
     exact (and_iff_left (element_dichotomy p G g)).symm
@@ -302,7 +302,7 @@ lemma sylow_5_options (G : Type*) [Group G] [Finite G]
   interval_cases k <;> (revert h_div12; rw [hk]; norm_num)
 
 
-lemma sylow_5_not_one (G : Subgroup (PGL p))
+lemma sylow_5_not_one (G : Subgroup (PGLOf (K p)))
     [Finite G] (hp3 : p = 3)
     (hn : Nat.card G = 60) (hn3 : Fintype.card (Sylow p G) = 10)
     : Fintype.card (Sylow 5 G) ≠ 1 := by
@@ -321,11 +321,11 @@ lemma sylow_5_not_one (G : Subgroup (PGL p))
     obtain ⟨q', hq_gen⟩ := (isCyclic_of_prime_card hQ_card).exists_generator
     exact ⟨q', q'.2, by rw [Subgroup.orderOf_coe, orderOf_eq_card_of_forall_mem_zpowers hq_gen, hQ_card]⟩
 
-  have hg_ord : orderOf (g : PGL p) = 3 := by rw [Subgroup.orderOf_coe, hg]
-  have hq_ord_PGL : orderOf (q : PGL p) = 5 := by rw [Subgroup.orderOf_coe, hq_ord]
+  have hg_ord : orderOf (g : PGLOf (K p)) = 3 := by rw [Subgroup.orderOf_coe, hg]
+  have hq_ord_PGL : orderOf (q : PGLOf (K p)) = 5 := by rw [Subgroup.orderOf_coe, hq_ord]
 
   exfalso
-  exact no_commute_p_coprime p (g : PGL p) (q : PGL p)
+  exact no_commute_p_coprime p (g : PGLOf (K p)) (q : PGLOf (K p))
     (fun h ↦ by rw [h, orderOf_one] at hg_ord; norm_num at hg_ord)
     (fun h ↦ by rw [h, orderOf_one] at hq_ord_PGL; norm_num at hq_ord_PGL)
     (by rw [hg_ord, hp3])
@@ -881,7 +881,7 @@ lemma is_simple_60_aux {G : Type*} [Group G] [Finite G] [Nontrivial G]
                  (Nat.prime_five.coprime_iff_not_dvd.mpr hN_div_5).symm⟩
         exact normal_divides_4_eq_bot hn hn3 N (h_cop.dvd_of_dvd_mul_right (show Nat.card N ∣ 4 * 15 from h_dvd)) hN_ne_bot
 
-theorem is_simple_60 (G : Subgroup (PGL p))
+theorem is_simple_60 (G : Subgroup (PGLOf (K p)))
     [Finite G] (hp3 : p = 3)
     (hn : Nat.card G = 60) (hn3 : Fintype.card (Sylow p G) = 10) :
     IsSimpleGroup G :=
@@ -973,7 +973,7 @@ theorem simple_60_is_A5 (G : Type*) [Group G] [Finite G]
   exact ⟨(h_iso_range.trans (MulEquiv.subgroupCongr (Equiv.Perm.eq_alternatingGroup_of_index_eq_two h_index))).trans
     (Fintype.equivOfCardEq ((simple_60_n2_eq_5 G hn hs).trans (Fintype.card_fin 5).symm)).altCongrHom⟩
 
-theorem recognition_A5_proof (G : Subgroup (PGL p))
+theorem recognition_A5_proof (G : Subgroup (PGLOf (K p)))
     [Finite G] (hp3 : p = 3)
     (hn : Nat.card G = 60) (hn3 : Fintype.card (Sylow p G) = 10) :
     Nonempty (G ≃* alternatingGroup (Fin 5)) :=

--- a/FLT/Slop/PGL2/FiniteSubgroups/TameClassification.lean
+++ b/FLT/Slop/PGL2/FiniteSubgroups/TameClassification.lean
@@ -14,7 +14,7 @@ public import FLT.Slop.PGL2.FiniteSubgroups.PGLBasic
 /-!
 # Dickson's classification: the tame case
 
-This file classifies the finite subgroups `G` of `PGL p = PGL₂(𝔽̄_p)` of order coprime
+This file classifies the finite subgroups `G` of `PGLOf (K p) = PGL₂(𝔽̄_p)` of order coprime
 to `p` (the *tame* case): the main theorem `Dickson.classification_tame_slop` shows any
 such `G` is cyclic, dihedral, or isomorphic to `A₄`, `S₄` or `A₅`.
 
@@ -53,9 +53,9 @@ noncomputable section
 
 variable (p : ℕ) [Fact (Nat.Prime p)] [h_odd : Fact (p > 2)]
 
-theorem tame_ncard_fixedPoints_eq_two (G : Subgroup (PGL p)) [Fintype G]
+theorem tame_ncard_fixedPoints_eq_two (G : Subgroup (PGLOf (K p))) [Fintype G]
     (hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
-    (g : PGL p) (hg : g ∈ G) (hg_ne : g ≠ 1) :
+    (g : PGLOf (K p)) (hg : g ∈ G) (hg_ne : g ≠ 1) :
     Set.ncard (fixedPoints p g) = 2 := by
 
   have h_coprime : p.Coprime (orderOf g) := by
@@ -71,8 +71,8 @@ theorem tame_ncard_fixedPoints_eq_two (G : Subgroup (PGL p)) [Fintype G]
 
 /-- The subgroup of `G` consisting of the elements that fix both `x` and `y` on the
 projective line. -/
-def pairStabilizer (G : Subgroup (PGL p)) (x y : ProjectiveLine p) : Subgroup G where
-  carrier := {g : G | (g : PGL p) • x = x ∧ (g : PGL p) • y = y}
+def pairStabilizer (G : Subgroup (PGLOf (K p))) (x y : ProjectiveLine p) : Subgroup G where
+  carrier := {g : G | (g : PGLOf (K p)) • x = x ∧ (g : PGLOf (K p)) • y = y}
   mul_mem' {a b} ha hb :=
     ⟨by rw [Subgroup.coe_mul, mul_smul, hb.1, ha.1],
      by rw [Subgroup.coe_mul, mul_smul, hb.2, ha.2]⟩
@@ -81,9 +81,9 @@ def pairStabilizer (G : Subgroup (PGL p)) (x y : ProjectiveLine p) : Subgroup G 
     ⟨by rw [Subgroup.coe_inv, inv_smul_eq_iff, hg.1],
      by rw [Subgroup.coe_inv, inv_smul_eq_iff, hg.2]⟩
 
-lemma fixedPoints_determined (G : Subgroup (PGL p)) [Fintype G]
+lemma fixedPoints_determined (G : Subgroup (PGLOf (K p))) [Fintype G]
     (hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
-    (g : PGL p) (hg : g ∈ G) (hg_ne : g ≠ 1)
+    (g : PGLOf (K p)) (hg : g ∈ G) (hg_ne : g ≠ 1)
     (x y : ProjectiveLine p) (hxy : x ≠ y) (hfx : g • x = x) (hfy : g • y = y) :
     fixedPoints p g = {x, y} := by
   have hcard : (fixedPoints p g).ncard = 2 := tame_ncard_fixedPoints_eq_two p G hG_tame g hg hg_ne
@@ -106,8 +106,8 @@ lemma fixedPoints_determined (G : Subgroup (PGL p)) [Fintype G]
 
 omit h_odd in
 @[nolint unusedArguments]
-lemma commute_of_fixedPair (G_sub : Subgroup (PGL p)) [Fintype G_sub]
-    (g h : PGL p) (hg : g ∈ G_sub) (hh : h ∈ G_sub)
+lemma commute_of_fixedPair (G_sub : Subgroup (PGLOf (K p))) [Fintype G_sub]
+    (g h : PGLOf (K p)) (hg : g ∈ G_sub) (hh : h ∈ G_sub)
     (x y : ProjectiveLine p) (hxy : x ≠ y)
     (hgx : g • x = x) (hgy : g • y = y)
     (hhx : h • x = x) (hhy : h • y = y) :
@@ -118,7 +118,7 @@ lemma commute_of_fixedPair (G_sub : Subgroup (PGL p)) [Fintype G_sub]
   obtain ⟨w, hw⟩ := y
 
   have extract_eigen : ∀ {M : GL (Fin 2) (K p)} {u : Fin 2 → K p} {hu : u ≠ 0},
-      (QuotientGroup.mk M : PGL p) • Projectivization.mk (K p) u hu = Projectivization.mk (K p) u
+      (QuotientGroup.mk M : PGLOf (K p)) • Projectivization.mk (K p) u hu = Projectivization.mk (K p) u
           hu →
       ∃ c : K p, M.val.mulVec u = c • u := by
     intro M u hu h_fix
@@ -161,7 +161,7 @@ omit h_odd in
 lemma scalar_eq_one_in_PGL (g : GL (Fin 2) (K p)) (c : K p)
     (x y : ProjectiveLine p) (hxy : x ≠ y)
     (hgx : g.val.mulVec x.rep = c • x.rep) (hgy : g.val.mulVec y.rep = c • y.rep) :
-    (QuotientGroup.mk g : PGL p) = 1 := by
+    (QuotientGroup.mk g : PGLOf (K p)) = 1 := by
   rw [QuotientGroup.eq_one_iff, Subgroup.mem_center_iff]
 
   have h_g_eq : g.val = c • (1 : Matrix (Fin 2) (Fin 2) (K p)) := by
@@ -196,12 +196,12 @@ lemma scalar_eq_one_in_PGL (g : GL (Fin 2) (K p)) (c : K p)
       Matrix.mul_one, Matrix.one_mul])
 omit h_odd in
 
-lemma exists_unique_normalizedLift (g : PGL p) (y : ProjectiveLine p)
+lemma exists_unique_normalizedLift (g : PGLOf (K p)) (y : ProjectiveLine p)
     (hgy : g • y = y) :
     ∃! (g' : GL (Fin 2) (K p)),
-      (QuotientGroup.mk g' : PGL p) = g ∧ g'.val.mulVec y.rep = y.rep := by
+      (QuotientGroup.mk g' : PGLOf (K p)) = g ∧ g'.val.mulVec y.rep = y.rep := by
 
-  have h_z_scalar : ∀ z : GL (Fin 2) (K p), (QuotientGroup.mk z : PGL p) = 1 → ∃ c : K p,
+  have h_z_scalar : ∀ z : GL (Fin 2) (K p), (QuotientGroup.mk z : PGLOf (K p)) = 1 → ∃ c : K p,
       z.val = c • 1 := by
     intro z hz
 
@@ -251,7 +251,7 @@ lemma exists_unique_normalizedLift (g : PGL p) (y : ProjectiveLine p)
   obtain ⟨g₀, hg₀⟩ := QuotientGroup.mk_surjective g
 
   obtain ⟨d, hd_ne_zero, hd⟩ : ∃ d : K p, d ≠ 0 ∧ g₀.val.mulVec y.rep = d • y.rep := by
-    have h_fix : (QuotientGroup.mk g₀ : PGL p) • Projectivization.mk (K p) y.rep y.rep_nonzero =
+    have h_fix : (QuotientGroup.mk g₀ : PGLOf (K p)) • Projectivization.mk (K p) y.rep y.rep_nonzero =
         Projectivization.mk (K p) y.rep y.rep_nonzero := by
       rw [Projectivization.mk_rep y, hg₀, hgy]
     change Projectivization.mk (K p)
@@ -270,7 +270,7 @@ lemma exists_unique_normalizedLift (g : PGL p) (y : ProjectiveLine p)
         rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul, mul_inv_cancel₀ hd_ne_zero, one_smul,
             g₀.inv_val] }
 
-  have hg'_mk : (QuotientGroup.mk g' : PGL p) = g := by
+  have hg'_mk : (QuotientGroup.mk g' : PGLOf (K p)) = g := by
     rw [← hg₀, QuotientGroup.eq, Subgroup.mem_center_iff]
     intro M
     apply Units.ext
@@ -293,8 +293,8 @@ lemma exists_unique_normalizedLift (g : PGL p) (y : ProjectiveLine p)
   rintro g'' ⟨hg''_mk, hg''_y⟩
   let z := g'' * g'⁻¹
 
-  have hz_mk : (QuotientGroup.mk z : PGL p) = 1 := by
-    change (QuotientGroup.mk g'' : PGL p) * (QuotientGroup.mk g' : PGL p)⁻¹ = 1
+  have hz_mk : (QuotientGroup.mk z : PGLOf (K p)) = 1 := by
+    change (QuotientGroup.mk g'' : PGLOf (K p)) * (QuotientGroup.mk g' : PGLOf (K p))⁻¹ = 1
     rw [hg''_mk, hg'_mk, mul_inv_cancel]
   obtain ⟨c, hz_val⟩ := h_z_scalar z hz_mk
 
@@ -323,17 +323,17 @@ lemma exists_unique_normalizedLift (g : PGL p) (y : ProjectiveLine p)
   _ = g'.val := one_smul _ _
 omit h_odd in
 
-lemma pairStabilizer_isCyclic (G : Subgroup (PGL p)) [Fintype G]
+lemma pairStabilizer_isCyclic (G : Subgroup (PGLOf (K p))) [Fintype G]
     (x y : ProjectiveLine p) (hxy : x ≠ y) :
     IsCyclic (pairStabilizer p G x y) := by
 
   have h_norm : ∀ g : pairStabilizer p G x y, ∃ g' : GL (Fin 2) (K p),
-      (QuotientGroup.mk g' : PGL p) = (g : PGL p) ∧ g'.val.mulVec y.rep = y.rep ∧
+      (QuotientGroup.mk g' : PGLOf (K p)) = (g : PGLOf (K p)) ∧ g'.val.mulVec y.rep = y.rep ∧
       ∀ g'',
-          (QuotientGroup.mk g'' : PGL p) = (g : PGL p) → g''.val.mulVec y.rep = y.rep → g'' = g' :=
+          (QuotientGroup.mk g'' : PGLOf (K p)) = (g : PGLOf (K p)) → g''.val.mulVec y.rep = y.rep → g'' = g' :=
             by
     intro g
-    obtain ⟨g', ⟨h1, h2⟩, h3⟩ := exists_unique_normalizedLift p (g : PGL p) y g.2.2
+    obtain ⟨g', ⟨h1, h2⟩, h3⟩ := exists_unique_normalizedLift p (g : PGLOf (K p)) y g.2.2
     exact ⟨g', h1, h2, fun g'' h1' h2' ↦ h3 g'' ⟨h1', h2'⟩⟩
   choose f hf_mk hf_y hf_uniq using h_norm
 
@@ -341,7 +341,7 @@ lemma pairStabilizer_isCyclic (G : Subgroup (PGL p)) [Fintype G]
       c ≠ 0 ∧ (f g).val.mulVec x.rep = c • x.rep := by
     intro g
 
-    have h_fix : (QuotientGroup.mk (f g) : PGL p) • Projectivization.mk (K p) x.rep x.rep_nonzero =
+    have h_fix : (QuotientGroup.mk (f g) : PGLOf (K p)) • Projectivization.mk (K p) x.rep x.rep_nonzero =
         Projectivization.mk (K p) x.rep x.rep_nonzero := by
       rw [Projectivization.mk_rep x, hf_mk, g.2.1]
     change Projectivization.mk (K p)
@@ -356,8 +356,8 @@ lemma pairStabilizer_isCyclic (G : Subgroup (PGL p)) [Fintype G]
     symm
     apply hf_uniq (g₁ * g₂)
 
-    · change (QuotientGroup.mk (f g₁) : PGL p) * (QuotientGroup.mk (f g₂) : PGL p) = (g₁ : PGL p) *
-        (g₂ : PGL p)
+    · change (QuotientGroup.mk (f g₁) : PGLOf (K p)) * (QuotientGroup.mk (f g₂) : PGLOf (K p)) = (g₁ : PGLOf (K p)) *
+        (g₂ : PGLOf (K p))
       rw [hf_mk, hf_mk]
 
     · rw [Units.val_mul, ← Matrix.mulVec_mulVec, hf_y, hf_y]
@@ -374,7 +374,7 @@ lemma pairStabilizer_isCyclic (G : Subgroup (PGL p)) [Fintype G]
     symm
     apply hf_uniq 1
 
-    · change (QuotientGroup.mk 1 : PGL p) = 1; rfl
+    · change (QuotientGroup.mk 1 : PGLOf (K p)) = 1; rfl
 
     · rw [Units.val_one, Matrix.one_mulVec]
 
@@ -399,11 +399,11 @@ lemma pairStabilizer_isCyclic (G : Subgroup (PGL p)) [Fintype G]
         (by rw [hc_x, h_div, one_smul]) (by rw [hf_y, one_smul])
   exact isCyclic_of_injective_ringHom hom hom_inj
 
-lemma disjoint_fixedPairs (G : Subgroup (PGL p)) [Fintype G]
+lemma disjoint_fixedPairs (G : Subgroup (PGLOf (K p))) [Fintype G]
     (hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
     (x y x' y' : ProjectiveLine p) (hxy : x ≠ y) (hx'y' : x' ≠ y')
     (hpairs : ({x, y} : Set (ProjectiveLine p)) ≠ {x', y'})
-    (g : PGL p) (hg : g ∈ G) (hg_ne : g ≠ 1)
+    (g : PGLOf (K p)) (hg : g ∈ G) (hg_ne : g ≠ 1)
     (hfx : g • x = x) (hfy : g • y = y) (hfx' : g • x' = x') (hfy' : g • y' = y') :
     False := by
   let S := Function.fixedPoints (HSMul.hSMul g : ProjectiveLine p → ProjectiveLine p)
@@ -429,7 +429,7 @@ lemma disjoint_fixedPairs (G : Subgroup (PGL p)) [Fintype G]
       · exact absurd rfl huv
   exact hpairs ((h_eq hxy hfx hfy).symm.trans (h_eq hx'y' hfx' hfy'))
 
-lemma normalizer_permutes_pair (G : Subgroup (PGL p)) [Fintype G]
+lemma normalizer_permutes_pair (G : Subgroup (PGLOf (K p))) [Fintype G]
     (hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
     (x y : ProjectiveLine p) (hxy : x ≠ y)
     (n : (Subgroup.normalizer (SetLike.coe (pairStabilizer p G x y))))
@@ -443,12 +443,12 @@ lemma normalizer_permutes_pair (G : Subgroup (PGL p)) [Fintype G]
       (fun h ↦ hg_ne (Subtype.ext (Subtype.ext h))) x y hxy g.2.1 g.2.2
   have hn_mem := (Subgroup.mem_normalizer_iff.mp n.property (g : G)).mp g.property
 
-  have h_prop {z : ProjectiveLine p} (hz : (((n : G) * (g : G) * (n : G)⁻¹ : G) : PGL p) • z = z) :
+  have h_prop {z : ProjectiveLine p} (hz : (((n : G) * (g : G) * (n : G)⁻¹ : G) : PGLOf (K p)) • z = z) :
       (n : G).val⁻¹ • z ∈ ({x, y} : Set (ProjectiveLine p)) := by
     rw [← h_fix_set]
     change (g : G).val • ((n : G).val⁻¹ • z) = (n : G).val⁻¹ • z
     rw [Subgroup.coe_mul, Subgroup.coe_mul, Subgroup.coe_inv, mul_smul, mul_smul] at hz
-    rw [← one_smul (PGL p) ((g : G).val • ((n : G).val⁻¹ • z)), ← inv_mul_cancel (n : G).val,
+    rw [← one_smul (PGLOf (K p)) ((g : G).val • ((n : G).val⁻¹ • z)), ← inv_mul_cancel (n : G).val,
         mul_smul, hz]
   have hnx := h_prop hn_mem.1
   have hny := h_prop hn_mem.2
@@ -468,7 +468,7 @@ lemma normalizer_permutes_pair (G : Subgroup (PGL p)) [Fintype G]
 
     · exact absurd (by rw [← h_eq_smul hnx_y, h_eq_smul hny_y]) hxy
 
-lemma normalizer_pairStabilizer_index_le_two (G : Subgroup (PGL p)) [Fintype G]
+lemma normalizer_pairStabilizer_index_le_two (G : Subgroup (PGLOf (K p))) [Fintype G]
     (hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
     (x y : ProjectiveLine p) (hxy : x ≠ y)
     (hne : ∃ g : pairStabilizer p G x y, g ≠ 1) :
@@ -520,37 +520,37 @@ lemma normalizer_pairStabilizer_index_le_two (G : Subgroup (PGL p)) [Fintype G]
     rw [H_top, Subgroup.index_top]
     omega
 
-lemma mem_pairStabilizer_of_ne_one (G : Subgroup (PGL p)) [Fintype G]
+lemma mem_pairStabilizer_of_ne_one (G : Subgroup (PGLOf (K p))) [Fintype G]
     (hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
     (g : G) (hg_ne : g ≠ 1) :
     ∃ (x y : ProjectiveLine p), x ≠ y ∧ g ∈ pairStabilizer p G x y := by
 
   obtain ⟨x, y, hxy, hfp⟩ := Set.ncard_eq_two.mp <|
-    tame_ncard_fixedPoints_eq_two p G hG_tame (g : PGL p) g.property (fun h ↦ hg_ne (Subtype.ext h))
+    tame_ncard_fixedPoints_eq_two p G hG_tame (g : PGLOf (K p)) g.property (fun h ↦ hg_ne (Subtype.ext h))
   exact ⟨x, y, hxy,
     show x ∈ fixedPoints p ↑g by rw [hfp]; exact Set.mem_insert x _,
     show y ∈ fixedPoints p ↑g by rw [hfp]; exact Set.mem_insert_of_mem x (Set.mem_singleton y)⟩
 omit h_odd in
 
 @[nolint unusedArguments]
-lemma pairStabilizer_conj (G : Subgroup (PGL p)) [Fintype G]
+lemma pairStabilizer_conj (G : Subgroup (PGLOf (K p))) [Fintype G]
     (x y : ProjectiveLine p) (h : G) :
     (pairStabilizer p G x y).map (MulAut.conj h).toMonoidHom =
-    pairStabilizer p G ((h : PGL p) • x) ((h : PGL p) • y) := by
+    pairStabilizer p G ((h : PGLOf (K p)) • x) ((h : PGLOf (K p)) • y) := by
   ext g
   constructor
 
   · rintro ⟨g', hg', rfl⟩
     have h_eq (z : ProjectiveLine p)
-        (hz : (g' : PGL p) • z = z) : ((h * g' * h⁻¹ : G) : PGL p) • ((h : PGL p) • z) = (h : PGL
-            p) • z := by
+        (hz : (g' : PGLOf (K p)) • z = z) : ((h * g' * h⁻¹ : G) : PGLOf (K p)) • ((h : PGLOf (K p)) • z) =
+          (h : PGLOf (K p)) • z := by
       rw [Subgroup.coe_mul, Subgroup.coe_mul, Subgroup.coe_inv, mul_smul, inv_smul_smul, mul_smul,
           hz]
     exact ⟨h_eq x hg'.1, h_eq y hg'.2⟩
 
   · intro hg
     have h_eq (z : ProjectiveLine p)
-        (hz : (g : PGL p) • ((h : PGL p) • z) = (h : PGL p) • z) : ((h⁻¹ * (g * h) : G) : PGL p) •
+        (hz : (g : PGLOf (K p)) • ((h : PGLOf (K p)) • z) = (h : PGLOf (K p)) • z) : ((h⁻¹ * (g * h) : G) : PGLOf (K p)) •
             z = z := by
       rw [Subgroup.coe_mul, Subgroup.coe_mul, Subgroup.coe_inv, mul_smul, mul_smul, hz,
           inv_smul_smul]
@@ -558,7 +558,7 @@ lemma pairStabilizer_conj (G : Subgroup (PGL p)) [Fintype G]
       show h * (h⁻¹ * (g * h)) * h⁻¹ = g by rw [← mul_assoc h h⁻¹, mul_inv_cancel, one_mul,
           mul_assoc, mul_inv_cancel, mul_one]⟩
 
-lemma conjugate_pairStabilizer_disjoint (G : Subgroup (PGL p)) [Fintype G]
+lemma conjugate_pairStabilizer_disjoint (G : Subgroup (PGLOf (K p))) [Fintype G]
     (hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
     (H₁ H₂ : Subgroup G)
     (hH₁ : ∃ x y : ProjectiveLine p, x ≠ y ∧ H₁ = pairStabilizer p G x y)
@@ -568,13 +568,13 @@ lemma conjugate_pairStabilizer_disjoint (G : Subgroup (PGL p)) [Fintype G]
     H₁.map (MulAut.conj g₁).toMonoidHom ⊓ H₂.map (MulAut.conj g₂).toMonoidHom = ⊥ := by
   obtain ⟨x₁, y₁, hxy₁, rfl⟩ := hH₁
   obtain ⟨x₂, y₂, hxy₂, rfl⟩ := hH₂
-  let x₁' := (g₁ : PGL p) • x₁
-  let y₁' := (g₁ : PGL p) • y₁
-  let x₂' := (g₂ : PGL p) • x₂
-  let y₂' := (g₂ : PGL p) • y₂
+  let x₁' := (g₁ : PGLOf (K p)) • x₁
+  let y₁' := (g₁ : PGLOf (K p)) • y₁
+  let x₂' := (g₂ : PGLOf (K p)) • x₂
+  let y₂' := (g₂ : PGLOf (K p)) • y₂
 
-  have h_inj (g : G) (x y : ProjectiveLine p) (hxy : x ≠ y) : (g : PGL p) • x ≠ (g : PGL p) • y :=
-    fun h ↦ hxy <| by rw [← inv_smul_smul (g : PGL p) x, h, inv_smul_smul]
+  have h_inj (g : G) (x y : ProjectiveLine p) (hxy : x ≠ y) : (g : PGLOf (K p)) • x ≠ (g : PGLOf (K p)) • y :=
+    fun h ↦ hxy <| by rw [← inv_smul_smul (g : PGLOf (K p)) x, h, inv_smul_smul]
   rw [pairStabilizer_conj, pairStabilizer_conj] at hne ⊢
   by_contra h_not_bot
 
@@ -586,7 +586,7 @@ lemma conjugate_pairStabilizer_disjoint (G : Subgroup (PGL p)) [Fintype G]
     exact ⟨fun hz ↦ by_contra fun hz_ne ↦ h_none ⟨z, hz, hz_ne⟩, fun h ↦ h ▸ Subgroup.one_mem _⟩
 
   have h_set_eq : ({x₁', y₁'} : Set (ProjectiveLine p)) = {x₂', y₂'} := by
-    have hg_ne_val : (g : PGL p) ≠ 1 := fun h ↦ hg_ne (Subtype.ext h)
+    have hg_ne_val : (g : PGLOf (K p)) ≠ 1 := fun h ↦ hg_ne (Subtype.ext h)
     exact (fixedPoints_determined p G hG_tame g g.property hg_ne_val x₁' y₁'
       (h_inj g₁ x₁ y₁ hxy₁) hg1.1 hg1.2).symm.trans
       (fixedPoints_determined p G hG_tame g g.property hg_ne_val x₂' y₂'
@@ -661,7 +661,7 @@ lemma finQuotientReps {α : Type*} [Fintype α] (s : Setoid α) :
       (e.symm j)))
 
 omit h_odd in
-lemma orbitPartitionConstruction (G : Subgroup (PGL p)) [Fintype G]
+lemma orbitPartitionConstruction (G : Subgroup (PGLOf (K p))) [Fintype G]
     (_hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
     (_hG_nontrivial : Nontrivial G) :
     ∃ (r : ℕ) (xrep yrep : Fin r → ProjectiveLine p),
@@ -721,7 +721,7 @@ lemma orbitPartitionConstruction (G : Subgroup (PGL p)) [Fintype G]
       exact ⟨i, g, by rw [heq_rep i] at hg; exact hg⟩,
     fun i j ⟨g, hg⟩ ↦ h_inj i j ⟨g, by rw [← heq_rep i, ← heq_rep j] at hg; exact hg.symm⟩⟩
 
-lemma orbitPartitionData (G : Subgroup (PGL p)) [Fintype G]
+lemma orbitPartitionData (G : Subgroup (PGLOf (K p))) [Fintype G]
     (hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
     (hG_nontrivial : Nontrivial G) :
     ∃ (r : ℕ) (d f : Fin r → ℕ)
@@ -1467,7 +1467,7 @@ lemma r3_allF_eq_two (d f : Fin 3 → ℕ) (n : ℕ) (hn : n ≥ 2)
 
   · exact hfi
 
-lemma tame_hasCyclicPartition (G : Subgroup (PGL p)) [Fintype G]
+lemma tame_hasCyclicPartition (G : Subgroup (PGLOf (K p))) [Fintype G]
     (hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
     (hG_nontrivial : Nontrivial G) :
     (∃ N : ℕ, Nat.card G = N ∧ HasCyclicPartition G [{d := N, f := 1}]) ∨
@@ -1634,7 +1634,7 @@ lemma tame_hasCyclicPartition (G : Subgroup (PGL p)) [Fintype G]
           (by rw [hnorm, hf2, hσ₀]) (by rw [hnorm, hf2, hσ₁]) (by rw [hnorm, hf2, hσ₂])
           (h_r3_disj σ) (h_r3_cover σ)
 
-theorem classification_tame_slop (G : Subgroup (PGL p)) [Fintype G]
+theorem classification_tame_slop (G : Subgroup (PGLOf (K p))) [Fintype G]
     (hG_tame : ¬ (p : ℕ) ∣ Nat.card G)
     (hG_nontrivial : Nontrivial G) :
     (IsCyclic G) ∨

--- a/FLT/Slop/PGL2/FiniteSubgroups/WildClassification.lean
+++ b/FLT/Slop/PGL2/FiniteSubgroups/WildClassification.lean
@@ -16,7 +16,7 @@ public import FLT.Slop.PGL2.FiniteSubgroups.PartitionProof
 /-!
 # Dickson's classification: the wild case
 
-This file classifies the finite subgroups `G` of `PGL p = PGL₂(𝔽̄_p)` of order
+This file classifies the finite subgroups `G` of `PGLOf (K p) = PGL₂(𝔽̄_p)` of order
 divisible by `p` (the *wild* case): the main theorem `Dickson.classification_wild_slop`
 shows any such `G` is
 
@@ -56,22 +56,22 @@ noncomputable section DiagRatio
 variable (p : ℕ) [Fact (Nat.Prime p)] [h_odd : Fact (p > 2)]
 
 
-/-- The group homomorphism from a finite subgroup `H` of `PGL p` fixing `infinity` to `(K p)ˣ`,
+/-- The group homomorphism from a finite subgroup `H` of `PGLOf (K p)` fixing `infinity` to `(K p)ˣ`,
 sending each element to its dilation parameter. -/
 @[nolint unusedArguments]
-noncomputable def dilationHomOfFix (H : Subgroup (PGL p)) [Finite H]
-    (hH_fix : ∀ g : H, (g : PGL p) • infinity p = infinity p) :
+noncomputable def dilationHomOfFix (H : Subgroup (PGLOf (K p))) [Finite H]
+    (hH_fix : ∀ g : H, (g : PGLOf (K p)) • infinity p = infinity p) :
     H →* (K p)ˣ where
   toFun g := Units.mk0 (dilationParam p ↑g (hH_fix g)) (dilationParam_ne_zero p ↑g (hH_fix g))
   map_one' := Units.ext (dilationParam_one p (hH_fix 1))
   map_mul' g₁ g₂ := Units.ext (dilationParam_mul_eq p ↑g₁ ↑g₂ (hH_fix g₁) (hH_fix g₂) (hH_fix (g₁ * g₂)))
 
 omit h_odd in
-theorem dilationHom_ker_order (H : Subgroup (PGL p)) [Finite H]
-    (hH_fix : ∀ g : H, (g : PGL p) • infinity p = infinity p)
+theorem dilationHom_ker_order (H : Subgroup (PGLOf (K p))) [Finite H]
+    (hH_fix : ∀ g : H, (g : PGLOf (K p)) • infinity p = infinity p)
     (g : H) (hg : g ∈ (dilationHomOfFix p H hH_fix).ker) :
     orderOf g ∣ p := by
-  obtain ⟨β, hβ⟩ := (dilationParam_eq_one_iff p (g : PGL p) (hH_fix g)).mp (congr_arg Units.val hg)
+  obtain ⟨β, hβ⟩ := (dilationParam_eq_one_iff p (g : PGLOf (K p)) (hH_fix g)).mp (congr_arg Units.val hg)
   have h_order_translation : ∀ n : ℕ, (translationPGL p β) ^ n = translationPGL p (n • β) := by
     intro n
     induction n with
@@ -83,12 +83,12 @@ theorem dilationHom_ker_order (H : Subgroup (PGL p)) [Finite H]
       rw [nsmul_eq_mul, nsmul_eq_mul, Nat.cast_add, Nat.cast_one]
       ring
   rw [orderOf_dvd_iff_pow_eq_one, Subtype.ext_iff]
-  change (g : PGL p) ^ p = 1
+  change (g : PGLOf (K p)) ^ p = 1
   rw [hβ, h_order_translation, show p • β = 0 by rw [nsmul_eq_mul, CharP.cast_eq_zero (K p) p, zero_mul], translationPGL_zero p]
 
 omit h_odd in
-theorem fixes_infinity_coprime_isCyclic (H : Subgroup (PGL p)) [Finite H]
-    (hH_fix : ∀ g : H, (g : PGL p) • infinity p = infinity p)
+theorem fixes_infinity_coprime_isCyclic (H : Subgroup (PGLOf (K p))) [Finite H]
+    (hH_fix : ∀ g : H, (g : PGLOf (K p)) • infinity p = infinity p)
     (hH_coprime : Nat.Coprime (Nat.card H) p) :
     IsCyclic H := by
   let f := dilationHomOfFix p H hH_fix
@@ -136,7 +136,7 @@ abbrev partitionTerm (si zi : ℕ) : ℚ := 1 / (si : ℚ) * (1 - 1 / (zi : ℚ)
 
 
 
-theorem sylow_comm_exp_p (G : Subgroup (PGL p)) [Finite G]
+theorem sylow_comm_exp_p (G : Subgroup (PGLOf (K p))) [Finite G]
     (P : Sylow p G) :
     (∀ g h : P.toSubgroup, g * h = h * g) ∧ (∀ g : P.toSubgroup, g ^ p = 1) := by
   let H := P.toSubgroup.map G.subtype
@@ -176,38 +176,38 @@ theorem sylow_comm_exp_p (G : Subgroup (PGL p)) [Finite G]
       exact pf
     exact ⟨fun g h ↦ by rw [h_one g, h_one h], fun g ↦ by rw [h_one g, one_pow]⟩
 
-theorem group_fixes_sylow_point (G : Subgroup (PGL p)) [Finite G]
+theorem group_fixes_sylow_point (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) (hP_normal : (P : Subgroup G).Normal)
-    (g : G) : (g : PGL p) • sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p P := by
+    (g : G) : (g : PGLOf (K p)) • sylowFixedPoint p G hG_p P = sylowFixedPoint p G hG_p P := by
   let H := (P : Subgroup G).map (Subgroup.subtype G)
   let x := sylowFixedPoint p G hG_p P
   have hx_spec := (sylow_unique_fixedPoint p G hG_p P).choose_spec
-  have h_conj_fixedPoint : ∀ h ∈ H, h • ((g : PGL p) • x) = (g : PGL p) • x := by
+  have h_conj_fixedPoint : ∀ h ∈ H, h • ((g : PGLOf (K p)) • x) = (g : PGLOf (K p)) • x := by
     intro h hh
     obtain ⟨h', hh', rfl⟩ := Subgroup.mem_map.mp hh
-    have hk : (g : PGL p)⁻¹ * (h' : PGL p) * (g : PGL p) ∈ H :=
+    have hk : (g : PGLOf (K p))⁻¹ * (h' : PGLOf (K p)) * (g : PGLOf (K p)) ∈ H :=
       Subgroup.mem_map_of_mem (Subgroup.subtype G) (inv_inv g ▸ hP_normal.conj_mem h' hh' g⁻¹)
-    have h_mul : (h' : PGL p) * (g : PGL p) = (g : PGL p) * ((g : PGL p)⁻¹ * (h' : PGL p) * (g : PGL p)) := by
-      rw [mul_assoc (g : PGL p)⁻¹, mul_inv_cancel_left]
-    change (h' : PGL p) • ((g : PGL p) • x) = (g : PGL p) • x
+    have h_mul : (h' : PGLOf (K p)) * (g : PGLOf (K p)) = (g : PGLOf (K p)) * ((g : PGLOf (K p))⁻¹ * (h' : PGLOf (K p)) * (g : PGLOf (K p))) := by
+      rw [mul_assoc (g : PGLOf (K p))⁻¹, mul_inv_cancel_left]
+    change (h' : PGLOf (K p)) • ((g : PGLOf (K p)) • x) = (g : PGLOf (K p)) • x
     rw [← mul_smul, h_mul, mul_smul]
     exact congrArg _ (hx_spec.1 _ hk)
-  exact hx_spec.2 ((g : PGL p) • x) h_conj_fixedPoint
+  exact hx_spec.2 ((g : PGLOf (K p)) • x) h_conj_fixedPoint
 
 omit h_odd in
-theorem fixes_point_coprime_isCyclic (H : Subgroup (PGL p)) [Finite H]
+theorem fixes_point_coprime_isCyclic (H : Subgroup (PGLOf (K p))) [Finite H]
     (x : ProjectiveLine p)
-    (hH_fix : ∀ g : H, (g : PGL p) • x = x)
+    (hH_fix : ∀ g : H, (g : PGLOf (K p)) • x = x)
     (hH_coprime : Nat.Coprime (Nat.card H) p) :
     IsCyclic H := by
-  obtain ⟨c, hc⟩ : ∃ c : PGL p, c • x = infinity p := exists_smul_eq_infinity p x
+  obtain ⟨c, hc⟩ : ∃ c : PGLOf (K p), c • x = infinity p := exists_smul_eq_infinity p x
   let e := MulEquiv.subgroupMap (MulAut.conj c) H
   let H' := H.map (MulAut.conj c).toMonoidHom
   haveI : Finite H' := Finite.of_equiv H e.toEquiv
-  have hH'_fix : ∀ g : H', (g : PGL p) • infinity p = infinity p := by
+  have hH'_fix : ∀ g : H', (g : PGLOf (K p)) • infinity p = infinity p := by
     intro ⟨g, hg⟩
     obtain ⟨h, hh, rfl⟩ := Subgroup.mem_map.mp hg
-    have heq : (c * h * c⁻¹ : PGL p) • c • x = c • x := by
+    have heq : (c * h * c⁻¹ : PGLOf (K p)) • c • x = c • x := by
       rw [← mul_smul, inv_mul_cancel_right, mul_smul, hH_fix ⟨h, hh⟩]
     exact hc ▸ heq
   have h_card : Nat.card H = Nat.card H' := Nat.card_congr e.toEquiv
@@ -215,7 +215,7 @@ theorem fixes_point_coprime_isCyclic (H : Subgroup (PGL p)) [Finite H]
     fixes_infinity_coprime_isCyclic p H' hH'_fix (h_card ▸ hH_coprime)
 
 omit h_odd in
-theorem complement_order_coprime (G : Subgroup (PGL p)) [Finite G]
+theorem complement_order_coprime (G : Subgroup (PGLOf (K p))) [Finite G]
     (P : Sylow p G)
     (K : Subgroup G) (hK : P.toSubgroup.IsComplement' K) :
     Nat.Coprime (Nat.card K) p := by
@@ -227,7 +227,7 @@ theorem complement_order_coprime (G : Subgroup (PGL p)) [Finite G]
     Nat.pow_succ_factorization_not_dvd Nat.card_pos.ne' (Fact.out : Nat.Prime p) <|
       h_card_G.symm ▸ mul_dvd_mul_left _ h
 
-theorem complement_isCyclic (G : Subgroup (PGL p)) [Finite G]
+theorem complement_isCyclic (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G) (hP_normal : (P : Subgroup G).Normal)
     (K : Subgroup G) (hK : P.toSubgroup.IsComplement' K) :
     IsCyclic K := by
@@ -235,7 +235,8 @@ theorem complement_isCyclic (G : Subgroup (PGL p)) [Finite G]
   let e : K ≃* K' := Subgroup.equivMapOfInjective K G.subtype Subtype.coe_injective
   haveI : Finite K' := Finite.of_equiv K e.toEquiv
   let x := sylowFixedPoint p G hG_p P
-  have hK'_fix : ∀ g : K', (g : PGL p) • x = x := fun ⟨_, hg⟩ ↦ by
+  -- `Dickson.K` is written out in full here because the local complement `K` shadows it
+  have hK'_fix : ∀ g : K', (g : PGLOf (Dickson.K p)) • x = x := fun ⟨_, hg⟩ ↦ by
     obtain ⟨k, _, rfl⟩ := Subgroup.mem_map.mp hg
     exact group_fixes_sylow_point p G hG_p P hP_normal k
   exact (MulEquiv.isCyclic e).mpr <|
@@ -259,7 +260,7 @@ theorem semidirect_of_complement_iso
   ⟨_, ⟨(SemidirectProduct.mulEquivSubgroup hc).symm.trans (SemidirectProduct.congr' fN fK)⟩⟩
 
 
-theorem branch1_semidirect (G : Subgroup (PGL p)) [Finite G]
+theorem branch1_semidirect (G : Subgroup (PGLOf (K p))) [Finite G]
     (P : Sylow p G) (hP_normal : (P : Subgroup G).Normal)
     (hG_p : p ∣ Nat.card G) :
     ∃ (m t : ℕ) (_ : m ≥ 1) (_ : Nat.Coprime t p) (_ : t ∣ p ^ m - 1)
@@ -342,7 +343,7 @@ theorem branch2a_constraints
     exact ⟨hpm_eq, rfl, Nat.cast_inj.mp <| inv_inj.mp hn_inv_eq⟩
 
 omit h_odd in
-theorem recognition_A4 (G : Subgroup (PGL p))
+theorem recognition_A4 (G : Subgroup (PGLOf (K p)))
     [hfin : Finite G] (hp3 : p = 3) (hn : Nat.card G = 12)
     (hn3 : Fintype.card (Sylow p G) = 4) :
     Nonempty (G ≃* alternatingGroup (Fin 4)) := by
@@ -387,7 +388,7 @@ theorem recognition_A4 (G : Subgroup (PGL p))
 
 
 theorem pgl_unique_index_two_subgroup (m : ℕ) (hm : m ≥ 1) (hpm : p ^ m ≥ 5)
-    (H : Subgroup (PGL p))
+    (H : Subgroup (PGLOf (K p)))
     (hH_le : H ≤ (pglMap (galoisFieldRingHom (p := p) m)).range)
     (hH_card : Nat.card H = p ^ m * (p ^ (2 * m) - 1) / 2) :
     Nonempty (H ≃* Matrix.ProjectiveSpecialLinearGroup (Fin 2) (GaloisField p m)) := by
@@ -429,7 +430,7 @@ theorem m_ge_one_of_pow_ge_three (m : ℕ) (hm : p ^ m ≥ 3) : m ≥ 1 := by
   · exact absurd hm (Nat.not_le_of_gt (Nat.le.step Nat.le.refl))
   · exact Nat.succ_pos _
 
-theorem recognition_PSL_iso (G : Subgroup (PGL p))
+theorem recognition_PSL_iso (G : Subgroup (PGLOf (K p)))
     [Finite G] (m : ℕ) (hm : p ^ m ≥ 5)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2) :
     Nonempty (G ≃* Matrix.ProjectiveSpecialLinearGroup (Fin 2) (GaloisField p m)) := by
@@ -439,7 +440,7 @@ theorem recognition_PSL_iso (G : Subgroup (PGL p))
     rw [← Nat.card_congr (G.equivMapOfInjective (MulEquiv.toMonoidHom (MulAut.conj g)) (MulEquiv.injective _)).toEquiv, hn])
   exact ⟨(G.equivMapOfInjective _ (MulEquiv.injective _)).trans iso'⟩
 
-theorem recognition_PGL_iso (G : Subgroup (PGL p))
+theorem recognition_PGL_iso (G : Subgroup (PGLOf (K p)))
     [Finite G] (m : ℕ) (hm : p ^ m ≥ 3)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1)) :
     Nonempty (G ≃* (GL (Fin 2) (GaloisField p m) ⧸
@@ -455,7 +456,7 @@ theorem recognition_PGL_iso (G : Subgroup (PGL p))
   exact ⟨(Subgroup.equivMapOfInjective G _ (MulEquiv.injective _)).trans <|
     (MulEquiv.subgroupCongr hg).trans h_pgl_iso_H.symm⟩
 
-theorem recognition_PSL_pm3 (G : Subgroup (PGL p))
+theorem recognition_PSL_pm3 (G : Subgroup (PGLOf (K p)))
     [Finite G] (hp3 : p = 3)
     (hn : Nat.card G = 12)
     (hn3 : Fintype.card (Sylow p G) = 4) :
@@ -466,7 +467,7 @@ theorem recognition_PSL_pm3 (G : Subgroup (PGL p))
   exact ⟨isoA4.trans isoPSL⟩
 
 omit h_odd in
-theorem sylow_count_of_order_12 (G : Subgroup (PGL p))
+theorem sylow_count_of_order_12 (G : Subgroup (PGLOf (K p)))
     [Finite G] (hp3 : p = 3)
     (hn : Nat.card G = 12)
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :
@@ -500,7 +501,7 @@ theorem sylow_count_of_order_12 (G : Subgroup (PGL p))
   · rfl
 
 
-theorem recognition_PSL_general (G : Subgroup (PGL p))
+theorem recognition_PSL_general (G : Subgroup (PGLOf (K p)))
     [Finite G] (m : ℕ) (hm : p ^ m ≥ 3)
     (hn : Nat.card G = p ^ m * (p ^ (2 * m) - 1) / 2)
     (hG_p : p ∣ Nat.card G)
@@ -527,7 +528,7 @@ theorem recognition_PSL_general (G : Subgroup (PGL p))
 
 
 theorem partition_equation
-    (G : Subgroup (PGL p)) [Finite G]
+    (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G)
     (P : Sylow p G)
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1) :
@@ -589,7 +590,7 @@ theorem partition_equation
       field_simp [hpm_pos, hz1_pos, hnp_pos]
       ring
 
-theorem dickson_branch2_z1_eq_1 (G : Subgroup (PGL p)) [Finite G]
+theorem dickson_branch2_z1_eq_1 (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1)
     (pm z1 n r : ℕ) (z : Fin r → ℕ) (s : Fin r → ℕ)
@@ -635,7 +636,7 @@ theorem dickson_branch2_z1_eq_1 (G : Subgroup (PGL p)) [Finite G]
   · exact hn_p_gt1
 
 
-theorem dickson_branch2_z1_ge_2 (G : Subgroup (PGL p)) [Finite G]
+theorem dickson_branch2_z1_ge_2 (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) (P : Sylow p G)
     (hn_p_gt1 : Fintype.card (Sylow p G) > 1)
     (pm : ℕ) (hpm_eq : pm = Nat.card P) (hpm : pm ≥ 3):
@@ -690,7 +691,7 @@ theorem dickson_branch2_z1_ge_2 (G : Subgroup (PGL p)) [Finite G]
       h.1 ▸ (h_pow ▸ dvd_pow_self p fun hm ↦ by rw [hm, pow_zero] at h_pow; linarith only [h.1, h_pow])
     exact Or.inr <| Or.inr <| Or.inr ⟨hp_eq_3, recognition_A5_proof p G hp_eq_3 (by rw [card_eq_pm_z1_np' p G P, h.1, h.2.1, h.2.2]) h.2.2⟩
 
-theorem classification_wild_slop (G : Subgroup (PGL p)) [Finite G]
+theorem classification_wild_slop (G : Subgroup (PGLOf (K p))) [Finite G]
     (hG_p : p ∣ Nat.card G) :
     (∃ (m t : ℕ) (_ : m ≥ 1) (_ : Nat.Coprime t p) (_ : t ∣ p ^ m - 1)
       (φ : Multiplicative (ZMod t) →* MulAut (Multiplicative (Fin m → ZMod p))),


### PR DESCRIPTION
Mathlib already has the projective general linear group as `Matrix.ProjGenLinGroup` (with `PGL(n, R)` notation), so `Dickson.PGL p` in `FLT.KnownIn1980s.PGL2.Defs` is now

```lean
abbrev PGL : Type := Matrix.ProjGenLinGroup (Fin 2) (K p)
```

instead of redefining the quotient `GL (Fin 2) (K p) ⧸ Subgroup.center _`. The two sorried public classification statements are textually unchanged.

### Why the diff touches `FLT/Slop/PGL2`

`Matrix.ProjGenLinGroup` is a `def`, so it is definitionally but not **reducibly** equal to the quotient. The AI-generated development in `FLT.Slop.PGL2` (which imports `Defs.lean`) relied on the old reducibility everywhere — rewriting with quotient-group lemmas, instance search — and broke in ~10 places per file. Rather than repairing each proof, every `PGL p` there is mechanically renamed to `PGLOf (K p)`, the slop tree's existing literal-quotient abbreviation (moved above its first use in `PGLBasic.lean`). That rename is elaboration-identical to the old code, so no proof logic changed. Hand edits beyond the rename: one line-break join in `TameClassification.lean`, and one `Dickson.K p` qualification in `WildClassification.lean` where a local `K : Subgroup G` shadows the field `K`.

`Proofs.lean` bridges the two definitionally equal spellings by `@`-application, supplying the `Fintype`/`Finite` instance arguments explicitly, since instance search cannot see through the semireducible `Matrix.ProjGenLinGroup`.

### Verification

- `lake build FLT.KnownIn1980s.PGL2.Proofs` succeeds locally (before the cef1e7d mathlib bump).
- `#print axioms` on `Dickson.classification_tame_proof` and `Dickson.classification_wild_proof`: only `propext`, `Classical.choice`, `Quot.sound`.

Possible follow-ups deliberately not done here: the inline `GL (Fin 2) (GaloisField p m) ⧸ Subgroup.center _` in the wild statement could also become `Matrix.ProjGenLinGroup` (left alone since it changes the text of a sorried blueprint target), and the slop tree's `PGLOf`/`pglMap`/`pgl_mulEquiv_psl` duplicate mathlib's `ProjGenLinGroup`/`ProjGenLinGroup.map`/`isoPSLOfAlgClosed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)