### PR TITLE
feat(Slop): Henselian pairs

### DIFF
--- a/FLT.lean
+++ b/FLT.lean
@@ -211,6 +211,13 @@ public import FLT.Slop.DimensionTheorem.DimLeGrowth
 public import FLT.Slop.DimensionTheorem.GrowthLeDelta
 public import FLT.Slop.DimensionTheorem.Main
 public import FLT.Slop.DimensionTheorem.Numeric
+public import FLT.Slop.HenselianPair
+public import FLT.Slop.HenselianPair.Coprime
+public import FLT.Slop.HenselianPair.Defs
+public import FLT.Slop.HenselianPair.HenselianRing
+public import FLT.Slop.HenselianPair.Idempotents
+public import FLT.Slop.HenselianPair.Polynomial
+public import FLT.Slop.HenselianPair.Quotient
 public import FLT.Slop.NumberTheory.TsumDivisorsAntidiagonal
 public import FLT.Slop.PGL2.FiniteSubgroups.CyclicPartition
 public import FLT.Slop.PGL2.FiniteSubgroups.DicksonClassification

--- a/FLT/Slop/HenselianPair.lean
+++ b/FLT/Slop/HenselianPair.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.HenselianPair.Coprime
+public import FLT.Slop.HenselianPair.Defs
+public import FLT.Slop.HenselianPair.HenselianRing
+public import FLT.Slop.HenselianPair.Idempotents
+public import FLT.Slop.HenselianPair.Polynomial
+public import FLT.Slop.HenselianPair.Quotient
+
+/-!
+# Henselian pairs
+
+A pair `(R, I)` is a *Henselian pair* if `I` is contained in the Jacobson radical of `R` and every
+monic polynomial whose reduction modulo `I` factors into coprime monic factors lifts to a matching
+factorisation over `R`.  This is the coprime-factorisation definition of Stacks Tag 09XE.
+
+This file re-exports the development.
+
+## Contents
+
+* `FLT.Slop.HenselianPair.Coprime` — coprimality of monic polynomials descends along
+  Jacobson-radical quotients.
+* `FLT.Slop.HenselianPair.Polynomial` — polynomial helpers; uniqueness of simple-root
+  lifts from `I ≤ Jac(R)` alone.
+* `FLT.Slop.HenselianPair.HenselianRing` — uniqueness of root lifts for `HenselianRing`.
+* `FLT.Slop.HenselianPair.Defs` — `IsHenselianPair` and the bridge to `HenselianRing`.
+* `FLT.Slop.HenselianPair.Idempotents` — lifting idempotents (Stacks Tag 09XI(2)).
+* `FLT.Slop.HenselianPair.Quotient` — quotient and subideal stability.
+
+## References
+
+* [Stacks Project, Tag 09XE](https://stacks.math.columbia.edu/tag/09XE)
+-/

--- a/FLT/Slop/HenselianPair/Coprime.lean
+++ b/FLT/Slop/HenselianPair/Coprime.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import Mathlib.RingTheory.Henselian
+public import Mathlib.RingTheory.Polynomial.Resultant.Basic
+
+/-!
+# Coprimality of polynomials over a Jacobson-radical quotient
+
+Two small coprimality facts used throughout the theory of Henselian pairs.
+
+## Main results
+
+* `isCoprime_X_sub_C_of_isUnit_eval` — if `p.eval a` is a unit then `X - C a` and `p`
+  are coprime, i.e. `a` is a *simple* root of `(X - C a) * p`.
+* `isCoprime_of_monic_of_isCoprime_map_quotient_of_le_jacobson` — coprimality of monic
+  polynomials descends from `R ⧸ J` to `R` when `J ≤ Jac(R)`.
+
+## References
+
+* [Stacks Project, Tag 09XE](https://stacks.math.columbia.edu/tag/09XE)
+-/
+
+@[expose] public section
+
+variable {R : Type*} [CommRing R]
+
+namespace Polynomial
+
+/-- If `p.eval a` is a unit then `X - C a` is coprime to `p`. This packages the
+fact that `a` is a *simple* root of `(X - C a) * p`. -/
+theorem isCoprime_X_sub_C_of_isUnit_eval {a : R} {p : R[X]}
+    (h : IsUnit (p.eval a)) : IsCoprime (X - C a) p := by
+  obtain ⟨v, hv⟩ := isUnit_iff_exists_inv.mp h
+  have hdvd : (X - C a) ∣ (p - C (p.eval a)) := X_sub_C_dvd_sub_C_eval
+  obtain ⟨k, hk⟩ := hdvd
+  refine ⟨-(C v * k), C v, ?_⟩
+  have hk2 : p - (X - C a) * k = C (p.eval a) := by rw [← hk]; ring
+  calc -(C v * k) * (X - C a) + C v * p
+      = C v * (p - (X - C a) * k) := by ring
+    _ = C v * C (p.eval a) := by rw [hk2]
+    _ = C (p.eval a * v) := by rw [← C_mul, mul_comm]
+    _ = C 1 := by rw [hv]
+    _ = 1 := C_1
+
+/-- **Coprimality lifts along Jacobson-radical quotients for monic polynomials.**
+If `J ≤ Jac(R)` and two monic polynomials become coprime modulo `J`, then they
+were already coprime over `R`.
+
+The proof uses the resultant: for a monic polynomial, being coprime is equivalent
+to the resultant being a unit.  The resultant is a unit modulo `J`; since the
+quotient map is local when `J ≤ Jac(R)`, it was already a unit in `R`. -/
+theorem isCoprime_of_monic_of_isCoprime_map_quotient_of_le_jacobson {J : Ideal R}
+    (hJ : J ≤ Ideal.jacobson (⊥ : Ideal R)) {g h : R[X]} (hg : g.Monic)
+    (hh : h.Monic)
+    (hcop : IsCoprime (g.map (Ideal.Quotient.mk J)) (h.map (Ideal.Quotient.mk J))) :
+    IsCoprime g h := by
+  rcases subsingleton_or_nontrivial R with _ | hR
+  · exact ⟨0, 0, Subsingleton.elim _ _⟩
+  have hJtop : J ≠ ⊤ := by
+    intro htop
+    have h1 : (1 : R) ∈ Ideal.jacobson (⊥ : Ideal R) :=
+      hJ (htop ▸ Submodule.mem_top)
+    rw [Ideal.mem_jacobson_bot] at h1
+    have h0 := h1 (-1)
+    rw [one_mul, neg_add_cancel] at h0
+    exact not_isUnit_zero h0
+  haveI : Nontrivial (R ⧸ J) := Ideal.Quotient.nontrivial_iff.mpr hJtop
+  haveI : IsLocalHom (Ideal.Quotient.mk J) := isLocalHom_of_le_jacobson_bot J hJ
+  rw [← Polynomial.isUnit_resultant_iff_isCoprime hg]
+  refine IsUnit.of_map (Ideal.Quotient.mk J) _ ?_
+  have hres :
+      IsUnit (Polynomial.resultant (g.map (Ideal.Quotient.mk J))
+        (h.map (Ideal.Quotient.mk J))) :=
+    (Polynomial.isUnit_resultant_iff_isCoprime (hg.map _)).mpr hcop
+  rwa [show (g.map (Ideal.Quotient.mk J)).natDegree = g.natDegree
+        from hg.natDegree_map _,
+      show (h.map (Ideal.Quotient.mk J)).natDegree = h.natDegree
+        from hh.natDegree_map _,
+      Polynomial.resultant_map_map] at hres
+
+end Polynomial

--- a/FLT/Slop/HenselianPair/Coprime.lean
+++ b/FLT/Slop/HenselianPair/Coprime.lean
@@ -33,19 +33,13 @@ namespace Polynomial
 
 /-- If `p.eval a` is a unit then `X - C a` is coprime to `p`. This packages the
 fact that `a` is a *simple* root of `(X - C a) * p`. -/
-theorem isCoprime_X_sub_C_of_isUnit_eval {a : R} {p : R[X]}
-    (h : IsUnit (p.eval a)) : IsCoprime (X - C a) p := by
+theorem isCoprime_X_sub_C_of_isUnit_eval {a : R} {p : R[X]} (h : IsUnit (p.eval a)) :
+    IsCoprime (X - C a) p := by
   obtain ⟨v, hv⟩ := isUnit_iff_exists_inv.mp h
-  have hdvd : (X - C a) ∣ (p - C (p.eval a)) := X_sub_C_dvd_sub_C_eval
-  obtain ⟨k, hk⟩ := hdvd
-  refine ⟨-(C v * k), C v, ?_⟩
-  have hk2 : p - (X - C a) * k = C (p.eval a) := by rw [← hk]; ring
-  calc -(C v * k) * (X - C a) + C v * p
-      = C v * (p - (X - C a) * k) := by ring
-    _ = C v * C (p.eval a) := by rw [hk2]
-    _ = C (p.eval a * v) := by rw [← C_mul, mul_comm]
-    _ = C 1 := by rw [hv]
-    _ = 1 := C_1
+  obtain ⟨k, hk⟩ : (X - C a) ∣ (p - C (p.eval a)) := X_sub_C_dvd_sub_C_eval
+  rw [show p = C (p.eval a) + (X - C a) * k by rw [← hk]; ring,
+    IsCoprime.add_mul_left_right_iff]
+  exact ⟨0, C v, by rw [zero_mul, zero_add, ← C_mul, mul_comm, hv, C_1]⟩
 
 /-- **Coprimality lifts along Jacobson-radical quotients for monic polynomials.**
 If `J ≤ Jac(R)` and two monic polynomials become coprime modulo `J`, then they
@@ -55,32 +49,18 @@ The proof uses the resultant: for a monic polynomial, being coprime is equivalen
 to the resultant being a unit.  The resultant is a unit modulo `J`; since the
 quotient map is local when `J ≤ Jac(R)`, it was already a unit in `R`. -/
 theorem isCoprime_of_monic_of_isCoprime_map_quotient_of_le_jacobson {J : Ideal R}
-    (hJ : J ≤ Ideal.jacobson (⊥ : Ideal R)) {g h : R[X]} (hg : g.Monic)
-    (hh : h.Monic)
+    (hJ : J ≤ Ideal.jacobson (⊥ : Ideal R)) {g h : R[X]} (hg : g.Monic) (hh : h.Monic)
     (hcop : IsCoprime (g.map (Ideal.Quotient.mk J)) (h.map (Ideal.Quotient.mk J))) :
     IsCoprime g h := by
   rcases subsingleton_or_nontrivial R with _ | hR
   · exact ⟨0, 0, Subsingleton.elim _ _⟩
-  have hJtop : J ≠ ⊤ := by
-    intro htop
-    have h1 : (1 : R) ∈ Ideal.jacobson (⊥ : Ideal R) :=
-      hJ (htop ▸ Submodule.mem_top)
-    rw [Ideal.mem_jacobson_bot] at h1
-    have h0 := h1 (-1)
-    rw [one_mul, neg_add_cancel] at h0
-    exact not_isUnit_zero h0
-  haveI : Nontrivial (R ⧸ J) := Ideal.Quotient.nontrivial_iff.mpr hJtop
-  haveI : IsLocalHom (Ideal.Quotient.mk J) := isLocalHom_of_le_jacobson_bot J hJ
+  have hJtop : J ≠ ⊤ :=
+    (hJ.trans_lt (Ideal.jacobson_bot (R := R) ▸ Ring.jacobson_lt_top R)).ne
+  have : Nontrivial (R ⧸ J) := Ideal.Quotient.nontrivial_iff.mpr hJtop
+  have : IsLocalHom (Ideal.Quotient.mk J) := isLocalHom_of_le_jacobson_bot J hJ
   rw [← Polynomial.isUnit_resultant_iff_isCoprime hg]
   refine IsUnit.of_map (Ideal.Quotient.mk J) _ ?_
-  have hres :
-      IsUnit (Polynomial.resultant (g.map (Ideal.Quotient.mk J))
-        (h.map (Ideal.Quotient.mk J))) :=
-    (Polynomial.isUnit_resultant_iff_isCoprime (hg.map _)).mpr hcop
-  rwa [show (g.map (Ideal.Quotient.mk J)).natDegree = g.natDegree
-        from hg.natDegree_map _,
-      show (h.map (Ideal.Quotient.mk J)).natDegree = h.natDegree
-        from hh.natDegree_map _,
-      Polynomial.resultant_map_map] at hres
+  simpa [hg.natDegree_map, hh.natDegree_map, Polynomial.resultant_map_map]
+    using (Polynomial.isUnit_resultant_iff_isCoprime (hg.map _)).mpr hcop
 
 end Polynomial

--- a/FLT/Slop/HenselianPair/Defs.lean
+++ b/FLT/Slop/HenselianPair/Defs.lean
@@ -1,0 +1,301 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.HenselianPair.Coprime
+public import FLT.Slop.HenselianPair.HenselianRing
+
+/-!
+# Henselian pairs
+
+A pair `(R, I)` is a **Henselian pair** if `I` is contained in the Jacobson radical of `R` and
+every monic polynomial whose reduction modulo `I` factors as a product of two monic *coprime*
+polynomials lifts to a matching factorisation over `R` (Stacks Tag 09XE).
+
+This file gives the definition, the bridge to mathlib's simple-root-lifting predicate
+`HenselianRing`, and the two basic examples `(R, ⊥)` and a Henselian local ring.
+
+## Main definitions
+
+* `IsHenselianPair R I` — the factorisation-lifting definition of a Henselian pair.
+
+## Main results
+
+* `IsHenselianPair.henselianRing` — a Henselian pair satisfies mathlib's `HenselianRing`.
+* `IsHenselianPair.henselianLocalRing` — a local ring Henselian at its maximal ideal is a
+  `HenselianLocalRing`.
+* `IsHenselianPair.existsUnique_root_lift_of_isUnit_derivative` — the simple-root lift is unique
+  in its congruence class.
+* `IsHenselianPair.bot` — `(R, ⊥)` is a Henselian pair.
+
+## References
+
+* [Stacks Project, Tag 09XE](https://stacks.math.columbia.edu/tag/09XE)
+* [Stacks Project, Tag 09XI](https://stacks.math.columbia.edu/tag/09XI)
+-/
+
+@[expose] public section
+
+open Polynomial
+
+variable {R : Type*} [CommRing R]
+
+/-- A pair `(R, I)` is a **Henselian pair** if `I` is contained in the Jacobson
+radical and every monic polynomial whose reduction modulo `I` factors as a
+product of two monic *coprime* polynomials lifts to a matching factorisation
+over `R` (Stacks Tag 09XE). -/
+@[stacks 09XE]
+class IsHenselianPair (R : Type*) [CommRing R] (I : Ideal R) : Prop where
+  /-- `I` is contained in the Jacobson radical of `R`. -/
+  le_jacobson : I ≤ Ideal.jacobson ⊥
+  /-- Coprime monic factorisations lift from `R/I` to `R`. -/
+  exists_lift_factorization : ∀ (f : R[X]), f.Monic →
+    ∀ {g₀ h₀ : (R ⧸ I)[X]}, g₀.Monic → h₀.Monic → IsCoprime g₀ h₀ →
+      f.map (Ideal.Quotient.mk I) = g₀ * h₀ →
+      ∃ g h : R[X], g.Monic ∧ h.Monic ∧ f = g * h ∧
+        g.map (Ideal.Quotient.mk I) = g₀ ∧ h.map (Ideal.Quotient.mk I) = h₀
+
+namespace IsHenselianPair
+
+/-- A Henselian pair is Henselian in the simple-root-lifting sense of mathlib's
+`HenselianRing`: a simple root of a monic polynomial over `R/I` lifts to a root
+over `R`. (Stacks Tag 09XE; the factorisation definition implies the
+root-lifting property.) -/
+@[stacks 09XI "(1) => (5), root-lifting form"]
+theorem henselianRing {I : Ideal R} (h : IsHenselianPair R I) : HenselianRing R I where
+  jac := h.le_jacobson
+  is_henselian := by
+    intro f hf a₀ h₁ h₂
+    rcases subsingleton_or_nontrivial R with _ | _
+    · exact ⟨a₀, Subsingleton.elim _ _, by rw [sub_self]; exact I.zero_mem⟩
+    -- `I ≠ ⊤`, hence `R/I` is nontrivial.
+    have hItop : I ≠ ⊤ := by
+      intro hI
+      have h1 : (1 : R) ∈ Ideal.jacobson ⊥ := h.le_jacobson (hI ▸ Submodule.mem_top)
+      rw [Ideal.mem_jacobson_bot] at h1
+      have h0 := h1 (-1)
+      rw [one_mul, neg_add_cancel] at h0
+      exact not_isUnit_zero h0
+    haveI : Nontrivial (R ⧸ I) := Ideal.Quotient.nontrivial_iff.mpr hItop
+    -- `a₀` reduces to a simple root of `f.map (mk I)`.
+    have hroot : (f.map (Ideal.Quotient.mk I)).IsRoot (Ideal.Quotient.mk I a₀) := by
+      change (f.map (Ideal.Quotient.mk I)).eval (Ideal.Quotient.mk I a₀) = 0
+      rw [eval_map_apply, Ideal.Quotient.eq_zero_iff_mem]
+      exact h₁
+    -- factor out the linear factor over `R/I`.
+    obtain ⟨h₀, hfact⟩ := dvd_iff_isRoot.mpr hroot
+    have hfb_monic : (f.map (Ideal.Quotient.mk I)).Monic := hf.map _
+    have hg0_monic : (X - C (Ideal.Quotient.mk I a₀)).Monic := monic_X_sub_C _
+    have hh0_monic : h₀.Monic := by
+      apply hg0_monic.of_mul_monic_left
+      rwa [← hfact]
+    -- the cofactor `h₀` does not vanish at `a₀`, i.e. the root is simple.
+    have hh0_eval : IsUnit (h₀.eval (Ideal.Quotient.mk I a₀)) := by
+      have hd : (derivative (f.map (Ideal.Quotient.mk I))).eval (Ideal.Quotient.mk I a₀)
+          = h₀.eval (Ideal.Quotient.mk I a₀) := by
+        rw [hfact]
+        simp [derivative_mul, eval_mul, eval_add, eval_sub, eval_X, eval_C]
+      have he : (derivative (f.map (Ideal.Quotient.mk I))).eval (Ideal.Quotient.mk I a₀)
+          = Ideal.Quotient.mk I (f.derivative.eval a₀) := by
+        rw [derivative_map, eval_map_apply]
+      rw [hd] at he
+      rw [he]; exact h₂
+    have hcop : IsCoprime (X - C (Ideal.Quotient.mk I a₀)) h₀ :=
+      isCoprime_X_sub_C_of_isUnit_eval hh0_eval
+    -- lift the factorisation to `R`.
+    obtain ⟨g, hh, hg_monic, -, hfgh, hgmap, -⟩ :=
+      h.exists_lift_factorization f hf (g₀ := X - C (Ideal.Quotient.mk I a₀)) (h₀ := h₀)
+        hg0_monic hh0_monic hcop (by rw [hfact])
+    -- `g` is monic of degree one, so it is `X - C a` for the lift `a` we seek.
+    have hgdeg : g.natDegree = 1 := by
+      have hmap := hg_monic.natDegree_map (Ideal.Quotient.mk I)
+      rw [hgmap, natDegree_X_sub_C] at hmap
+      exact hmap.symm
+    have hgeq : g = X + C (g.coeff 0) := hg_monic.eq_X_add_C hgdeg
+    refine ⟨-(g.coeff 0), ?_, ?_⟩
+    · change f.eval (-(g.coeff 0)) = 0
+      rw [hfgh, eval_mul]
+      have : g.eval (-(g.coeff 0)) = 0 := by rw [hgeq]; simp
+      rw [this, zero_mul]
+    · rw [← Ideal.Quotient.eq_zero_iff_mem, map_sub, sub_eq_zero]
+      have hc0 : Ideal.Quotient.mk I (g.coeff 0) = -(Ideal.Quotient.mk I a₀) := by
+        have := congrArg (fun p => Polynomial.coeff p 0) hgmap
+        simpa [coeff_map, coeff_sub, coeff_X_zero, coeff_C_zero, zero_sub] using this
+      rw [map_neg, hc0, neg_neg]
+
+/-- A simple root lift for a Henselian pair is unique in its congruence class.
+
+This is the Jacobson-radical uniqueness argument for simple roots: if two roots
+of `f` are congruent to the same `a₀` modulo `I`, and `f' a₀` is a unit modulo
+`I`, then the two roots are equal.  No monicity is needed for this uniqueness
+statement. -/
+theorem root_lift_unique_of_isUnit_derivative {I : Ideal R} (h : IsHenselianPair R I)
+    {f : R[X]} {a₀ a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b)
+    (haI : a - a₀ ∈ I) (hbI : b - a₀ ∈ I)
+    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) :
+    a = b := by
+  letI : HenselianRing R I := h.henselianRing
+  exact HenselianRing.root_lift_unique_of_isUnit_derivative ha hb haI hbI hderiv
+
+/-- A Henselian pair has a unique lift of a simple root in the prescribed
+congruence class.  This is the `∃!` form of `IsHenselianPair.henselianRing`. -/
+theorem existsUnique_root_lift_of_isUnit_derivative {I : Ideal R}
+    (h : IsHenselianPair R I) {f : R[X]} (hf : f.Monic) (a₀ : R)
+    (hroot : f.eval a₀ ∈ I)
+    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) :
+    ∃! a : R, f.IsRoot a ∧ a - a₀ ∈ I := by
+  letI : HenselianRing R I := h.henselianRing
+  exact HenselianRing.existsUnique_root_lift_of_isUnit_derivative hf a₀ hroot hderiv
+
+/-- Uniqueness in the quotient form of the Stacks Tag 09XI root condition for
+a Henselian pair.
+
+This uniqueness statement needs only the Jacobson-radical condition, but this
+pair-level spelling is convenient when working from `IsHenselianPair R I`. -/
+theorem root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R}
+    (h : IsHenselianPair R I) {f : R[X]} (n : ℕ)
+    (hmod : f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I)))
+    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
+    (hbI : b - 1 ∈ I) :
+    a = b := by
+  letI : HenselianRing R I := h.henselianRing
+  exact HenselianRing.root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one n hmod
+    ha hb haI hbI
+
+/-- Uniqueness in the coefficientwise-congruence form of the Stacks Tag 09XI
+root condition for a Henselian pair. -/
+theorem root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
+    {I : Ideal R} (h : IsHenselianPair R I) {f : R[X]} (n : ℕ)
+    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I)
+    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
+    (hbI : b - 1 ∈ I) :
+    a = b := by
+  letI : HenselianRing R I := h.henselianRing
+  exact HenselianRing.root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
+    n hcoeff ha hb haI hbI
+
+/-- Uniqueness in the perturbation form of the Stacks Tag 09XI root condition
+for a Henselian pair. -/
+theorem root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one
+    {I : Ideal R} (h : IsHenselianPair R I) (n : ℕ) {p : R[X]}
+    (hp : ∀ k, p.coeff k ∈ I) {a b : R}
+    (ha : (X ^ n * (X - C (1 : R)) + p).IsRoot a)
+    (hb : (X ^ n * (X - C (1 : R)) + p).IsRoot b) (haI : a - 1 ∈ I)
+    (hbI : b - 1 ∈ I) :
+    a = b := by
+  letI : HenselianRing R I := h.henselianRing
+  exact HenselianRing.root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one
+    n hp ha hb haI hbI
+
+/-- Uniqueness in the literal finite-coefficient form of the Stacks Tag 09XI
+root condition for a Henselian pair. -/
+theorem root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
+    {I : Ideal R} (h : IsHenselianPair R I) (n : ℕ) (a : ℕ → R)
+    (ha_coeff : ∀ i ≤ n, a i ∈ I) {x y : R}
+    (hx : (X ^ n * (X - C (1 : R)) +
+      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x)
+    (hy : (X ^ n * (X - C (1 : R)) +
+      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot y)
+    (hxI : x - 1 ∈ I) (hyI : y - 1 ∈ I) :
+    x = y := by
+  letI : HenselianRing R I := h.henselianRing
+  exact HenselianRing.root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
+    n a ha_coeff hx hy hxI hyI
+
+/-- **The root condition for a Henselian pair**, in the direction supplied by
+factorisation lifting (Stacks Tag 09XI, `(1) ⇒ (5)`).
+
+If `f` is monic and `f` reduces modulo `I` to `X ^ n * (X - 1)`, then `f` has a
+unique root congruent to `1` modulo `I`. -/
+theorem existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R}
+    (h : IsHenselianPair R I) {f : R[X]} (hf : f.Monic) (n : ℕ)
+    (hmod : f.map (Ideal.Quotient.mk I) =
+      X ^ n * (X - C (1 : R ⧸ I))) :
+    ∃! a : R, f.IsRoot a ∧ a - 1 ∈ I := by
+  letI : HenselianRing R I := h.henselianRing
+  exact HenselianRing.existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one
+    hf n hmod
+
+/-- Coefficientwise-congruence form of the Stacks Tag 09XI root condition.
+
+If the coefficients of `f - X ^ n * (X - 1)` all lie in `I`, then `f` has a
+unique root congruent to `1` modulo `I`. -/
+theorem existsUnique_root_one_mod_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
+    {I : Ideal R} (h : IsHenselianPair R I) {f : R[X]} (hf : f.Monic) (n : ℕ)
+    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I) :
+    ∃! a : R, f.IsRoot a ∧ a - 1 ∈ I := by
+  apply h.existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one hf n
+  exact Polynomial.map_eq_X_pow_mul_X_sub_C_one_of_forall_coeff_sub_mem n hcoeff
+
+/-- Stacks-style perturbation form of the Tag 09XI root condition.
+
+If `p` has all coefficients in `I`, then every monic polynomial of the form
+`X ^ n * (X - 1) + p` has a unique root congruent to `1` modulo `I`. -/
+theorem existsUnique_root_one_mod_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one
+    {I : Ideal R} (h : IsHenselianPair R I) (n : ℕ) {p : R[X]}
+    (hp : ∀ k, p.coeff k ∈ I) (hf : (X ^ n * (X - C (1 : R)) + p).Monic) :
+    ∃! a : R, (X ^ n * (X - C (1 : R)) + p).IsRoot a ∧ a - 1 ∈ I := by
+  apply h.existsUnique_root_one_mod_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one hf n
+  intro k
+  simpa [coeff_sub, coeff_add, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hp k
+
+/-- Finite-coefficient form of the Stacks Tag 09XI root condition.
+
+If `a₀, ..., aₙ` lie in `I`, then the Stacks polynomial
+`X ^ n * (X - 1) + aₙ X ^ n + ... + a₀` has a unique root congruent to `1`
+modulo `I`. This is condition (5) in Tag 09XI in its literal finite-sum shape,
+for the direction supplied by a Henselian pair. -/
+@[stacks 09XI "(5)"]
+theorem existsUnique_root_one_mod_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
+    {I : Ideal R} (h : IsHenselianPair R I) (n : ℕ) (a : ℕ → R)
+    (ha : ∀ i ≤ n, a i ∈ I) :
+    ∃! x : R,
+      (X ^ n * (X - C (1 : R)) +
+        ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x ∧ x - 1 ∈ I := by
+  have hf :
+      (X ^ n * (X - C (1 : R)) +
+        ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).Monic :=
+    Polynomial.monic_X_pow_mul_X_sub_C_one_add_sum_range_C_mul_X_pow n a
+  apply h.existsUnique_root_one_mod_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one n ?_ hf
+  intro k
+  rw [Polynomial.coeff_sum_range_C_mul_X_pow n a k]
+  split_ifs with hk
+  · exact ha k hk
+  · exact I.zero_mem
+
+/-- **Local-ring bridge, easy direction** (Stacks Tag 04GH / 0DYD, `←`).
+If `(R, 𝔪)` is a Henselian pair at the maximal ideal of a local ring, then `R`
+is a Henselian local ring. (The converse is the coprime-factorisation lift, which
+is the hard direction and a mathlib TODO.) -/
+@[stacks 04GH]
+theorem henselianLocalRing [IsLocalRing R]
+    (h : IsHenselianPair R (IsLocalRing.maximalIdeal R)) : HenselianLocalRing R where
+  is_henselian f hf a₀ h₁ h₂ :=
+    h.henselianRing.is_henselian f hf a₀ h₁ (h₂.map (Ideal.Quotient.mk _))
+
+/-- The pair `(R, ⊥)` is a Henselian pair for any commutative ring `R`: reduction
+modulo `⊥` is an isomorphism, so any coprime monic factorisation of the reduction
+transports back to `R`. In particular a field `K` gives the Henselian pair `(K, ⊥)`. -/
+theorem bot : IsHenselianPair R (⊥ : Ideal R) where
+  le_jacobson := bot_le
+  exists_lift_factorization := by
+    intro f _ g₀ h₀ hg₀ hh₀ _ hfact
+    -- `e : R ⧸ ⊥ ≃+* R` is the canonical isomorphism.
+    set e := RingEquiv.quotientBot R with he
+    set mk₀ := Ideal.Quotient.mk (⊥ : Ideal R) with hmk₀
+    -- `e ∘ mk₀ = id` and `mk₀ ∘ e = id`, as ring homomorphisms.
+    have h1 : e.toRingHom.comp mk₀ = RingHom.id R :=
+      RingHom.ext fun r => RingEquiv.quotientBot_mk r
+    have h2 : (mk₀ : R →+* R ⧸ (⊥ : Ideal R)).comp e.toRingHom = RingHom.id _ :=
+      RingHom.ext fun x => by
+        rw [RingHom.comp_apply, RingHom.id_apply, hmk₀, ← RingEquiv.quotientBot_symm_mk]
+        exact e.symm_apply_apply x
+    refine ⟨g₀.map e.toRingHom, h₀.map e.toRingHom, hg₀.map _, hh₀.map _, ?_, ?_, ?_⟩
+    · rw [← Polynomial.map_mul, ← hfact, Polynomial.map_map, h1, Polynomial.map_id]
+    · rw [Polynomial.map_map, h2, Polynomial.map_id]
+    · rw [Polynomial.map_map, h2, Polynomial.map_id]
+
+end IsHenselianPair

--- a/FLT/Slop/HenselianPair/Defs.lean
+++ b/FLT/Slop/HenselianPair/Defs.lean
@@ -72,14 +72,9 @@ theorem henselianRing {I : Ideal R} (h : IsHenselianPair R I) : HenselianRing R 
     rcases subsingleton_or_nontrivial R with _ | _
     · exact ⟨a₀, Subsingleton.elim _ _, by rw [sub_self]; exact I.zero_mem⟩
     -- `I ≠ ⊤`, hence `R/I` is nontrivial.
-    have hItop : I ≠ ⊤ := by
-      intro hI
-      have h1 : (1 : R) ∈ Ideal.jacobson ⊥ := h.le_jacobson (hI ▸ Submodule.mem_top)
-      rw [Ideal.mem_jacobson_bot] at h1
-      have h0 := h1 (-1)
-      rw [one_mul, neg_add_cancel] at h0
-      exact not_isUnit_zero h0
-    haveI : Nontrivial (R ⧸ I) := Ideal.Quotient.nontrivial_iff.mpr hItop
+    have hItop : I ≠ ⊤ :=
+      (h.le_jacobson.trans_lt (Ideal.jacobson_bot (R := R) ▸ Ring.jacobson_lt_top R)).ne
+    have : Nontrivial (R ⧸ I) := Ideal.Quotient.nontrivial_iff.mpr hItop
     -- `a₀` reduces to a simple root of `f.map (mk I)`.
     have hroot : (f.map (Ideal.Quotient.mk I)).IsRoot (Ideal.Quotient.mk I a₀) := by
       change (f.map (Ideal.Quotient.mk I)).eval (Ideal.Quotient.mk I a₀) = 0
@@ -122,7 +117,7 @@ theorem henselianRing {I : Ideal R} (h : IsHenselianPair R I) : HenselianRing R 
       rw [this, zero_mul]
     · rw [← Ideal.Quotient.eq_zero_iff_mem, map_sub, sub_eq_zero]
       have hc0 : Ideal.Quotient.mk I (g.coeff 0) = -(Ideal.Quotient.mk I a₀) := by
-        have := congrArg (fun p => Polynomial.coeff p 0) hgmap
+        have := congrArg (fun p ↦ Polynomial.coeff p 0) hgmap
         simpa [coeff_map, coeff_sub, coeff_X_zero, coeff_C_zero, zero_sub] using this
       rw [map_neg, hc0, neg_neg]
 
@@ -132,62 +127,45 @@ This is the Jacobson-radical uniqueness argument for simple roots: if two roots
 of `f` are congruent to the same `a₀` modulo `I`, and `f' a₀` is a unit modulo
 `I`, then the two roots are equal.  No monicity is needed for this uniqueness
 statement. -/
-theorem root_lift_unique_of_isUnit_derivative {I : Ideal R} (h : IsHenselianPair R I)
-    {f : R[X]} {a₀ a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b)
-    (haI : a - a₀ ∈ I) (hbI : b - a₀ ∈ I)
-    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) :
-    a = b := by
-  letI : HenselianRing R I := h.henselianRing
-  exact HenselianRing.root_lift_unique_of_isUnit_derivative ha hb haI hbI hderiv
+theorem root_lift_unique_of_isUnit_derivative {I : Ideal R} (h : IsHenselianPair R I) {f : R[X]}
+    {a₀ a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - a₀ ∈ I) (hbI : b - a₀ ∈ I)
+    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) : a = b :=
+  h.henselianRing.root_lift_unique_of_isUnit_derivative ha hb haI hbI hderiv
 
 /-- A Henselian pair has a unique lift of a simple root in the prescribed
 congruence class.  This is the `∃!` form of `IsHenselianPair.henselianRing`. -/
-theorem existsUnique_root_lift_of_isUnit_derivative {I : Ideal R}
-    (h : IsHenselianPair R I) {f : R[X]} (hf : f.Monic) (a₀ : R)
-    (hroot : f.eval a₀ ∈ I)
+theorem existsUnique_root_lift_of_isUnit_derivative {I : Ideal R} (h : IsHenselianPair R I)
+    {f : R[X]} (hf : f.Monic) (a₀ : R) (hroot : f.eval a₀ ∈ I)
     (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) :
-    ∃! a : R, f.IsRoot a ∧ a - a₀ ∈ I := by
-  letI : HenselianRing R I := h.henselianRing
-  exact HenselianRing.existsUnique_root_lift_of_isUnit_derivative hf a₀ hroot hderiv
+    ∃! a : R, f.IsRoot a ∧ a - a₀ ∈ I :=
+  h.henselianRing.existsUnique_root_lift_of_isUnit_derivative hf a₀ hroot hderiv
 
 /-- Uniqueness in the quotient form of the Stacks Tag 09XI root condition for
 a Henselian pair.
 
 This uniqueness statement needs only the Jacobson-radical condition, but this
 pair-level spelling is convenient when working from `IsHenselianPair R I`. -/
-theorem root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R}
-    (h : IsHenselianPair R I) {f : R[X]} (n : ℕ)
-    (hmod : f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I)))
-    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
-    (hbI : b - 1 ∈ I) :
-    a = b := by
-  letI : HenselianRing R I := h.henselianRing
-  exact HenselianRing.root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one n hmod
-    ha hb haI hbI
+theorem root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R} (h : IsHenselianPair R I)
+    {f : R[X]} (n : ℕ) (hmod : f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I)))
+    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I) (hbI : b - 1 ∈ I) : a = b :=
+  h.henselianRing.root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one n hmod ha hb haI hbI
 
 /-- Uniqueness in the coefficientwise-congruence form of the Stacks Tag 09XI
 root condition for a Henselian pair. -/
 theorem root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
     {I : Ideal R} (h : IsHenselianPair R I) {f : R[X]} (n : ℕ)
-    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I)
-    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
-    (hbI : b - 1 ∈ I) :
-    a = b := by
-  letI : HenselianRing R I := h.henselianRing
-  exact HenselianRing.root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
+    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I) {a b : R} (ha : f.IsRoot a)
+    (hb : f.IsRoot b) (haI : a - 1 ∈ I) (hbI : b - 1 ∈ I) : a = b :=
+  h.henselianRing.root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
     n hcoeff ha hb haI hbI
 
 /-- Uniqueness in the perturbation form of the Stacks Tag 09XI root condition
 for a Henselian pair. -/
 theorem root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one
-    {I : Ideal R} (h : IsHenselianPair R I) (n : ℕ) {p : R[X]}
-    (hp : ∀ k, p.coeff k ∈ I) {a b : R}
-    (ha : (X ^ n * (X - C (1 : R)) + p).IsRoot a)
-    (hb : (X ^ n * (X - C (1 : R)) + p).IsRoot b) (haI : a - 1 ∈ I)
-    (hbI : b - 1 ∈ I) :
-    a = b := by
-  letI : HenselianRing R I := h.henselianRing
-  exact HenselianRing.root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one
+    {I : Ideal R} (h : IsHenselianPair R I) (n : ℕ) {p : R[X]} (hp : ∀ k, p.coeff k ∈ I) {a b : R}
+    (ha : (X ^ n * (X - C (1 : R)) + p).IsRoot a) (hb : (X ^ n * (X - C (1 : R)) + p).IsRoot b)
+    (haI : a - 1 ∈ I) (hbI : b - 1 ∈ I) : a = b :=
+  h.henselianRing.root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one
     n hp ha hb haI hbI
 
 /-- Uniqueness in the literal finite-coefficient form of the Stacks Tag 09XI
@@ -195,14 +173,10 @@ root condition for a Henselian pair. -/
 theorem root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
     {I : Ideal R} (h : IsHenselianPair R I) (n : ℕ) (a : ℕ → R)
     (ha_coeff : ∀ i ≤ n, a i ∈ I) {x y : R}
-    (hx : (X ^ n * (X - C (1 : R)) +
-      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x)
-    (hy : (X ^ n * (X - C (1 : R)) +
-      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot y)
-    (hxI : x - 1 ∈ I) (hyI : y - 1 ∈ I) :
-    x = y := by
-  letI : HenselianRing R I := h.henselianRing
-  exact HenselianRing.root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
+    (hx : (X ^ n * (X - C (1 : R)) + ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x)
+    (hy : (X ^ n * (X - C (1 : R)) + ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot y)
+    (hxI : x - 1 ∈ I) (hyI : y - 1 ∈ I) : x = y :=
+  h.henselianRing.root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
     n a ha_coeff hx hy hxI hyI
 
 /-- **The root condition for a Henselian pair**, in the direction supplied by
@@ -212,12 +186,9 @@ If `f` is monic and `f` reduces modulo `I` to `X ^ n * (X - 1)`, then `f` has a
 unique root congruent to `1` modulo `I`. -/
 theorem existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R}
     (h : IsHenselianPair R I) {f : R[X]} (hf : f.Monic) (n : ℕ)
-    (hmod : f.map (Ideal.Quotient.mk I) =
-      X ^ n * (X - C (1 : R ⧸ I))) :
-    ∃! a : R, f.IsRoot a ∧ a - 1 ∈ I := by
-  letI : HenselianRing R I := h.henselianRing
-  exact HenselianRing.existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one
-    hf n hmod
+    (hmod : f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I))) :
+    ∃! a : R, f.IsRoot a ∧ a - 1 ∈ I :=
+  h.henselianRing.existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one hf n hmod
 
 /-- Coefficientwise-congruence form of the Stacks Tag 09XI root condition.
 
@@ -225,10 +196,9 @@ If the coefficients of `f - X ^ n * (X - 1)` all lie in `I`, then `f` has a
 unique root congruent to `1` modulo `I`. -/
 theorem existsUnique_root_one_mod_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
     {I : Ideal R} (h : IsHenselianPair R I) {f : R[X]} (hf : f.Monic) (n : ℕ)
-    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I) :
-    ∃! a : R, f.IsRoot a ∧ a - 1 ∈ I := by
-  apply h.existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one hf n
-  exact Polynomial.map_eq_X_pow_mul_X_sub_C_one_of_forall_coeff_sub_mem n hcoeff
+    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I) : ∃! a : R, f.IsRoot a ∧ a - 1 ∈ I :=
+  h.existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one hf n
+    (Polynomial.map_eq_X_pow_mul_X_sub_C_one_of_forall_coeff_sub_mem n hcoeff)
 
 /-- Stacks-style perturbation form of the Tag 09XI root condition.
 
@@ -238,8 +208,7 @@ theorem existsUnique_root_one_mod_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one
     {I : Ideal R} (h : IsHenselianPair R I) (n : ℕ) {p : R[X]}
     (hp : ∀ k, p.coeff k ∈ I) (hf : (X ^ n * (X - C (1 : R)) + p).Monic) :
     ∃! a : R, (X ^ n * (X - C (1 : R)) + p).IsRoot a ∧ a - 1 ∈ I := by
-  apply h.existsUnique_root_one_mod_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one hf n
-  intro k
+  refine h.existsUnique_root_one_mod_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one hf n fun k => ?_
   simpa [coeff_sub, coeff_add, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hp k
 
 /-- Finite-coefficient form of the Stacks Tag 09XI root condition.
@@ -250,29 +219,24 @@ modulo `I`. This is condition (5) in Tag 09XI in its literal finite-sum shape,
 for the direction supplied by a Henselian pair. -/
 @[stacks 09XI "(5)"]
 theorem existsUnique_root_one_mod_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
-    {I : Ideal R} (h : IsHenselianPair R I) (n : ℕ) (a : ℕ → R)
-    (ha : ∀ i ≤ n, a i ∈ I) :
+    {I : Ideal R} (h : IsHenselianPair R I) (n : ℕ) (a : ℕ → R) (ha : ∀ i ≤ n, a i ∈ I) :
     ∃! x : R,
       (X ^ n * (X - C (1 : R)) +
         ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x ∧ x - 1 ∈ I := by
-  have hf :
-      (X ^ n * (X - C (1 : R)) +
-        ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).Monic :=
-    Polynomial.monic_X_pow_mul_X_sub_C_one_add_sum_range_C_mul_X_pow n a
+  have hf := Polynomial.monic_X_pow_mul_X_sub_C_one_add_sum_range_C_mul_X_pow n a
   apply h.existsUnique_root_one_mod_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one n ?_ hf
   intro k
   rw [Polynomial.coeff_sum_range_C_mul_X_pow n a k]
   split_ifs with hk
-  · exact ha k hk
-  · exact I.zero_mem
+  exacts [ha k hk, I.zero_mem]
 
 /-- **Local-ring bridge, easy direction** (Stacks Tag 04GH / 0DYD, `←`).
 If `(R, 𝔪)` is a Henselian pair at the maximal ideal of a local ring, then `R`
 is a Henselian local ring. (The converse is the coprime-factorisation lift, which
 is the hard direction and a mathlib TODO.) -/
 @[stacks 04GH]
-theorem henselianLocalRing [IsLocalRing R]
-    (h : IsHenselianPair R (IsLocalRing.maximalIdeal R)) : HenselianLocalRing R where
+theorem henselianLocalRing [IsLocalRing R] (h : IsHenselianPair R (IsLocalRing.maximalIdeal R)) :
+    HenselianLocalRing R where
   is_henselian f hf a₀ h₁ h₂ :=
     h.henselianRing.is_henselian f hf a₀ h₁ (h₂.map (Ideal.Quotient.mk _))
 
@@ -284,7 +248,7 @@ theorem bot : IsHenselianPair R (⊥ : Ideal R) where
   exists_lift_factorization := by
     intro f _ g₀ h₀ hg₀ hh₀ _ hfact
     -- `e : R ⧸ ⊥ ≃+* R` is the canonical isomorphism.
-    set e := RingEquiv.quotientBot R with he
+    set e := RingEquiv.quotientBot R
     set mk₀ := Ideal.Quotient.mk (⊥ : Ideal R) with hmk₀
     -- `e ∘ mk₀ = id` and `mk₀ ∘ e = id`, as ring homomorphisms.
     have h1 : e.toRingHom.comp mk₀ = RingHom.id R :=

--- a/FLT/Slop/HenselianPair/HenselianRing.lean
+++ b/FLT/Slop/HenselianPair/HenselianRing.lean
@@ -40,24 +40,20 @@ This is the Jacobson-radical uniqueness argument for simple roots: if two roots
 of `f` are congruent to the same `a₀` modulo `I`, and `f' a₀` is a unit modulo
 `I`, then the two roots are equal. No monicity is needed for this uniqueness
 statement. -/
-theorem root_lift_unique_of_isUnit_derivative {I : Ideal R} [HenselianRing R I]
-    {f : R[X]} {a₀ a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b)
-    (haI : a - a₀ ∈ I) (hbI : b - a₀ ∈ I)
-    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) :
-    a = b := by
-  exact Polynomial.root_lift_unique_of_isUnit_derivative_of_le_jacobson
+theorem root_lift_unique_of_isUnit_derivative {I : Ideal R} [HenselianRing R I] {f : R[X]}
+    {a₀ a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - a₀ ∈ I) (hbI : b - a₀ ∈ I)
+    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) : a = b :=
+  Polynomial.root_lift_unique_of_isUnit_derivative_of_le_jacobson
     (HenselianRing.jac (R := R) (I := I)) ha hb haI hbI hderiv
 
 /-- A `HenselianRing` has a unique lift of a simple root in the prescribed
 congruence class. This is the `∃!` form of `HenselianRing.is_henselian`. -/
-theorem existsUnique_root_lift_of_isUnit_derivative {I : Ideal R} [HenselianRing R I]
-    {f : R[X]} (hf : f.Monic) (a₀ : R) (hroot : f.eval a₀ ∈ I)
+theorem existsUnique_root_lift_of_isUnit_derivative {I : Ideal R} [HenselianRing R I] {f : R[X]}
+    (hf : f.Monic) (a₀ : R) (hroot : f.eval a₀ ∈ I)
     (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) :
     ∃! a : R, f.IsRoot a ∧ a - a₀ ∈ I := by
   obtain ⟨a, ha, haI⟩ := HenselianRing.is_henselian f hf a₀ hroot hderiv
-  refine ⟨a, ⟨ha, haI⟩, ?_⟩
-  intro b hb
-  exact root_lift_unique_of_isUnit_derivative hb.1 ha hb.2 haI hderiv
+  exact ⟨a, ⟨ha, haI⟩, fun b hb ↦ root_lift_unique_of_isUnit_derivative hb.1 ha hb.2 haI hderiv⟩
 
 /-- Uniqueness in the quotient form of the Stacks Tag 09XI root condition for
 any `HenselianRing`.
@@ -65,12 +61,9 @@ any `HenselianRing`.
 No monicity or existence/lifting hypothesis is needed for this uniqueness
 statement; it is just the Jacobson-radical argument bundled with
 `HenselianRing.jac`. -/
-theorem root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R}
-    [HenselianRing R I] {f : R[X]} (n : ℕ)
-    (hmod : f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I)))
-    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
-    (hbI : b - 1 ∈ I) :
-    a = b :=
+theorem root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R} [HenselianRing R I]
+    {f : R[X]} (n : ℕ) (hmod : f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I))) {a b : R}
+    (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I) (hbI : b - 1 ∈ I) : a = b :=
   Polynomial.root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one_of_le_jacobson
     (HenselianRing.jac (R := R) (I := I)) n hmod ha hb haI hbI
 
@@ -78,36 +71,27 @@ theorem root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R}
 root condition for any `HenselianRing`. -/
 theorem root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
     {I : Ideal R} [HenselianRing R I] {f : R[X]} (n : ℕ)
-    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I)
-    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
-    (hbI : b - 1 ∈ I) :
-    a = b :=
+    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I) {a b : R} (ha : f.IsRoot a)
+    (hb : f.IsRoot b) (haI : a - 1 ∈ I) (hbI : b - 1 ∈ I) : a = b :=
   Polynomial.root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
     (HenselianRing.jac (R := R) (I := I)) n hcoeff ha hb haI hbI
 
 /-- Uniqueness in the perturbation form of the Stacks Tag 09XI root condition
 for any `HenselianRing`. -/
 theorem root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one
-    {I : Ideal R} [HenselianRing R I] (n : ℕ) {p : R[X]}
-    (hp : ∀ k, p.coeff k ∈ I) {a b : R}
+    {I : Ideal R} [HenselianRing R I] (n : ℕ) {p : R[X]} (hp : ∀ k, p.coeff k ∈ I) {a b : R}
     (ha : (X ^ n * (X - C (1 : R)) + p).IsRoot a)
-    (hb : (X ^ n * (X - C (1 : R)) + p).IsRoot b) (haI : a - 1 ∈ I)
-    (hbI : b - 1 ∈ I) :
-    a = b :=
+    (hb : (X ^ n * (X - C (1 : R)) + p).IsRoot b) (haI : a - 1 ∈ I) (hbI : b - 1 ∈ I) : a = b :=
   Polynomial.root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one_of_le_jacobson
     (HenselianRing.jac (R := R) (I := I)) n hp ha hb haI hbI
 
 /-- Uniqueness in the literal finite-coefficient form of the Stacks Tag 09XI
 root condition for any `HenselianRing`. -/
 theorem root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
-    {I : Ideal R} [HenselianRing R I] (n : ℕ) (a : ℕ → R)
-    (ha_coeff : ∀ i ≤ n, a i ∈ I) {x y : R}
-    (hx : (X ^ n * (X - C (1 : R)) +
-      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x)
-    (hy : (X ^ n * (X - C (1 : R)) +
-      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot y)
-    (hxI : x - 1 ∈ I) (hyI : y - 1 ∈ I) :
-    x = y :=
+    {I : Ideal R} [HenselianRing R I] (n : ℕ) (a : ℕ → R) (ha_coeff : ∀ i ≤ n, a i ∈ I) {x y : R}
+    (hx : (X ^ n * (X - C (1 : R)) + ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x)
+    (hy : (X ^ n * (X - C (1 : R)) + ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot y)
+    (hxI : x - 1 ∈ I) (hyI : y - 1 ∈ I) : x = y :=
   Polynomial.root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
     (HenselianRing.jac (R := R) (I := I)) n a ha_coeff hx hy hxI hyI
 
@@ -133,8 +117,7 @@ theorem existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R}
 any `HenselianRing`. -/
 theorem existsUnique_root_one_mod_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
     {I : Ideal R} [HenselianRing R I] {f : R[X]} (hf : f.Monic) (n : ℕ)
-    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I) :
-    ∃! a : R, f.IsRoot a ∧ a - 1 ∈ I :=
+    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I) : ∃! a : R, f.IsRoot a ∧ a - 1 ∈ I :=
   existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one hf n
     (Polynomial.map_eq_X_pow_mul_X_sub_C_one_of_forall_coeff_sub_mem n hcoeff)
 
@@ -156,11 +139,8 @@ theorem existsUnique_root_one_mod_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
     ∃! x : R,
       (X ^ n * (X - C (1 : R)) +
         ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x ∧ x - 1 ∈ I := by
-  have hf :
-      (X ^ n * (X - C (1 : R)) +
-        ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).Monic :=
-    Polynomial.monic_X_pow_mul_X_sub_C_one_add_sum_range_C_mul_X_pow n a
-  apply existsUnique_root_one_mod_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one n ?_ hf
+  apply existsUnique_root_one_mod_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one n ?_
+    (Polynomial.monic_X_pow_mul_X_sub_C_one_add_sum_range_C_mul_X_pow n a)
   intro k
   rw [Polynomial.coeff_sum_range_C_mul_X_pow n a k]
   split_ifs with hk

--- a/FLT/Slop/HenselianPair/HenselianRing.lean
+++ b/FLT/Slop/HenselianPair/HenselianRing.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.HenselianPair.Polynomial
+
+/-!
+# Uniqueness of root lifts for `HenselianRing`
+
+Mathlib's `HenselianRing R I` asserts that a simple root of a monic polynomial over `R ⧸ I`
+lifts to a root over `R`. This file records that the lift is *unique* in its congruence class,
+and specialises the statement to the shape used in Stacks Tag 09XI(5).
+
+## Main results
+
+* `HenselianRing.existsUnique_root_lift_of_isUnit_derivative` — the simple-root lift is unique
+  in its congruence class.
+* `HenselianRing.existsUnique_root_one_mod_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one` — the
+  Tag 09XI(5) root condition, stated at the `HenselianRing` level of generality.
+
+## References
+
+* [Stacks Project, Tag 09XI](https://stacks.math.columbia.edu/tag/09XI)
+-/
+
+@[expose] public section
+
+open Polynomial
+
+variable {R : Type*} [CommRing R]
+
+namespace HenselianRing
+
+/-- A simple root lift for a `HenselianRing` is unique in its congruence class.
+
+This is the Jacobson-radical uniqueness argument for simple roots: if two roots
+of `f` are congruent to the same `a₀` modulo `I`, and `f' a₀` is a unit modulo
+`I`, then the two roots are equal. No monicity is needed for this uniqueness
+statement. -/
+theorem root_lift_unique_of_isUnit_derivative {I : Ideal R} [HenselianRing R I]
+    {f : R[X]} {a₀ a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b)
+    (haI : a - a₀ ∈ I) (hbI : b - a₀ ∈ I)
+    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) :
+    a = b := by
+  exact Polynomial.root_lift_unique_of_isUnit_derivative_of_le_jacobson
+    (HenselianRing.jac (R := R) (I := I)) ha hb haI hbI hderiv
+
+/-- A `HenselianRing` has a unique lift of a simple root in the prescribed
+congruence class. This is the `∃!` form of `HenselianRing.is_henselian`. -/
+theorem existsUnique_root_lift_of_isUnit_derivative {I : Ideal R} [HenselianRing R I]
+    {f : R[X]} (hf : f.Monic) (a₀ : R) (hroot : f.eval a₀ ∈ I)
+    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) :
+    ∃! a : R, f.IsRoot a ∧ a - a₀ ∈ I := by
+  obtain ⟨a, ha, haI⟩ := HenselianRing.is_henselian f hf a₀ hroot hderiv
+  refine ⟨a, ⟨ha, haI⟩, ?_⟩
+  intro b hb
+  exact root_lift_unique_of_isUnit_derivative hb.1 ha hb.2 haI hderiv
+
+/-- Uniqueness in the quotient form of the Stacks Tag 09XI root condition for
+any `HenselianRing`.
+
+No monicity or existence/lifting hypothesis is needed for this uniqueness
+statement; it is just the Jacobson-radical argument bundled with
+`HenselianRing.jac`. -/
+theorem root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R}
+    [HenselianRing R I] {f : R[X]} (n : ℕ)
+    (hmod : f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I)))
+    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
+    (hbI : b - 1 ∈ I) :
+    a = b :=
+  Polynomial.root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one_of_le_jacobson
+    (HenselianRing.jac (R := R) (I := I)) n hmod ha hb haI hbI
+
+/-- Uniqueness in the coefficientwise-congruence form of the Stacks Tag 09XI
+root condition for any `HenselianRing`. -/
+theorem root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
+    {I : Ideal R} [HenselianRing R I] {f : R[X]} (n : ℕ)
+    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I)
+    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
+    (hbI : b - 1 ∈ I) :
+    a = b :=
+  Polynomial.root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
+    (HenselianRing.jac (R := R) (I := I)) n hcoeff ha hb haI hbI
+
+/-- Uniqueness in the perturbation form of the Stacks Tag 09XI root condition
+for any `HenselianRing`. -/
+theorem root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one
+    {I : Ideal R} [HenselianRing R I] (n : ℕ) {p : R[X]}
+    (hp : ∀ k, p.coeff k ∈ I) {a b : R}
+    (ha : (X ^ n * (X - C (1 : R)) + p).IsRoot a)
+    (hb : (X ^ n * (X - C (1 : R)) + p).IsRoot b) (haI : a - 1 ∈ I)
+    (hbI : b - 1 ∈ I) :
+    a = b :=
+  Polynomial.root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one_of_le_jacobson
+    (HenselianRing.jac (R := R) (I := I)) n hp ha hb haI hbI
+
+/-- Uniqueness in the literal finite-coefficient form of the Stacks Tag 09XI
+root condition for any `HenselianRing`. -/
+theorem root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
+    {I : Ideal R} [HenselianRing R I] (n : ℕ) (a : ℕ → R)
+    (ha_coeff : ∀ i ≤ n, a i ∈ I) {x y : R}
+    (hx : (X ^ n * (X - C (1 : R)) +
+      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x)
+    (hy : (X ^ n * (X - C (1 : R)) +
+      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot y)
+    (hxI : x - 1 ∈ I) (hyI : y - 1 ∈ I) :
+    x = y :=
+  Polynomial.root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
+    (HenselianRing.jac (R := R) (I := I)) n a ha_coeff hx hy hxI hyI
+
+/-- The Stacks Tag 09XI root condition in quotient form for any
+`HenselianRing`.
+
+If `f` is monic and `f mod I = X ^ n * (X - 1)`, then `f` has a unique root
+congruent to `1` modulo `I`. -/
+theorem existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one {I : Ideal R}
+    [HenselianRing R I] {f : R[X]} (hf : f.Monic) (n : ℕ)
+    (hmod : f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I))) :
+    ∃! a : R, f.IsRoot a ∧ a - 1 ∈ I := by
+  apply HenselianRing.existsUnique_root_lift_of_isUnit_derivative hf 1
+  · rw [← Ideal.Quotient.eq_zero_iff_mem, ← eval_map_apply, hmod]
+    simp [eval_mul, eval_sub]
+  · have hderiv : Ideal.Quotient.mk I (f.derivative.eval 1) = (1 : R ⧸ I) := by
+      rw [← eval_map_apply, ← derivative_map, hmod]
+      simp [derivative_mul, eval_mul, eval_add, eval_sub, eval_X]
+    rw [hderiv]
+    exact isUnit_one
+
+/-- Coefficientwise-congruence form of the Stacks Tag 09XI root condition for
+any `HenselianRing`. -/
+theorem existsUnique_root_one_mod_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one
+    {I : Ideal R} [HenselianRing R I] {f : R[X]} (hf : f.Monic) (n : ℕ)
+    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I) :
+    ∃! a : R, f.IsRoot a ∧ a - 1 ∈ I :=
+  existsUnique_root_one_mod_of_map_eq_X_pow_mul_X_sub_C_one hf n
+    (Polynomial.map_eq_X_pow_mul_X_sub_C_one_of_forall_coeff_sub_mem n hcoeff)
+
+/-- Perturbation form of the Stacks Tag 09XI root condition for any
+`HenselianRing`. -/
+theorem existsUnique_root_one_mod_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one
+    {I : Ideal R} [HenselianRing R I] (n : ℕ) {p : R[X]}
+    (hp : ∀ k, p.coeff k ∈ I) (hf : (X ^ n * (X - C (1 : R)) + p).Monic) :
+    ∃! a : R, (X ^ n * (X - C (1 : R)) + p).IsRoot a ∧ a - 1 ∈ I := by
+  apply existsUnique_root_one_mod_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one hf n
+  intro k
+  simpa [coeff_sub, coeff_add, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hp k
+
+/-- Literal finite-coefficient form of the Stacks Tag 09XI root condition for
+any `HenselianRing`. -/
+theorem existsUnique_root_one_mod_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one
+    {I : Ideal R} [HenselianRing R I] (n : ℕ) (a : ℕ → R)
+    (ha : ∀ i ≤ n, a i ∈ I) :
+    ∃! x : R,
+      (X ^ n * (X - C (1 : R)) +
+        ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x ∧ x - 1 ∈ I := by
+  have hf :
+      (X ^ n * (X - C (1 : R)) +
+        ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).Monic :=
+    Polynomial.monic_X_pow_mul_X_sub_C_one_add_sum_range_C_mul_X_pow n a
+  apply existsUnique_root_one_mod_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one n ?_ hf
+  intro k
+  rw [Polynomial.coeff_sum_range_C_mul_X_pow n a k]
+  split_ifs with hk
+  · exact ha k hk
+  · exact I.zero_mem
+
+end HenselianRing

--- a/FLT/Slop/HenselianPair/Idempotents.lean
+++ b/FLT/Slop/HenselianPair/Idempotents.lean
@@ -1,0 +1,674 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.HenselianPair.Defs
+public import Mathlib.RingTheory.Ideal.GoingUp
+public import Mathlib.RingTheory.Idempotents
+
+/-!
+# Lifting idempotents along a Henselian pair
+
+For a Henselian pair `(R, I)` idempotents of `R ⧸ I` lift uniquely to idempotents of `R`, and
+likewise for orthogonal and complete orthogonal systems of idempotents. This is one of the
+equivalent conditions in the Henselian-pair TFAE (Stacks Tag 09XI(2)).
+
+Conversely, bijectivity of the idempotent-reduction map for all finite (or integral) algebras
+already forces `I ≤ Jac(R)`, which isolates the first paragraph of the converse direction.
+
+## Main definitions
+
+* `IsHenselianPair.idempotentQuotientEquiv` — idempotents of `R` are equivalent to idempotents
+  of `R ⧸ I`.
+* `IsHenselianPair.orthogonalIdempotentsQuotientEquiv`,
+  `IsHenselianPair.completeOrthogonalIdempotentsQuotientEquiv` — the same for systems.
+
+## Main results
+
+* `IsHenselianPair.existsUnique_isIdempotentElem_lift` — idempotents lift uniquely.
+* `IsHenselianPair.le_jacobson_of_idempotentQuotientMap_bijective_of_finite` and the integral
+  variant — the idempotent-bijection criteria imply `I ≤ Jac(R)`.
+
+## References
+
+* [Stacks Project, Tag 09XI](https://stacks.math.columbia.edu/tag/09XI)
+-/
+
+@[expose] public section
+
+open Polynomial
+
+variable {R : Type*} [CommRing R]
+
+namespace IsHenselianPair
+
+/-- **Idempotents lift along `R → R ⧸ I`** for a Henselian pair `(R, I)`.
+This is one of the equivalent conditions in the pair TFAE (Stacks Tag 09XI): an
+idempotent `ē` of `R ⧸ I` is a simple root of `X² - X`, so it lifts to an
+idempotent of `R`. -/
+theorem exists_isIdempotentElem_lift {I : Ideal R} (h : IsHenselianPair R I)
+    {ε : R ⧸ I} (hε : IsIdempotentElem ε) :
+    ∃ e : R, IsIdempotentElem e ∧ Ideal.Quotient.mk I e = ε := by
+  obtain ⟨a₀, ha₀⟩ := Ideal.Quotient.mk_surjective ε
+  set f : R[X] := X ^ 2 - X with hf
+  have hfmonic : f.Monic := by
+    rw [hf]
+    exact monic_X_pow_sub (n := 2) (lt_of_le_of_lt degree_X_le (by decide))
+  have heval : f.eval a₀ = a₀ ^ 2 - a₀ := by simp [hf]
+  -- `a₀² - a₀ ∈ I` because `ε` is idempotent.
+  have hmem : a₀ ^ 2 - a₀ ∈ I := by
+    rw [← Ideal.Quotient.eq_zero_iff_mem, map_sub, map_pow, ha₀, sub_eq_zero, sq]
+    exact hε
+  -- the derivative `2X - 1` evaluates to a unit modulo `I` (it is its own inverse).
+  have hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀)) := by
+    have hde : f.derivative.eval a₀ = 2 * a₀ - 1 := by
+      simp only [hf, derivative_sub, derivative_X_pow, derivative_X, Nat.cast_ofNat,
+        eval_sub, eval_mul, eval_C, eval_pow, eval_X, eval_one]
+      ring
+    rw [hde]
+    have hsq : Ideal.Quotient.mk I (2 * a₀ - 1) * Ideal.Quotient.mk I (2 * a₀ - 1) = 1 := by
+      rw [← map_mul, ← map_one (Ideal.Quotient.mk I), Ideal.Quotient.eq]
+      have hcalc : (2 * a₀ - 1) * (2 * a₀ - 1) - 1 = 4 * (a₀ ^ 2 - a₀) := by ring
+      rw [hcalc]
+      exact I.mul_mem_left 4 hmem
+    exact ⟨⟨_, _, hsq, by rw [mul_comm]; exact hsq⟩, rfl⟩
+  obtain ⟨e, he_root, he_sub⟩ :=
+    h.henselianRing.is_henselian f hfmonic a₀ (heval ▸ hmem) hderiv
+  have he_eval : e ^ 2 - e = 0 := by
+    have : f.eval e = 0 := he_root
+    rwa [hf, eval_sub, eval_pow, eval_X] at this
+  refine ⟨e, ?_, ?_⟩
+  · change e * e = e
+    have : e ^ 2 = e := by rw [← sub_eq_zero]; exact he_eval
+    rwa [sq] at this
+  · rw [← ha₀, ← sub_eq_zero, ← map_sub, Ideal.Quotient.eq_zero_iff_mem]
+    exact he_sub
+
+/-- An idempotent element in the Jacobson radical is zero. -/
+theorem isIdempotentElem_eq_zero_of_mem_jacobson {e : R} (he : IsIdempotentElem e)
+    (hejac : e ∈ Ideal.jacobson (⊥ : Ideal R)) : e = 0 := by
+  rw [Ideal.mem_jacobson_bot] at hejac
+  have hunit : IsUnit (1 - e) := by
+    convert hejac (-1) using 1
+    ring
+  have hmul : (1 - e) * e = 0 := he.one_sub_mul_self
+  exact hunit.mul_right_eq_zero.mp hmul
+
+/-- Two idempotents congruent modulo the Jacobson radical are equal. -/
+theorem isIdempotentElem_eq_of_sub_mem_jacobson {e₁ e₂ : R}
+    (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
+    (hdiff : e₁ - e₂ ∈ Ideal.jacobson (⊥ : Ideal R)) : e₁ = e₂ := by
+  let J : Ideal R := Ideal.jacobson (⊥ : Ideal R)
+  have hleft_mem : e₁ * (1 - e₂) ∈ J := by
+    have hrewrite : e₁ * (1 - e₂) = e₁ * (e₁ - e₂) := by
+      rw [mul_sub, mul_sub, mul_one, he₁.eq]
+    rw [hrewrite]
+    exact J.mul_mem_left e₁ hdiff
+  have hleft_idem : IsIdempotentElem (e₁ * (1 - e₂)) := he₁.mul he₂.one_sub
+  have hleft_zero : e₁ * (1 - e₂) = 0 :=
+    isIdempotentElem_eq_zero_of_mem_jacobson hleft_idem hleft_mem
+  have hdiff' : e₂ - e₁ ∈ J := by
+    simpa [sub_eq_add_neg, add_comm, add_left_comm, add_assoc] using J.neg_mem hdiff
+  have hright_mem : (1 - e₁) * e₂ ∈ J := by
+    have hrewrite : (1 - e₁) * e₂ = (1 - e₁) * (e₂ - e₁) := by
+      rw [mul_sub, he₁.one_sub_mul_self, sub_zero]
+    rw [hrewrite]
+    exact J.mul_mem_left (1 - e₁) hdiff'
+  have hright_idem : IsIdempotentElem ((1 - e₁) * e₂) := he₁.one_sub.mul he₂
+  have hright_zero : (1 - e₁) * e₂ = 0 :=
+    isIdempotentElem_eq_zero_of_mem_jacobson hright_idem hright_mem
+  have h₁ : e₁ = e₁ * e₂ := by
+    simpa [mul_sub, mul_one, sub_eq_zero] using hleft_zero
+  have h₂ : e₂ = e₁ * e₂ := by
+    simpa [sub_mul, one_mul, sub_eq_zero] using hright_zero
+  exact h₁.trans h₂.symm
+
+/-- If `I` is contained in the Jacobson radical, idempotent lifts along
+`R → R ⧸ I` are unique. -/
+theorem isIdempotentElem_lift_unique_of_le_jacobson {I : Ideal R}
+    (hIjac : I ≤ Ideal.jacobson (⊥ : Ideal R)) {e₁ e₂ : R}
+    (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
+    (hmod : Ideal.Quotient.mk I e₁ = Ideal.Quotient.mk I e₂) : e₁ = e₂ :=
+  isIdempotentElem_eq_of_sub_mem_jacobson he₁ he₂ (hIjac (Ideal.Quotient.eq.mp hmod))
+
+/-- In a henselian pair, idempotent lifts along `R → R ⧸ I` are unique. -/
+theorem isIdempotentElem_lift_unique {I : Ideal R} (h : IsHenselianPair R I)
+    {e₁ e₂ : R} (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
+    (hmod : Ideal.Quotient.mk I e₁ = Ideal.Quotient.mk I e₂) : e₁ = e₂ :=
+  isIdempotentElem_lift_unique_of_le_jacobson h.le_jacobson he₁ he₂ hmod
+
+/-- **Idempotents lift uniquely along `R → R ⧸ I`** for a Henselian pair.
+This packages the idempotent-lifting clause of Stacks Tag 09XI as an `∃!`
+statement. -/
+@[stacks 09XI "(2)"]
+theorem existsUnique_isIdempotentElem_lift {I : Ideal R} (h : IsHenselianPair R I)
+    {ε : R ⧸ I} (hε : IsIdempotentElem ε) :
+    ∃! e : R, IsIdempotentElem e ∧ Ideal.Quotient.mk I e = ε := by
+  obtain ⟨e, he, heq⟩ := h.exists_isIdempotentElem_lift hε
+  refine ⟨e, ⟨he, heq⟩, ?_⟩
+  intro y hy
+  exact h.isIdempotentElem_lift_unique hy.1 he (hy.2.trans heq.symm)
+
+/-- The quotient map on idempotent elements induced by `R → R ⧸ I`. -/
+def idempotentQuotientMap {I : Ideal R} :
+    {e : R // IsIdempotentElem e} → {ε : R ⧸ I // IsIdempotentElem ε} :=
+  fun e => ⟨Ideal.Quotient.mk I e.1, e.2.map (Ideal.Quotient.mk I)⟩
+
+@[simp]
+theorem idempotentQuotientMap_apply {I : Ideal R} (e : {e : R // IsIdempotentElem e}) :
+    idempotentQuotientMap (R := R) (I := I) e =
+      (⟨Ideal.Quotient.mk I e.1, e.2.map (Ideal.Quotient.mk I)⟩ :
+        {ε : R ⧸ I // IsIdempotentElem ε}) :=
+  rfl
+
+/-- For a Henselian pair `(R, I)`, the quotient map induces a bijection on
+idempotent elements. This is the subtype form of the idempotent clause in
+Stacks Tag 09XI/Raynaud XI, §1. -/
+@[stacks 09XI "(2)"]
+theorem idempotentQuotientMap_bijective {I : Ideal R} (h : IsHenselianPair R I) :
+    Function.Bijective (idempotentQuotientMap (R := R) (I := I)) := by
+  constructor
+  · intro e₁ e₂ hmap
+    apply Subtype.ext
+    exact h.isIdempotentElem_lift_unique e₁.2 e₂.2 (congrArg Subtype.val hmap)
+  · intro ε
+    obtain ⟨e, he, heq⟩ := h.exists_isIdempotentElem_lift ε.2
+    exact ⟨⟨e, he⟩, Subtype.ext heq⟩
+
+/-- For a Henselian pair `(R, I)`, reduction modulo `I` gives an equivalence on
+idempotent elements. -/
+noncomputable def idempotentQuotientEquiv {I : Ideal R} (h : IsHenselianPair R I) :
+    {e : R // IsIdempotentElem e} ≃ {ε : R ⧸ I // IsIdempotentElem ε} :=
+  Equiv.ofBijective (idempotentQuotientMap (R := R) (I := I))
+    h.idempotentQuotientMap_bijective
+
+@[simp]
+theorem idempotentQuotientEquiv_apply {I : Ideal R} (h : IsHenselianPair R I)
+    (e : {e : R // IsIdempotentElem e}) :
+    h.idempotentQuotientEquiv e = idempotentQuotientMap (R := R) (I := I) e :=
+  Equiv.ofBijective_apply _ _ e
+
+/-- Orthogonal systems of idempotents lift along `R → R ⧸ I` for a Henselian
+pair. Orthogonality is recovered from uniqueness: the product of two distinct
+coordinate lifts is an idempotent reducing to zero. -/
+theorem exists_orthogonalIdempotents_lift {I : Ideal R} (h : IsHenselianPair R I)
+    {ι : Type*} {ε : ι → R ⧸ I} (hε : OrthogonalIdempotents ε) :
+    ∃ e : ι → R, OrthogonalIdempotents e ∧ Ideal.Quotient.mk I ∘ e = ε := by
+  classical
+  choose e he hmap using fun i => h.exists_isIdempotentElem_lift (hε.idem i)
+  refine ⟨e, ?_, funext hmap⟩
+  refine ⟨he, ?_⟩
+  intro i j hij
+  have hprod_idem : IsIdempotentElem (e i * e j) := (he i).mul (he j)
+  have hprod_mod :
+      Ideal.Quotient.mk I (e i * e j) = Ideal.Quotient.mk I (0 : R) := by
+    simp [map_mul, hmap i, hmap j, hε.ortho hij]
+  exact h.isIdempotentElem_lift_unique hprod_idem IsIdempotentElem.zero hprod_mod
+
+/-- Orthogonal systems of idempotents lift uniquely along `R → R ⧸ I` for a
+Henselian pair. -/
+theorem orthogonalIdempotents_lift_unique {I : Ideal R} (h : IsHenselianPair R I)
+    {ι : Type*} {e₁ e₂ : ι → R} (he₁ : OrthogonalIdempotents e₁)
+    (he₂ : OrthogonalIdempotents e₂)
+    (hmod : Ideal.Quotient.mk I ∘ e₁ = Ideal.Quotient.mk I ∘ e₂) :
+    e₁ = e₂ := by
+  funext i
+  exact h.isIdempotentElem_lift_unique (he₁.idem i) (he₂.idem i) (congrFun hmod i)
+
+/-- Orthogonal systems of idempotents have unique lifts along `R → R ⧸ I` for a
+Henselian pair, packaged as an `∃!`. -/
+theorem existsUnique_orthogonalIdempotents_lift {I : Ideal R} (h : IsHenselianPair R I)
+    {ι : Type*} {ε : ι → R ⧸ I} (hε : OrthogonalIdempotents ε) :
+    ∃! e : ι → R, OrthogonalIdempotents e ∧ Ideal.Quotient.mk I ∘ e = ε := by
+  obtain ⟨e, he, hmap⟩ := h.exists_orthogonalIdempotents_lift hε
+  refine ⟨e, ⟨he, hmap⟩, ?_⟩
+  intro y hy
+  exact h.orthogonalIdempotents_lift_unique hy.1 he (hy.2.trans hmap.symm)
+
+/-- The quotient map on orthogonal systems of idempotents induced by `R → R ⧸ I`. -/
+def orthogonalIdempotentsQuotientMap {I : Ideal R} {ι : Type*} :
+    {e : ι → R // OrthogonalIdempotents e} →
+      {ε : ι → R ⧸ I // OrthogonalIdempotents ε} :=
+  fun e => ⟨Ideal.Quotient.mk I ∘ e.1, e.2.map (Ideal.Quotient.mk I)⟩
+
+@[simp]
+theorem orthogonalIdempotentsQuotientMap_apply {I : Ideal R} {ι : Type*}
+    (e : {e : ι → R // OrthogonalIdempotents e}) :
+    orthogonalIdempotentsQuotientMap (R := R) (I := I) e =
+      (⟨Ideal.Quotient.mk I ∘ e.1, e.2.map (Ideal.Quotient.mk I)⟩ :
+        {ε : ι → R ⧸ I // OrthogonalIdempotents ε}) :=
+  rfl
+
+/-- The quotient map of a Henselian pair induces a bijection on orthogonal
+systems of idempotents. -/
+theorem orthogonalIdempotentsQuotientMap_bijective {I : Ideal R} (h : IsHenselianPair R I)
+    {ι : Type*} :
+    Function.Bijective (orthogonalIdempotentsQuotientMap (R := R) (I := I) (ι := ι)) := by
+  constructor
+  · intro e₁ e₂ hmap
+    apply Subtype.ext
+    exact h.orthogonalIdempotents_lift_unique e₁.2 e₂.2 (congrArg Subtype.val hmap)
+  · intro ε
+    obtain ⟨e, he, hmap⟩ := h.exists_orthogonalIdempotents_lift ε.2
+    exact ⟨⟨e, he⟩, Subtype.ext hmap⟩
+
+/-- For a Henselian pair `(R, I)`, reduction modulo `I` gives an equivalence on
+orthogonal systems of idempotents. -/
+noncomputable def orthogonalIdempotentsQuotientEquiv {I : Ideal R}
+    (h : IsHenselianPair R I) {ι : Type*} :
+    {e : ι → R // OrthogonalIdempotents e} ≃
+      {ε : ι → R ⧸ I // OrthogonalIdempotents ε} :=
+  Equiv.ofBijective (orthogonalIdempotentsQuotientMap (R := R) (I := I) (ι := ι))
+    h.orthogonalIdempotentsQuotientMap_bijective
+
+@[simp]
+theorem orthogonalIdempotentsQuotientEquiv_apply {I : Ideal R}
+    (h : IsHenselianPair R I) {ι : Type*}
+    (e : {e : ι → R // OrthogonalIdempotents e}) :
+    h.orthogonalIdempotentsQuotientEquiv e =
+      orthogonalIdempotentsQuotientMap (R := R) (I := I) e :=
+  Equiv.ofBijective_apply _ _ e
+
+/-- Complete orthogonal systems of idempotents lift along `R → R ⧸ I` for a
+Henselian pair. Completeness is recovered from uniqueness by comparing the sum
+of the lifted orthogonal system with `1`. -/
+theorem exists_completeOrthogonalIdempotents_lift {I : Ideal R} (h : IsHenselianPair R I)
+    {ι : Type*} [Fintype ι] {ε : ι → R ⧸ I} (hε : CompleteOrthogonalIdempotents ε) :
+    ∃ e : ι → R, CompleteOrthogonalIdempotents e ∧ Ideal.Quotient.mk I ∘ e = ε := by
+  obtain ⟨e, he, hmap⟩ := h.exists_orthogonalIdempotents_lift hε.toOrthogonalIdempotents
+  have hmap_apply : ∀ i, Ideal.Quotient.mk I (e i) = ε i := fun i => congrFun hmap i
+  have hsum_mod :
+      Ideal.Quotient.mk I (∑ i, e i) = Ideal.Quotient.mk I (1 : R) := by
+    simp [map_sum, hmap_apply, hε.complete]
+  have hcomplete : ∑ i, e i = 1 :=
+    h.isIdempotentElem_lift_unique
+      (he.isIdempotentElem_sum (s := Finset.univ)) IsIdempotentElem.one hsum_mod
+  exact ⟨e, ⟨he, hcomplete⟩, hmap⟩
+
+/-- Complete orthogonal systems of idempotents lift uniquely along `R → R ⧸ I`
+for a Henselian pair. -/
+theorem completeOrthogonalIdempotents_lift_unique {I : Ideal R} (h : IsHenselianPair R I)
+    {ι : Type*} [Fintype ι] {e₁ e₂ : ι → R}
+    (he₁ : CompleteOrthogonalIdempotents e₁) (he₂ : CompleteOrthogonalIdempotents e₂)
+    (hmod : Ideal.Quotient.mk I ∘ e₁ = Ideal.Quotient.mk I ∘ e₂) :
+    e₁ = e₂ :=
+  h.orthogonalIdempotents_lift_unique he₁.toOrthogonalIdempotents
+    he₂.toOrthogonalIdempotents hmod
+
+/-- Complete orthogonal systems of idempotents have unique lifts along
+`R → R ⧸ I` for a Henselian pair, packaged as an `∃!`. -/
+theorem existsUnique_completeOrthogonalIdempotents_lift {I : Ideal R}
+    (h : IsHenselianPair R I) {ι : Type*} [Fintype ι] {ε : ι → R ⧸ I}
+    (hε : CompleteOrthogonalIdempotents ε) :
+    ∃! e : ι → R, CompleteOrthogonalIdempotents e ∧ Ideal.Quotient.mk I ∘ e = ε := by
+  obtain ⟨e, he, hmap⟩ := h.exists_completeOrthogonalIdempotents_lift hε
+  refine ⟨e, ⟨he, hmap⟩, ?_⟩
+  intro y hy
+  exact h.completeOrthogonalIdempotents_lift_unique hy.1 he (hy.2.trans hmap.symm)
+
+/-- The quotient map on finite complete orthogonal systems of idempotents induced by
+`R → R ⧸ I`. -/
+def completeOrthogonalIdempotentsQuotientMap {I : Ideal R} {ι : Type*} [Fintype ι] :
+    {e : ι → R // CompleteOrthogonalIdempotents e} →
+      {ε : ι → R ⧸ I // CompleteOrthogonalIdempotents ε} :=
+  fun e => ⟨Ideal.Quotient.mk I ∘ e.1, e.2.map (Ideal.Quotient.mk I)⟩
+
+@[simp]
+theorem completeOrthogonalIdempotentsQuotientMap_apply {I : Ideal R} {ι : Type*}
+    [Fintype ι] (e : {e : ι → R // CompleteOrthogonalIdempotents e}) :
+    completeOrthogonalIdempotentsQuotientMap (R := R) (I := I) e =
+      (⟨Ideal.Quotient.mk I ∘ e.1, e.2.map (Ideal.Quotient.mk I)⟩ :
+        {ε : ι → R ⧸ I // CompleteOrthogonalIdempotents ε}) :=
+  rfl
+
+/-- The quotient map of a Henselian pair induces a bijection on finite complete
+orthogonal systems of idempotents. -/
+theorem completeOrthogonalIdempotentsQuotientMap_bijective {I : Ideal R}
+    (h : IsHenselianPair R I) {ι : Type*} [Fintype ι] :
+    Function.Bijective (completeOrthogonalIdempotentsQuotientMap
+      (R := R) (I := I) (ι := ι)) := by
+  constructor
+  · intro e₁ e₂ hmap
+    apply Subtype.ext
+    exact h.completeOrthogonalIdempotents_lift_unique e₁.2 e₂.2 (congrArg Subtype.val hmap)
+  · intro ε
+    obtain ⟨e, he, hmap⟩ := h.exists_completeOrthogonalIdempotents_lift ε.2
+    exact ⟨⟨e, he⟩, Subtype.ext hmap⟩
+
+/-- For a Henselian pair `(R, I)`, reduction modulo `I` gives an equivalence on
+finite complete orthogonal systems of idempotents. -/
+noncomputable def completeOrthogonalIdempotentsQuotientEquiv {I : Ideal R}
+    (h : IsHenselianPair R I) {ι : Type*} [Fintype ι] :
+    {e : ι → R // CompleteOrthogonalIdempotents e} ≃
+      {ε : ι → R ⧸ I // CompleteOrthogonalIdempotents ε} :=
+  Equiv.ofBijective (completeOrthogonalIdempotentsQuotientMap (R := R) (I := I) (ι := ι))
+    h.completeOrthogonalIdempotentsQuotientMap_bijective
+
+@[simp]
+theorem completeOrthogonalIdempotentsQuotientEquiv_apply {I : Ideal R}
+    (h : IsHenselianPair R I) {ι : Type*} [Fintype ι]
+    (e : {e : ι → R // CompleteOrthogonalIdempotents e}) :
+    h.completeOrthogonalIdempotentsQuotientEquiv e =
+      completeOrthogonalIdempotentsQuotientMap (R := R) (I := I) e :=
+  Equiv.ofBijective_apply _ _ e
+
+/-- Integral extensions carry ideals contained in the Jacobson radical into the
+Jacobson radical after extension of scalars. -/
+theorem map_le_jacobson_of_isIntegral {S : Type*} [CommRing S] [Algebra R S]
+    [Algebra.IsIntegral R S] {I : Ideal R} (hIjac : I ≤ Ideal.jacobson (⊥ : Ideal R)) :
+    I.map (algebraMap R S) ≤ Ideal.jacobson (⊥ : Ideal S) := by
+  intro x hx
+  rw [Ideal.jacobson, Ideal.mem_sInf]
+  intro M hM
+  haveI : M.IsMaximal := hM.2
+  have hcomap_max : (M.comap (algebraMap R S)).IsMaximal :=
+    Ideal.isMaximal_comap_of_isIntegral_of_isMaximal (R := R) (S := S) M
+  have hI_le_comap : I ≤ M.comap (algebraMap R S) := by
+    intro r hr
+    have hrjac : r ∈ Ideal.jacobson (⊥ : Ideal R) := hIjac hr
+    rw [Ideal.jacobson, Ideal.mem_sInf] at hrjac
+    exact hrjac (I := M.comap (algebraMap R S)) ⟨bot_le, hcomap_max⟩
+  exact (Ideal.map_le_iff_le_comap.mpr hI_le_comap) hx
+
+/-- The quotient map on idempotents in an `R`-algebra `S`, induced by
+`S → S ⧸ I·S`. -/
+def idempotentQuotientMapOfAlgebra {S : Type*} [CommRing S] [Algebra R S] {I : Ideal R} :
+    {e : S // IsIdempotentElem e} →
+      {ε : S ⧸ I.map (algebraMap R S) // IsIdempotentElem ε} :=
+  fun e => ⟨Ideal.Quotient.mk (I.map (algebraMap R S)) e.1,
+    e.2.map (Ideal.Quotient.mk (I.map (algebraMap R S)))⟩
+
+@[simp]
+theorem idempotentQuotientMapOfAlgebra_apply {S : Type*} [CommRing S] [Algebra R S]
+    {I : Ideal R} (e : {e : S // IsIdempotentElem e}) :
+    idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I) e =
+      (⟨Ideal.Quotient.mk (I.map (algebraMap R S)) e.1,
+        e.2.map (Ideal.Quotient.mk (I.map (algebraMap R S)))⟩ :
+        {ε : S ⧸ I.map (algebraMap R S) // IsIdempotentElem ε}) :=
+  rfl
+
+/-- The quotient map on orthogonal systems of idempotents in an `R`-algebra `S`,
+induced by `S → S ⧸ I·S`. -/
+def orthogonalIdempotentsQuotientMapOfAlgebra {S : Type*} [CommRing S] [Algebra R S]
+    {I : Ideal R} {ι : Type*} :
+    {e : ι → S // OrthogonalIdempotents e} →
+      {ε : ι → S ⧸ I.map (algebraMap R S) // OrthogonalIdempotents ε} :=
+  fun e => ⟨Ideal.Quotient.mk (I.map (algebraMap R S)) ∘ e.1,
+    e.2.map (Ideal.Quotient.mk (I.map (algebraMap R S)))⟩
+
+@[simp]
+theorem orthogonalIdempotentsQuotientMapOfAlgebra_apply {S : Type*} [CommRing S]
+    [Algebra R S] {I : Ideal R} {ι : Type*}
+    (e : {e : ι → S // OrthogonalIdempotents e}) :
+    orthogonalIdempotentsQuotientMapOfAlgebra (R := R) (S := S) (I := I) e =
+      (⟨Ideal.Quotient.mk (I.map (algebraMap R S)) ∘ e.1,
+        e.2.map (Ideal.Quotient.mk (I.map (algebraMap R S)))⟩ :
+        {ε : ι → S ⧸ I.map (algebraMap R S) // OrthogonalIdempotents ε}) :=
+  rfl
+
+/-- The quotient map on finite complete orthogonal systems of idempotents in an
+`R`-algebra `S`, induced by `S → S ⧸ I·S`. -/
+def completeOrthogonalIdempotentsQuotientMapOfAlgebra {S : Type*} [CommRing S]
+    [Algebra R S] {I : Ideal R} {ι : Type*} [Fintype ι] :
+    {e : ι → S // CompleteOrthogonalIdempotents e} →
+      {ε : ι → S ⧸ I.map (algebraMap R S) // CompleteOrthogonalIdempotents ε} :=
+  fun e => ⟨Ideal.Quotient.mk (I.map (algebraMap R S)) ∘ e.1,
+    e.2.map (Ideal.Quotient.mk (I.map (algebraMap R S)))⟩
+
+@[simp]
+theorem completeOrthogonalIdempotentsQuotientMapOfAlgebra_apply {S : Type*} [CommRing S]
+    [Algebra R S] {I : Ideal R} {ι : Type*} [Fintype ι]
+    (e : {e : ι → S // CompleteOrthogonalIdempotents e}) :
+    completeOrthogonalIdempotentsQuotientMapOfAlgebra (R := R) (S := S) (I := I) e =
+      (⟨Ideal.Quotient.mk (I.map (algebraMap R S)) ∘ e.1,
+        e.2.map (Ideal.Quotient.mk (I.map (algebraMap R S)))⟩ :
+        {ε : ι → S ⧸ I.map (algebraMap R S) // CompleteOrthogonalIdempotents ε}) :=
+  rfl
+
+universe u
+
+/-- The finite-algebra injectivity condition on idempotents forces the base ideal
+to lie in the Jacobson radical. This is the Jacobson-radical part of the
+finite-idempotent converse in Stacks Tag 09XI.
+
+The proof tests the condition on `R ⧸ (I ⊓ M)` for each maximal ideal `M`. If
+some `x ∈ I` is not in `M`, then `I` and `M` are comaximal, so the Chinese
+remainder theorem supplies two distinct idempotents with the same reduction
+modulo `I`. -/
+theorem le_jacobson_of_idempotentQuotientMap_injective_of_finite {R : Type u}
+    [CommRing R] {I : Ideal R}
+    (hfinite : ∀ (S : Type u) [CommRing S] [Algebra R S] [Module.Finite R S],
+      Function.Injective
+        (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
+    I ≤ Ideal.jacobson (⊥ : Ideal R) := by
+  intro x hxI
+  rw [Ideal.jacobson, Ideal.mem_sInf]
+  intro M hM
+  have hMmax : M.IsMaximal := hM.2
+  by_contra hxM
+  obtain ⟨y, m, hm, hym⟩ := hMmax.exists_inv hxM
+  have hIMtop : I ⊔ M = ⊤ := by
+    rw [Ideal.eq_top_iff_one]
+    rw [← hym]
+    exact Submodule.mem_sup.mpr ⟨y * x, I.mul_mem_left y hxI, m, hm, rfl⟩
+  let J : Ideal R := I ⊓ M
+  let S : Type u := R ⧸ J
+  have hcop : IsCoprime I M := Ideal.isCoprime_iff_sup_eq.mpr hIMtop
+  let e : S ≃+* (R ⧸ I) × R ⧸ M :=
+    Ideal.quotientInfEquivQuotientProd I M hcop
+  haveI : Nontrivial (R ⧸ M) := Ideal.Quotient.nontrivial_iff.mpr hMmax.ne_top
+  let a : S := e.symm (1, 0)
+  let b : S := e.symm (1, 1)
+  have ha : IsIdempotentElem a := by
+    change a * a = a
+    apply e.injective
+    simp [a]
+  have hb : IsIdempotentElem b := by
+    change b * b = b
+    apply e.injective
+    simp [b]
+  have hne : a ≠ b := by
+    intro hab
+    have hprod : ((1 : R ⧸ I), (0 : R ⧸ M)) = ((1 : R ⧸ I), (1 : R ⧸ M)) := by
+      simpa [a, b] using congrArg e hab
+    have hzero_one : (0 : R ⧸ M) = 1 := congrArg Prod.snd hprod
+    exact zero_ne_one hzero_one
+  let q : S →+* S ⧸ I.map (algebraMap R S) :=
+    Ideal.Quotient.mk (I.map (algebraMap R S))
+  have hJI : J ≤ I := inf_le_left
+  let d : (S ⧸ I.map (algebraMap R S)) ≃+* R ⧸ I :=
+    DoubleQuot.quotQuotEquivQuotOfLE hJI
+  have hd_eq_fst (z : S) : d (q z) = (e z).fst := by
+    obtain ⟨r, rfl⟩ := Ideal.Quotient.mk_surjective z
+    change d (DoubleQuot.quotQuotMk J I r) =
+      (Ideal.quotientInfEquivQuotientProd I M hcop (Ideal.Quotient.mk (I ⊓ M) r)).fst
+    rw [Ideal.quotientInfEquivQuotientProd_fst]
+    change d (DoubleQuot.quotQuotMk J I r) = Ideal.Quotient.mk I r
+    exact DoubleQuot.quotQuotEquivQuotOfLE_quotQuotMk r hJI
+  have hq : q a = q b := by
+    apply d.injective
+    rw [hd_eq_fst a, hd_eq_fst b]
+    simp [a, b]
+  haveI : Module.Finite R S :=
+    Module.Finite.of_surjective (Ideal.Quotient.mkₐ R J).toLinearMap
+      Ideal.Quotient.mk_surjective
+  have hinj := hfinite S
+  have hsub :
+      idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I) ⟨a, ha⟩ =
+        idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I) ⟨b, hb⟩ := by
+    apply Subtype.ext
+    exact hq
+  exact hne (congrArg Subtype.val (hinj hsub))
+
+/-- The finite-algebra bijectivity condition on idempotents forces the base
+ideal to lie in the Jacobson radical. This is the formulation closest to the
+finite-idempotent condition in Stacks Tag 09XI. -/
+theorem le_jacobson_of_idempotentQuotientMap_bijective_of_finite {R : Type u}
+    [CommRing R] {I : Ideal R}
+    (hfinite : ∀ (S : Type u) [CommRing S] [Algebra R S] [Module.Finite R S],
+      Function.Bijective
+        (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
+    I ≤ Ideal.jacobson (⊥ : Ideal R) :=
+  le_jacobson_of_idempotentQuotientMap_injective_of_finite (by
+    intro S _ _ _
+    exact (hfinite S).1)
+
+/-- The integral-algebra injectivity condition on idempotents forces the base
+ideal to lie in the Jacobson radical. This is the integral-algebra variant of
+`le_jacobson_of_idempotentQuotientMap_injective_of_finite`; it reduces to the
+finite case because finite algebras are integral. -/
+theorem le_jacobson_of_idempotentQuotientMap_injective_of_isIntegral {R : Type u}
+    [CommRing R] {I : Ideal R}
+    (hintegral : ∀ (S : Type u) [CommRing S] [Algebra R S] [Algebra.IsIntegral R S],
+      Function.Injective
+        (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
+    I ≤ Ideal.jacobson (⊥ : Ideal R) :=
+  le_jacobson_of_idempotentQuotientMap_injective_of_finite (by
+    intro S _ _ _
+    exact hintegral S)
+
+/-- The integral-algebra bijectivity condition on idempotents forces the base
+ideal to lie in the Jacobson radical. This is the formulation matching the
+integral-idempotent condition in Stacks Tag 09XI. -/
+theorem le_jacobson_of_idempotentQuotientMap_bijective_of_isIntegral {R : Type u}
+    [CommRing R] {I : Ideal R}
+    (hintegral : ∀ (S : Type u) [CommRing S] [Algebra R S] [Algebra.IsIntegral R S],
+      Function.Bijective
+        (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
+    I ≤ Ideal.jacobson (⊥ : Ideal R) :=
+  le_jacobson_of_idempotentQuotientMap_injective_of_isIntegral (by
+    intro S _ _ _
+    exact (hintegral S).1)
+
+/-- In an integral `R`-algebra `S`, idempotent lifts modulo `I·S` are unique
+whenever `I ≤ Jac(R)`. -/
+theorem isIdempotentElem_lift_unique_map_of_isIntegral {S : Type*} [CommRing S] [Algebra R S]
+    [Algebra.IsIntegral R S] {I : Ideal R} (hIjac : I ≤ Ideal.jacobson (⊥ : Ideal R))
+    {e₁ e₂ : S} (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
+    (hmod : Ideal.Quotient.mk (I.map (algebraMap R S)) e₁ =
+      Ideal.Quotient.mk (I.map (algebraMap R S)) e₂) :
+    e₁ = e₂ :=
+  isIdempotentElem_lift_unique_of_le_jacobson
+    (map_le_jacobson_of_isIntegral hIjac) he₁ he₂ hmod
+
+/-- If `I ≤ Jac(R)` and `S` is integral over `R`, the quotient map
+`S → S/IS` is injective on idempotents. -/
+theorem idempotentQuotientMap_injective_of_isIntegral_of_le_jacobson {S : Type*}
+    [CommRing S] [Algebra R S] [Algebra.IsIntegral R S] {I : Ideal R}
+    (hIjac : I ≤ Ideal.jacobson (⊥ : Ideal R)) :
+    Function.Injective (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I)) := by
+  intro e₁ e₂ hmap
+  apply Subtype.ext
+  exact isIdempotentElem_lift_unique_map_of_isIntegral hIjac e₁.2 e₂.2
+    (congrArg Subtype.val hmap)
+
+/-- If `I ≤ Jac(R)` and `S` is integral over `R`, the quotient map
+`S → S/IS` is injective on orthogonal systems of idempotents. -/
+theorem orthogonalIdempotentsQuotientMap_injective_of_isIntegral_of_le_jacobson
+    {S : Type*} [CommRing S] [Algebra R S] [Algebra.IsIntegral R S] {I : Ideal R}
+    (hIjac : I ≤ Ideal.jacobson (⊥ : Ideal R)) {ι : Type*} :
+    Function.Injective
+      (orthogonalIdempotentsQuotientMapOfAlgebra (R := R) (S := S) (I := I) (ι := ι)) := by
+  intro e₁ e₂ hmap
+  apply Subtype.ext
+  funext i
+  exact isIdempotentElem_lift_unique_map_of_isIntegral hIjac (e₁.2.idem i) (e₂.2.idem i)
+    (congrFun (congrArg Subtype.val hmap) i)
+
+/-- If `I ≤ Jac(R)` and `S` is integral over `R`, the quotient map
+`S → S/IS` is injective on finite complete orthogonal systems of idempotents. -/
+theorem completeOrthogonalIdempotentsQuotientMap_injective_of_isIntegral_of_le_jacobson
+    {S : Type*} [CommRing S] [Algebra R S] [Algebra.IsIntegral R S] {I : Ideal R}
+    (hIjac : I ≤ Ideal.jacobson (⊥ : Ideal R)) {ι : Type*} [Fintype ι] :
+    Function.Injective
+      (completeOrthogonalIdempotentsQuotientMapOfAlgebra
+        (R := R) (S := S) (I := I) (ι := ι)) := by
+  intro e₁ e₂ hmap
+  apply Subtype.ext
+  funext i
+  exact isIdempotentElem_lift_unique_map_of_isIntegral hIjac (e₁.2.idem i) (e₂.2.idem i)
+    (congrFun (congrArg Subtype.val hmap) i)
+
+/-- In an integral algebra over a Henselian pair `(R, I)`, idempotent lifts
+modulo `I·S` are unique. Existence for finite étale algebras is the remaining
+hard 09XI/Raynaud section-lifting input; this theorem supplies the uniqueness
+half for all integral algebras. -/
+theorem isIdempotentElem_lift_unique_map_of_pair {S : Type*} [CommRing S] [Algebra R S]
+    [Algebra.IsIntegral R S] {I : Ideal R} (h : IsHenselianPair R I)
+    {e₁ e₂ : S} (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
+    (hmod : Ideal.Quotient.mk (I.map (algebraMap R S)) e₁ =
+      Ideal.Quotient.mk (I.map (algebraMap R S)) e₂) :
+    e₁ = e₂ :=
+  isIdempotentElem_lift_unique_map_of_isIntegral h.le_jacobson he₁ he₂ hmod
+
+/-- Finite algebras are integral, so idempotent lifts modulo `I·S` are unique
+over a Henselian pair. -/
+theorem isIdempotentElem_lift_unique_map_of_finite {S : Type*} [CommRing S] [Algebra R S]
+    [Module.Finite R S] {I : Ideal R} (h : IsHenselianPair R I)
+    {e₁ e₂ : S} (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
+    (hmod : Ideal.Quotient.mk (I.map (algebraMap R S)) e₁ =
+      Ideal.Quotient.mk (I.map (algebraMap R S)) e₂) :
+    e₁ = e₂ :=
+  isIdempotentElem_lift_unique_map_of_pair h he₁ he₂ hmod
+
+/-- For an integral algebra over a Henselian pair, the quotient map on
+idempotents is injective. This is the uniqueness half of the idempotent lifting
+criterion in Raynaud XI, §1 / Stacks Tag 09XI, and is the part that only uses
+the Jacobson-radical condition. -/
+theorem idempotentQuotientMap_injective_of_isIntegral {S : Type*} [CommRing S]
+    [Algebra R S] [Algebra.IsIntegral R S] {I : Ideal R} (h : IsHenselianPair R I) :
+    Function.Injective (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I)) :=
+  idempotentQuotientMap_injective_of_isIntegral_of_le_jacobson h.le_jacobson
+
+/-- For an integral algebra over a Henselian pair, the quotient map is injective
+on orthogonal systems of idempotents. -/
+theorem orthogonalIdempotentsQuotientMap_injective_of_isIntegral {S : Type*}
+    [CommRing S] [Algebra R S] [Algebra.IsIntegral R S] {I : Ideal R}
+    (h : IsHenselianPair R I)
+    {ι : Type*} :
+    Function.Injective
+      (orthogonalIdempotentsQuotientMapOfAlgebra (R := R) (S := S) (I := I) (ι := ι)) :=
+  orthogonalIdempotentsQuotientMap_injective_of_isIntegral_of_le_jacobson h.le_jacobson
+
+/-- For an integral algebra over a Henselian pair, the quotient map is injective
+on finite complete orthogonal systems of idempotents. -/
+theorem completeOrthogonalIdempotentsQuotientMap_injective_of_isIntegral {S : Type*}
+    [CommRing S] [Algebra R S] [Algebra.IsIntegral R S] {I : Ideal R}
+    (h : IsHenselianPair R I) {ι : Type*} [Fintype ι] :
+    Function.Injective
+      (completeOrthogonalIdempotentsQuotientMapOfAlgebra
+        (R := R) (S := S) (I := I) (ι := ι)) :=
+  completeOrthogonalIdempotentsQuotientMap_injective_of_isIntegral_of_le_jacobson
+    h.le_jacobson
+
+/-- For a finite algebra over a Henselian pair, the quotient map on idempotents
+is injective. This is the finite-algebra specialization of the integral
+uniqueness half of Raynaud XI, §1 / Stacks Tag 09XI. -/
+theorem idempotentQuotientMap_injective_of_finite {S : Type*} [CommRing S] [Algebra R S]
+    [Module.Finite R S] {I : Ideal R} (h : IsHenselianPair R I) :
+    Function.Injective (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I)) :=
+  idempotentQuotientMap_injective_of_isIntegral h
+
+/-- For a finite algebra over a Henselian pair, the quotient map is injective on
+orthogonal systems of idempotents. -/
+theorem orthogonalIdempotentsQuotientMap_injective_of_finite {S : Type*} [CommRing S]
+    [Algebra R S] [Module.Finite R S] {I : Ideal R} (h : IsHenselianPair R I)
+    {ι : Type*} :
+    Function.Injective
+      (orthogonalIdempotentsQuotientMapOfAlgebra (R := R) (S := S) (I := I) (ι := ι)) :=
+  orthogonalIdempotentsQuotientMap_injective_of_isIntegral h
+
+/-- For a finite algebra over a Henselian pair, the quotient map is injective on
+finite complete orthogonal systems of idempotents. -/
+theorem completeOrthogonalIdempotentsQuotientMap_injective_of_finite {S : Type*}
+    [CommRing S] [Algebra R S] [Module.Finite R S] {I : Ideal R}
+    (h : IsHenselianPair R I) {ι : Type*} [Fintype ι] :
+    Function.Injective
+      (completeOrthogonalIdempotentsQuotientMapOfAlgebra
+        (R := R) (S := S) (I := I) (ι := ι)) :=
+  completeOrthogonalIdempotentsQuotientMap_injective_of_isIntegral h
+
+end IsHenselianPair

--- a/FLT/Slop/HenselianPair/Idempotents.lean
+++ b/FLT/Slop/HenselianPair/Idempotents.lean
@@ -46,13 +46,11 @@ variable {R : Type*} [CommRing R]
 namespace IsHenselianPair
 
 /-- **Idempotents lift along `R → R ⧸ I`** for a Henselian pair `(R, I)`.
-This is one of the equivalent conditions in the pair TFAE (Stacks Tag 09XI): an
-idempotent `ē` of `R ⧸ I` is a simple root of `X² - X`, so it lifts to an
-idempotent of `R`. -/
-theorem exists_isIdempotentElem_lift {I : Ideal R} (h : IsHenselianPair R I)
-    {ε : R ⧸ I} (hε : IsIdempotentElem ε) :
-    ∃ e : R, IsIdempotentElem e ∧ Ideal.Quotient.mk I e = ε := by
+This is one of the equivalent conditions in the pair TFAE (Stacks Tag 09XI). -/
+theorem exists_isIdempotentElem_lift {I : Ideal R} (h : IsHenselianPair R I) {ε : R ⧸ I}
+    (hε : IsIdempotentElem ε) : ∃ e : R, IsIdempotentElem e ∧ Ideal.Quotient.mk I e = ε := by
   obtain ⟨a₀, ha₀⟩ := Ideal.Quotient.mk_surjective ε
+  -- `ε` is a simple root of `f = X² - X` mod `I`; its Henselian lift is the idempotent.
   set f : R[X] := X ^ 2 - X with hf
   have hfmonic : f.Monic := by
     rw [hf]
@@ -60,8 +58,7 @@ theorem exists_isIdempotentElem_lift {I : Ideal R} (h : IsHenselianPair R I)
   have heval : f.eval a₀ = a₀ ^ 2 - a₀ := by simp [hf]
   -- `a₀² - a₀ ∈ I` because `ε` is idempotent.
   have hmem : a₀ ^ 2 - a₀ ∈ I := by
-    rw [← Ideal.Quotient.eq_zero_iff_mem, map_sub, map_pow, ha₀, sub_eq_zero, sq]
-    exact hε
+    rwa [← Ideal.Quotient.eq_zero_iff_mem, map_sub, map_pow, ha₀, sub_eq_zero, sq]
   -- the derivative `2X - 1` evaluates to a unit modulo `I` (it is its own inverse).
   have hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀)) := by
     have hde : f.derivative.eval a₀ = 2 * a₀ - 1 := by
@@ -69,12 +66,10 @@ theorem exists_isIdempotentElem_lift {I : Ideal R} (h : IsHenselianPair R I)
         eval_sub, eval_mul, eval_C, eval_pow, eval_X, eval_one]
       ring
     rw [hde]
-    have hsq : Ideal.Quotient.mk I (2 * a₀ - 1) * Ideal.Quotient.mk I (2 * a₀ - 1) = 1 := by
-      rw [← map_mul, ← map_one (Ideal.Quotient.mk I), Ideal.Quotient.eq]
-      have hcalc : (2 * a₀ - 1) * (2 * a₀ - 1) - 1 = 4 * (a₀ ^ 2 - a₀) := by ring
-      rw [hcalc]
-      exact I.mul_mem_left 4 hmem
-    exact ⟨⟨_, _, hsq, by rw [mul_comm]; exact hsq⟩, rfl⟩
+    refine IsUnit.of_mul_eq_one (Ideal.Quotient.mk I (2 * a₀ - 1)) ?_
+    rw [← map_mul, ← map_one (Ideal.Quotient.mk I), Ideal.Quotient.eq,
+      show (2 * a₀ - 1) * (2 * a₀ - 1) - 1 = 4 * (a₀ ^ 2 - a₀) by ring]
+    exact I.mul_mem_left 4 hmem
   obtain ⟨e, he_root, he_sub⟩ :=
     h.henselianRing.is_henselian f hfmonic a₀ (heval ▸ hmem) hderiv
   have he_eval : e ^ 2 - e = 0 := by
@@ -82,10 +77,8 @@ theorem exists_isIdempotentElem_lift {I : Ideal R} (h : IsHenselianPair R I)
     rwa [hf, eval_sub, eval_pow, eval_X] at this
   refine ⟨e, ?_, ?_⟩
   · change e * e = e
-    have : e ^ 2 = e := by rw [← sub_eq_zero]; exact he_eval
-    rwa [sq] at this
-  · rw [← ha₀, ← sub_eq_zero, ← map_sub, Ideal.Quotient.eq_zero_iff_mem]
-    exact he_sub
+    linear_combination he_eval
+  · rwa [← ha₀, ← sub_eq_zero, ← map_sub, Ideal.Quotient.eq_zero_iff_mem]
 
 /-- An idempotent element in the Jacobson radical is zero. -/
 theorem isIdempotentElem_eq_zero_of_mem_jacobson {e : R} (he : IsIdempotentElem e)
@@ -94,37 +87,29 @@ theorem isIdempotentElem_eq_zero_of_mem_jacobson {e : R} (he : IsIdempotentElem 
   have hunit : IsUnit (1 - e) := by
     convert hejac (-1) using 1
     ring
-  have hmul : (1 - e) * e = 0 := he.one_sub_mul_self
-  exact hunit.mul_right_eq_zero.mp hmul
+  exact hunit.mul_right_eq_zero.mp he.one_sub_mul_self
 
 /-- Two idempotents congruent modulo the Jacobson radical are equal. -/
-theorem isIdempotentElem_eq_of_sub_mem_jacobson {e₁ e₂ : R}
-    (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
-    (hdiff : e₁ - e₂ ∈ Ideal.jacobson (⊥ : Ideal R)) : e₁ = e₂ := by
+theorem isIdempotentElem_eq_of_sub_mem_jacobson {e₁ e₂ : R} (he₁ : IsIdempotentElem e₁)
+    (he₂ : IsIdempotentElem e₂) (hdiff : e₁ - e₂ ∈ Ideal.jacobson (⊥ : Ideal R)) : e₁ = e₂ := by
   let J : Ideal R := Ideal.jacobson (⊥ : Ideal R)
   have hleft_mem : e₁ * (1 - e₂) ∈ J := by
     have hrewrite : e₁ * (1 - e₂) = e₁ * (e₁ - e₂) := by
       rw [mul_sub, mul_sub, mul_one, he₁.eq]
     rw [hrewrite]
     exact J.mul_mem_left e₁ hdiff
-  have hleft_idem : IsIdempotentElem (e₁ * (1 - e₂)) := he₁.mul he₂.one_sub
   have hleft_zero : e₁ * (1 - e₂) = 0 :=
-    isIdempotentElem_eq_zero_of_mem_jacobson hleft_idem hleft_mem
+    isIdempotentElem_eq_zero_of_mem_jacobson (he₁.mul he₂.one_sub) hleft_mem
   have hdiff' : e₂ - e₁ ∈ J := by
-    simpa [sub_eq_add_neg, add_comm, add_left_comm, add_assoc] using J.neg_mem hdiff
+    simpa only [neg_sub] using J.neg_mem hdiff
   have hright_mem : (1 - e₁) * e₂ ∈ J := by
     have hrewrite : (1 - e₁) * e₂ = (1 - e₁) * (e₂ - e₁) := by
       rw [mul_sub, he₁.one_sub_mul_self, sub_zero]
     rw [hrewrite]
     exact J.mul_mem_left (1 - e₁) hdiff'
-  have hright_idem : IsIdempotentElem ((1 - e₁) * e₂) := he₁.one_sub.mul he₂
   have hright_zero : (1 - e₁) * e₂ = 0 :=
-    isIdempotentElem_eq_zero_of_mem_jacobson hright_idem hright_mem
-  have h₁ : e₁ = e₁ * e₂ := by
-    simpa [mul_sub, mul_one, sub_eq_zero] using hleft_zero
-  have h₂ : e₂ = e₁ * e₂ := by
-    simpa [sub_mul, one_mul, sub_eq_zero] using hright_zero
-  exact h₁.trans h₂.symm
+    isIdempotentElem_eq_zero_of_mem_jacobson (he₁.one_sub.mul he₂) hright_mem
+  linear_combination hleft_zero - hright_zero
 
 /-- If `I` is contained in the Jacobson radical, idempotent lifts along
 `R → R ⧸ I` are unique. -/
@@ -144,19 +129,18 @@ theorem isIdempotentElem_lift_unique {I : Ideal R} (h : IsHenselianPair R I)
 This packages the idempotent-lifting clause of Stacks Tag 09XI as an `∃!`
 statement. -/
 @[stacks 09XI "(2)"]
-theorem existsUnique_isIdempotentElem_lift {I : Ideal R} (h : IsHenselianPair R I)
-    {ε : R ⧸ I} (hε : IsIdempotentElem ε) :
-    ∃! e : R, IsIdempotentElem e ∧ Ideal.Quotient.mk I e = ε := by
-  obtain ⟨e, he, heq⟩ := h.exists_isIdempotentElem_lift hε
-  refine ⟨e, ⟨he, heq⟩, ?_⟩
-  intro y hy
-  exact h.isIdempotentElem_lift_unique hy.1 he (hy.2.trans heq.symm)
+theorem existsUnique_isIdempotentElem_lift {I : Ideal R} (h : IsHenselianPair R I) {ε : R ⧸ I}
+    (hε : IsIdempotentElem ε) : ∃! e : R, IsIdempotentElem e ∧ Ideal.Quotient.mk I e = ε :=
+  existsUnique_of_exists_of_unique (h.exists_isIdempotentElem_lift hε)
+    fun _ _ hy₁ hy₂ ↦ h.isIdempotentElem_lift_unique hy₁.1 hy₂.1 (hy₁.2.trans hy₂.2.symm)
 
 /-- The quotient map on idempotent elements induced by `R → R ⧸ I`. -/
 def idempotentQuotientMap {I : Ideal R} :
     {e : R // IsIdempotentElem e} → {ε : R ⧸ I // IsIdempotentElem ε} :=
   fun e => ⟨Ideal.Quotient.mk I e.1, e.2.map (Ideal.Quotient.mk I)⟩
 
+/-- `simp`-normal form for `idempotentQuotientMap`: it reduces `e` componentwise via
+`Ideal.Quotient.mk I`. -/
 @[simp]
 theorem idempotentQuotientMap_apply {I : Ideal R} (e : {e : R // IsIdempotentElem e}) :
     idempotentQuotientMap (R := R) (I := I) e =
@@ -172,8 +156,7 @@ theorem idempotentQuotientMap_bijective {I : Ideal R} (h : IsHenselianPair R I) 
     Function.Bijective (idempotentQuotientMap (R := R) (I := I)) := by
   constructor
   · intro e₁ e₂ hmap
-    apply Subtype.ext
-    exact h.isIdempotentElem_lift_unique e₁.2 e₂.2 (congrArg Subtype.val hmap)
+    exact Subtype.ext (h.isIdempotentElem_lift_unique e₁.2 e₂.2 (congrArg Subtype.val hmap))
   · intro ε
     obtain ⟨e, he, heq⟩ := h.exists_isIdempotentElem_lift ε.2
     exact ⟨⟨e, he⟩, Subtype.ext heq⟩
@@ -194,38 +177,30 @@ theorem idempotentQuotientEquiv_apply {I : Ideal R} (h : IsHenselianPair R I)
 /-- Orthogonal systems of idempotents lift along `R → R ⧸ I` for a Henselian
 pair. Orthogonality is recovered from uniqueness: the product of two distinct
 coordinate lifts is an idempotent reducing to zero. -/
-theorem exists_orthogonalIdempotents_lift {I : Ideal R} (h : IsHenselianPair R I)
-    {ι : Type*} {ε : ι → R ⧸ I} (hε : OrthogonalIdempotents ε) :
+theorem exists_orthogonalIdempotents_lift {I : Ideal R} (h : IsHenselianPair R I) {ι : Type*}
+    {ε : ι → R ⧸ I} (hε : OrthogonalIdempotents ε) :
     ∃ e : ι → R, OrthogonalIdempotents e ∧ Ideal.Quotient.mk I ∘ e = ε := by
   classical
   choose e he hmap using fun i => h.exists_isIdempotentElem_lift (hε.idem i)
-  refine ⟨e, ?_, funext hmap⟩
-  refine ⟨he, ?_⟩
-  intro i j hij
-  have hprod_idem : IsIdempotentElem (e i * e j) := (he i).mul (he j)
-  have hprod_mod :
-      Ideal.Quotient.mk I (e i * e j) = Ideal.Quotient.mk I (0 : R) := by
-    simp [map_mul, hmap i, hmap j, hε.ortho hij]
-  exact h.isIdempotentElem_lift_unique hprod_idem IsIdempotentElem.zero hprod_mod
+  refine ⟨e, ⟨he, fun i j hij => ?_⟩, funext hmap⟩
+  refine h.isIdempotentElem_lift_unique ((he i).mul (he j)) IsIdempotentElem.zero ?_
+  simp [map_mul, hmap i, hmap j, hε.ortho hij]
 
 /-- Orthogonal systems of idempotents lift uniquely along `R → R ⧸ I` for a
 Henselian pair. -/
-theorem orthogonalIdempotents_lift_unique {I : Ideal R} (h : IsHenselianPair R I)
-    {ι : Type*} {e₁ e₂ : ι → R} (he₁ : OrthogonalIdempotents e₁)
-    (he₂ : OrthogonalIdempotents e₂)
-    (hmod : Ideal.Quotient.mk I ∘ e₁ = Ideal.Quotient.mk I ∘ e₂) :
-    e₁ = e₂ := by
+theorem orthogonalIdempotents_lift_unique {I : Ideal R} (h : IsHenselianPair R I) {ι : Type*}
+    {e₁ e₂ : ι → R} (he₁ : OrthogonalIdempotents e₁) (he₂ : OrthogonalIdempotents e₂)
+    (hmod : Ideal.Quotient.mk I ∘ e₁ = Ideal.Quotient.mk I ∘ e₂) : e₁ = e₂ := by
   funext i
   exact h.isIdempotentElem_lift_unique (he₁.idem i) (he₂.idem i) (congrFun hmod i)
 
 /-- Orthogonal systems of idempotents have unique lifts along `R → R ⧸ I` for a
 Henselian pair, packaged as an `∃!`. -/
-theorem existsUnique_orthogonalIdempotents_lift {I : Ideal R} (h : IsHenselianPair R I)
-    {ι : Type*} {ε : ι → R ⧸ I} (hε : OrthogonalIdempotents ε) :
+theorem existsUnique_orthogonalIdempotents_lift {I : Ideal R} (h : IsHenselianPair R I) {ι : Type*}
+    {ε : ι → R ⧸ I} (hε : OrthogonalIdempotents ε) :
     ∃! e : ι → R, OrthogonalIdempotents e ∧ Ideal.Quotient.mk I ∘ e = ε := by
   obtain ⟨e, he, hmap⟩ := h.exists_orthogonalIdempotents_lift hε
-  refine ⟨e, ⟨he, hmap⟩, ?_⟩
-  intro y hy
+  refine ⟨e, ⟨he, hmap⟩, fun y hy => ?_⟩
   exact h.orthogonalIdempotents_lift_unique hy.1 he (hy.2.trans hmap.symm)
 
 /-- The quotient map on orthogonal systems of idempotents induced by `R → R ⧸ I`. -/
@@ -249,27 +224,23 @@ theorem orthogonalIdempotentsQuotientMap_bijective {I : Ideal R} (h : IsHenselia
     Function.Bijective (orthogonalIdempotentsQuotientMap (R := R) (I := I) (ι := ι)) := by
   constructor
   · intro e₁ e₂ hmap
-    apply Subtype.ext
-    exact h.orthogonalIdempotents_lift_unique e₁.2 e₂.2 (congrArg Subtype.val hmap)
+    exact Subtype.ext (h.orthogonalIdempotents_lift_unique e₁.2 e₂.2 (congrArg Subtype.val hmap))
   · intro ε
     obtain ⟨e, he, hmap⟩ := h.exists_orthogonalIdempotents_lift ε.2
     exact ⟨⟨e, he⟩, Subtype.ext hmap⟩
 
 /-- For a Henselian pair `(R, I)`, reduction modulo `I` gives an equivalence on
 orthogonal systems of idempotents. -/
-noncomputable def orthogonalIdempotentsQuotientEquiv {I : Ideal R}
-    (h : IsHenselianPair R I) {ι : Type*} :
-    {e : ι → R // OrthogonalIdempotents e} ≃
-      {ε : ι → R ⧸ I // OrthogonalIdempotents ε} :=
+noncomputable def orthogonalIdempotentsQuotientEquiv {I : Ideal R} (h : IsHenselianPair R I)
+    {ι : Type*} :
+    {e : ι → R // OrthogonalIdempotents e} ≃ {ε : ι → R ⧸ I // OrthogonalIdempotents ε} :=
   Equiv.ofBijective (orthogonalIdempotentsQuotientMap (R := R) (I := I) (ι := ι))
     h.orthogonalIdempotentsQuotientMap_bijective
 
 @[simp]
-theorem orthogonalIdempotentsQuotientEquiv_apply {I : Ideal R}
-    (h : IsHenselianPair R I) {ι : Type*}
+theorem orthogonalIdempotentsQuotientEquiv_apply {I : Ideal R} (h : IsHenselianPair R I) {ι : Type*}
     (e : {e : ι → R // OrthogonalIdempotents e}) :
-    h.orthogonalIdempotentsQuotientEquiv e =
-      orthogonalIdempotentsQuotientMap (R := R) (I := I) e :=
+    h.orthogonalIdempotentsQuotientEquiv e = orthogonalIdempotentsQuotientMap (R := R) (I := I) e :=
   Equiv.ofBijective_apply _ _ e
 
 /-- Complete orthogonal systems of idempotents lift along `R → R ⧸ I` for a
@@ -280,8 +251,7 @@ theorem exists_completeOrthogonalIdempotents_lift {I : Ideal R} (h : IsHenselian
     ∃ e : ι → R, CompleteOrthogonalIdempotents e ∧ Ideal.Quotient.mk I ∘ e = ε := by
   obtain ⟨e, he, hmap⟩ := h.exists_orthogonalIdempotents_lift hε.toOrthogonalIdempotents
   have hmap_apply : ∀ i, Ideal.Quotient.mk I (e i) = ε i := fun i => congrFun hmap i
-  have hsum_mod :
-      Ideal.Quotient.mk I (∑ i, e i) = Ideal.Quotient.mk I (1 : R) := by
+  have hsum_mod : Ideal.Quotient.mk I (∑ i, e i) = Ideal.Quotient.mk I (1 : R) := by
     simp [map_sum, hmap_apply, hε.complete]
   have hcomplete : ∑ i, e i = 1 :=
     h.isIdempotentElem_lift_unique
@@ -293,8 +263,7 @@ for a Henselian pair. -/
 theorem completeOrthogonalIdempotents_lift_unique {I : Ideal R} (h : IsHenselianPair R I)
     {ι : Type*} [Fintype ι] {e₁ e₂ : ι → R}
     (he₁ : CompleteOrthogonalIdempotents e₁) (he₂ : CompleteOrthogonalIdempotents e₂)
-    (hmod : Ideal.Quotient.mk I ∘ e₁ = Ideal.Quotient.mk I ∘ e₂) :
-    e₁ = e₂ :=
+    (hmod : Ideal.Quotient.mk I ∘ e₁ = Ideal.Quotient.mk I ∘ e₂) : e₁ = e₂ :=
   h.orthogonalIdempotents_lift_unique he₁.toOrthogonalIdempotents
     he₂.toOrthogonalIdempotents hmod
 
@@ -305,9 +274,8 @@ theorem existsUnique_completeOrthogonalIdempotents_lift {I : Ideal R}
     (hε : CompleteOrthogonalIdempotents ε) :
     ∃! e : ι → R, CompleteOrthogonalIdempotents e ∧ Ideal.Quotient.mk I ∘ e = ε := by
   obtain ⟨e, he, hmap⟩ := h.exists_completeOrthogonalIdempotents_lift hε
-  refine ⟨e, ⟨he, hmap⟩, ?_⟩
-  intro y hy
-  exact h.completeOrthogonalIdempotents_lift_unique hy.1 he (hy.2.trans hmap.symm)
+  exact ⟨e, ⟨he, hmap⟩, fun y hy =>
+    h.completeOrthogonalIdempotents_lift_unique hy.1 he (hy.2.trans hmap.symm)⟩
 
 /-- The quotient map on finite complete orthogonal systems of idempotents induced by
 `R → R ⧸ I`. -/
@@ -317,8 +285,8 @@ def completeOrthogonalIdempotentsQuotientMap {I : Ideal R} {ι : Type*} [Fintype
   fun e => ⟨Ideal.Quotient.mk I ∘ e.1, e.2.map (Ideal.Quotient.mk I)⟩
 
 @[simp]
-theorem completeOrthogonalIdempotentsQuotientMap_apply {I : Ideal R} {ι : Type*}
-    [Fintype ι] (e : {e : ι → R // CompleteOrthogonalIdempotents e}) :
+theorem completeOrthogonalIdempotentsQuotientMap_apply {I : Ideal R} {ι : Type*} [Fintype ι]
+    (e : {e : ι → R // CompleteOrthogonalIdempotents e}) :
     completeOrthogonalIdempotentsQuotientMap (R := R) (I := I) e =
       (⟨Ideal.Quotient.mk I ∘ e.1, e.2.map (Ideal.Quotient.mk I)⟩ :
         {ε : ι → R ⧸ I // CompleteOrthogonalIdempotents ε}) :=
@@ -326,10 +294,9 @@ theorem completeOrthogonalIdempotentsQuotientMap_apply {I : Ideal R} {ι : Type*
 
 /-- The quotient map of a Henselian pair induces a bijection on finite complete
 orthogonal systems of idempotents. -/
-theorem completeOrthogonalIdempotentsQuotientMap_bijective {I : Ideal R}
-    (h : IsHenselianPair R I) {ι : Type*} [Fintype ι] :
-    Function.Bijective (completeOrthogonalIdempotentsQuotientMap
-      (R := R) (I := I) (ι := ι)) := by
+theorem completeOrthogonalIdempotentsQuotientMap_bijective {I : Ideal R} (h : IsHenselianPair R I)
+    {ι : Type*} [Fintype ι] :
+    Function.Bijective (completeOrthogonalIdempotentsQuotientMap (R := R) (I := I) (ι := ι)) := by
   constructor
   · intro e₁ e₂ hmap
     apply Subtype.ext
@@ -340,8 +307,8 @@ theorem completeOrthogonalIdempotentsQuotientMap_bijective {I : Ideal R}
 
 /-- For a Henselian pair `(R, I)`, reduction modulo `I` gives an equivalence on
 finite complete orthogonal systems of idempotents. -/
-noncomputable def completeOrthogonalIdempotentsQuotientEquiv {I : Ideal R}
-    (h : IsHenselianPair R I) {ι : Type*} [Fintype ι] :
+noncomputable def completeOrthogonalIdempotentsQuotientEquiv {I : Ideal R} (h : IsHenselianPair R I)
+    {ι : Type*} [Fintype ι] :
     {e : ι → R // CompleteOrthogonalIdempotents e} ≃
       {ε : ι → R ⧸ I // CompleteOrthogonalIdempotents ε} :=
   Equiv.ofBijective (completeOrthogonalIdempotentsQuotientMap (R := R) (I := I) (ι := ι))
@@ -363,7 +330,7 @@ theorem map_le_jacobson_of_isIntegral {S : Type*} [CommRing S] [Algebra R S]
   intro x hx
   rw [Ideal.jacobson, Ideal.mem_sInf]
   intro M hM
-  haveI : M.IsMaximal := hM.2
+  have : M.IsMaximal := hM.2
   have hcomap_max : (M.comap (algebraMap R S)).IsMaximal :=
     Ideal.isMaximal_comap_of_isIntegral_of_isMaximal (R := R) (S := S) M
   have hI_le_comap : I ≤ M.comap (algebraMap R S) := by
@@ -381,9 +348,11 @@ def idempotentQuotientMapOfAlgebra {S : Type*} [CommRing S] [Algebra R S] {I : I
   fun e => ⟨Ideal.Quotient.mk (I.map (algebraMap R S)) e.1,
     e.2.map (Ideal.Quotient.mk (I.map (algebraMap R S)))⟩
 
+/-- `simp`-normal form for `idempotentQuotientMapOfAlgebra`: it reduces `e` via
+`Ideal.Quotient.mk (I.map (algebraMap R S))`. -/
 @[simp]
-theorem idempotentQuotientMapOfAlgebra_apply {S : Type*} [CommRing S] [Algebra R S]
-    {I : Ideal R} (e : {e : S // IsIdempotentElem e}) :
+theorem idempotentQuotientMapOfAlgebra_apply {S : Type*} [CommRing S] [Algebra R S] {I : Ideal R}
+    (e : {e : S // IsIdempotentElem e}) :
     idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I) e =
       (⟨Ideal.Quotient.mk (I.map (algebraMap R S)) e.1,
         e.2.map (Ideal.Quotient.mk (I.map (algebraMap R S)))⟩ :
@@ -399,10 +368,11 @@ def orthogonalIdempotentsQuotientMapOfAlgebra {S : Type*} [CommRing S] [Algebra 
   fun e => ⟨Ideal.Quotient.mk (I.map (algebraMap R S)) ∘ e.1,
     e.2.map (Ideal.Quotient.mk (I.map (algebraMap R S)))⟩
 
+/-- `simp`-normal form for `orthogonalIdempotentsQuotientMapOfAlgebra`: it reduces `e`
+componentwise via `Ideal.Quotient.mk (I.map (algebraMap R S))`. -/
 @[simp]
-theorem orthogonalIdempotentsQuotientMapOfAlgebra_apply {S : Type*} [CommRing S]
-    [Algebra R S] {I : Ideal R} {ι : Type*}
-    (e : {e : ι → S // OrthogonalIdempotents e}) :
+theorem orthogonalIdempotentsQuotientMapOfAlgebra_apply {S : Type*} [CommRing S] [Algebra R S]
+    {I : Ideal R} {ι : Type*} (e : {e : ι → S // OrthogonalIdempotents e}) :
     orthogonalIdempotentsQuotientMapOfAlgebra (R := R) (S := S) (I := I) e =
       (⟨Ideal.Quotient.mk (I.map (algebraMap R S)) ∘ e.1,
         e.2.map (Ideal.Quotient.mk (I.map (algebraMap R S)))⟩ :
@@ -411,8 +381,8 @@ theorem orthogonalIdempotentsQuotientMapOfAlgebra_apply {S : Type*} [CommRing S]
 
 /-- The quotient map on finite complete orthogonal systems of idempotents in an
 `R`-algebra `S`, induced by `S → S ⧸ I·S`. -/
-def completeOrthogonalIdempotentsQuotientMapOfAlgebra {S : Type*} [CommRing S]
-    [Algebra R S] {I : Ideal R} {ι : Type*} [Fintype ι] :
+def completeOrthogonalIdempotentsQuotientMapOfAlgebra {S : Type*} [CommRing S] [Algebra R S]
+    {I : Ideal R} {ι : Type*} [Fintype ι] :
     {e : ι → S // CompleteOrthogonalIdempotents e} →
       {ε : ι → S ⧸ I.map (algebraMap R S) // CompleteOrthogonalIdempotents ε} :=
   fun e => ⟨Ideal.Quotient.mk (I.map (algebraMap R S)) ∘ e.1,
@@ -432,34 +402,30 @@ universe u
 
 /-- The finite-algebra injectivity condition on idempotents forces the base ideal
 to lie in the Jacobson radical. This is the Jacobson-radical part of the
-finite-idempotent converse in Stacks Tag 09XI.
-
-The proof tests the condition on `R ⧸ (I ⊓ M)` for each maximal ideal `M`. If
-some `x ∈ I` is not in `M`, then `I` and `M` are comaximal, so the Chinese
-remainder theorem supplies two distinct idempotents with the same reduction
-modulo `I`. -/
-theorem le_jacobson_of_idempotentQuotientMap_injective_of_finite {R : Type u}
-    [CommRing R] {I : Ideal R}
-    (hfinite : ∀ (S : Type u) [CommRing S] [Algebra R S] [Module.Finite R S],
-      Function.Injective
-        (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
+finite-idempotent converse in Stacks Tag 09XI. -/
+theorem le_jacobson_of_idempotentQuotientMap_injective_of_finite {R : Type u} [CommRing R]
+    {I : Ideal R} (hfinite : ∀ (S : Type u) [CommRing S] [Algebra R S] [Module.Finite R S],
+      Function.Injective (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
     I ≤ Ideal.jacobson (⊥ : Ideal R) := by
   intro x hxI
+  -- test `x ∈ Jac(⊥)` against each maximal ideal `M`.
   rw [Ideal.jacobson, Ideal.mem_sInf]
   intro M hM
   have hMmax : M.IsMaximal := hM.2
+  -- suppose `x ∉ M`; as `x ∈ I` and `M` is maximal, `I` and `M` are comaximal.
   by_contra hxM
   obtain ⟨y, m, hm, hym⟩ := hMmax.exists_inv hxM
   have hIMtop : I ⊔ M = ⊤ := by
-    rw [Ideal.eq_top_iff_one]
-    rw [← hym]
+    rw [Ideal.eq_top_iff_one, ← hym]
     exact Submodule.mem_sup.mpr ⟨y * x, I.mul_mem_left y hxI, m, hm, rfl⟩
+  -- CRT: `S := R ⧸ (I ⊓ M)` is isomorphic to `(R ⧸ I) × (R ⧸ M)`.
   let J : Ideal R := I ⊓ M
   let S : Type u := R ⧸ J
   have hcop : IsCoprime I M := Ideal.isCoprime_iff_sup_eq.mpr hIMtop
   let e : S ≃+* (R ⧸ I) × R ⧸ M :=
     Ideal.quotientInfEquivQuotientProd I M hcop
-  haveI : Nontrivial (R ⧸ M) := Ideal.Quotient.nontrivial_iff.mpr hMmax.ne_top
+  have : Nontrivial (R ⧸ M) := Ideal.Quotient.nontrivial_iff.mpr hMmax.ne_top
+  -- the CRT-preimages of `(1, 0)` and `(1, 1)`: two idempotents of `S`, distinct as `0 ≠ 1`.
   let a : S := e.symm (1, 0)
   let b : S := e.symm (1, 1)
   have ha : IsIdempotentElem a := by
@@ -488,71 +454,57 @@ theorem le_jacobson_of_idempotentQuotientMap_injective_of_finite {R : Type u}
     rw [Ideal.quotientInfEquivQuotientProd_fst]
     change d (DoubleQuot.quotQuotMk J I r) = Ideal.Quotient.mk I r
     exact DoubleQuot.quotQuotEquivQuotOfLE_quotQuotMk r hJI
+  -- yet `a` and `b` have the same reduction modulo `I·S`.
   have hq : q a = q b := by
     apply d.injective
     rw [hd_eq_fst a, hd_eq_fst b]
     simp [a, b]
-  haveI : Module.Finite R S :=
+  -- `S` is module-finite over `R`, so injectivity of the idempotent map forces `a = b`.
+  have : Module.Finite R S :=
     Module.Finite.of_surjective (Ideal.Quotient.mkₐ R J).toLinearMap
       Ideal.Quotient.mk_surjective
-  have hinj := hfinite S
   have hsub :
       idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I) ⟨a, ha⟩ =
-        idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I) ⟨b, hb⟩ := by
-    apply Subtype.ext
-    exact hq
-  exact hne (congrArg Subtype.val (hinj hsub))
+        idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I) ⟨b, hb⟩ :=
+    Subtype.ext hq
+  exact hne (congrArg Subtype.val (hfinite S hsub))
 
 /-- The finite-algebra bijectivity condition on idempotents forces the base
 ideal to lie in the Jacobson radical. This is the formulation closest to the
 finite-idempotent condition in Stacks Tag 09XI. -/
-theorem le_jacobson_of_idempotentQuotientMap_bijective_of_finite {R : Type u}
-    [CommRing R] {I : Ideal R}
-    (hfinite : ∀ (S : Type u) [CommRing S] [Algebra R S] [Module.Finite R S],
-      Function.Bijective
-        (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
+theorem le_jacobson_of_idempotentQuotientMap_bijective_of_finite {R : Type u} [CommRing R]
+    {I : Ideal R} (hfinite : ∀ (S : Type u) [CommRing S] [Algebra R S] [Module.Finite R S],
+      Function.Bijective (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
     I ≤ Ideal.jacobson (⊥ : Ideal R) :=
-  le_jacobson_of_idempotentQuotientMap_injective_of_finite (by
-    intro S _ _ _
-    exact (hfinite S).1)
+  le_jacobson_of_idempotentQuotientMap_injective_of_finite fun S _ _ _ ↦ (hfinite S).1
 
 /-- The integral-algebra injectivity condition on idempotents forces the base
 ideal to lie in the Jacobson radical. This is the integral-algebra variant of
 `le_jacobson_of_idempotentQuotientMap_injective_of_finite`; it reduces to the
 finite case because finite algebras are integral. -/
-theorem le_jacobson_of_idempotentQuotientMap_injective_of_isIntegral {R : Type u}
-    [CommRing R] {I : Ideal R}
-    (hintegral : ∀ (S : Type u) [CommRing S] [Algebra R S] [Algebra.IsIntegral R S],
-      Function.Injective
-        (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
+theorem le_jacobson_of_idempotentQuotientMap_injective_of_isIntegral {R : Type u} [CommRing R]
+    {I : Ideal R} (hintegral : ∀ (S : Type u) [CommRing S] [Algebra R S] [Algebra.IsIntegral R S],
+      Function.Injective (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
     I ≤ Ideal.jacobson (⊥ : Ideal R) :=
-  le_jacobson_of_idempotentQuotientMap_injective_of_finite (by
-    intro S _ _ _
-    exact hintegral S)
+  le_jacobson_of_idempotentQuotientMap_injective_of_finite fun S _ _ _ ↦ hintegral S
 
 /-- The integral-algebra bijectivity condition on idempotents forces the base
 ideal to lie in the Jacobson radical. This is the formulation matching the
 integral-idempotent condition in Stacks Tag 09XI. -/
-theorem le_jacobson_of_idempotentQuotientMap_bijective_of_isIntegral {R : Type u}
-    [CommRing R] {I : Ideal R}
-    (hintegral : ∀ (S : Type u) [CommRing S] [Algebra R S] [Algebra.IsIntegral R S],
-      Function.Bijective
-        (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
+theorem le_jacobson_of_idempotentQuotientMap_bijective_of_isIntegral {R : Type u} [CommRing R]
+    {I : Ideal R} (hintegral : ∀ (S : Type u) [CommRing S] [Algebra R S] [Algebra.IsIntegral R S],
+      Function.Bijective (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I))) :
     I ≤ Ideal.jacobson (⊥ : Ideal R) :=
-  le_jacobson_of_idempotentQuotientMap_injective_of_isIntegral (by
-    intro S _ _ _
-    exact (hintegral S).1)
+  le_jacobson_of_idempotentQuotientMap_injective_of_isIntegral fun S _ _ _ ↦ (hintegral S).1
 
 /-- In an integral `R`-algebra `S`, idempotent lifts modulo `I·S` are unique
 whenever `I ≤ Jac(R)`. -/
 theorem isIdempotentElem_lift_unique_map_of_isIntegral {S : Type*} [CommRing S] [Algebra R S]
-    [Algebra.IsIntegral R S] {I : Ideal R} (hIjac : I ≤ Ideal.jacobson (⊥ : Ideal R))
-    {e₁ e₂ : S} (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
+    [Algebra.IsIntegral R S] {I : Ideal R} (hIjac : I ≤ Ideal.jacobson (⊥ : Ideal R)) {e₁ e₂ : S}
+    (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
     (hmod : Ideal.Quotient.mk (I.map (algebraMap R S)) e₁ =
-      Ideal.Quotient.mk (I.map (algebraMap R S)) e₂) :
-    e₁ = e₂ :=
-  isIdempotentElem_lift_unique_of_le_jacobson
-    (map_le_jacobson_of_isIntegral hIjac) he₁ he₂ hmod
+      Ideal.Quotient.mk (I.map (algebraMap R S)) e₂) : e₁ = e₂ :=
+  isIdempotentElem_lift_unique_of_le_jacobson (map_le_jacobson_of_isIntegral hIjac) he₁ he₂ hmod
 
 /-- If `I ≤ Jac(R)` and `S` is integral over `R`, the quotient map
 `S → S/IS` is injective on idempotents. -/
@@ -561,9 +513,8 @@ theorem idempotentQuotientMap_injective_of_isIntegral_of_le_jacobson {S : Type*}
     (hIjac : I ≤ Ideal.jacobson (⊥ : Ideal R)) :
     Function.Injective (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I)) := by
   intro e₁ e₂ hmap
-  apply Subtype.ext
-  exact isIdempotentElem_lift_unique_map_of_isIntegral hIjac e₁.2 e₂.2
-    (congrArg Subtype.val hmap)
+  exact Subtype.ext (isIdempotentElem_lift_unique_map_of_isIntegral hIjac e₁.2 e₂.2
+    (congrArg Subtype.val hmap))
 
 /-- If `I ≤ Jac(R)` and `S` is integral over `R`, the quotient map
 `S → S/IS` is injective on orthogonal systems of idempotents. -/
@@ -584,8 +535,7 @@ theorem completeOrthogonalIdempotentsQuotientMap_injective_of_isIntegral_of_le_j
     {S : Type*} [CommRing S] [Algebra R S] [Algebra.IsIntegral R S] {I : Ideal R}
     (hIjac : I ≤ Ideal.jacobson (⊥ : Ideal R)) {ι : Type*} [Fintype ι] :
     Function.Injective
-      (completeOrthogonalIdempotentsQuotientMapOfAlgebra
-        (R := R) (S := S) (I := I) (ι := ι)) := by
+      (completeOrthogonalIdempotentsQuotientMapOfAlgebra (R := R) (S := S) (I := I) (ι := ι)) := by
   intro e₁ e₂ hmap
   apply Subtype.ext
   funext i
@@ -600,8 +550,7 @@ theorem isIdempotentElem_lift_unique_map_of_pair {S : Type*} [CommRing S] [Algeb
     [Algebra.IsIntegral R S] {I : Ideal R} (h : IsHenselianPair R I)
     {e₁ e₂ : S} (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
     (hmod : Ideal.Quotient.mk (I.map (algebraMap R S)) e₁ =
-      Ideal.Quotient.mk (I.map (algebraMap R S)) e₂) :
-    e₁ = e₂ :=
+      Ideal.Quotient.mk (I.map (algebraMap R S)) e₂) : e₁ = e₂ :=
   isIdempotentElem_lift_unique_map_of_isIntegral h.le_jacobson he₁ he₂ hmod
 
 /-- Finite algebras are integral, so idempotent lifts modulo `I·S` are unique
@@ -610,16 +559,15 @@ theorem isIdempotentElem_lift_unique_map_of_finite {S : Type*} [CommRing S] [Alg
     [Module.Finite R S] {I : Ideal R} (h : IsHenselianPair R I)
     {e₁ e₂ : S} (he₁ : IsIdempotentElem e₁) (he₂ : IsIdempotentElem e₂)
     (hmod : Ideal.Quotient.mk (I.map (algebraMap R S)) e₁ =
-      Ideal.Quotient.mk (I.map (algebraMap R S)) e₂) :
-    e₁ = e₂ :=
+      Ideal.Quotient.mk (I.map (algebraMap R S)) e₂) : e₁ = e₂ :=
   isIdempotentElem_lift_unique_map_of_pair h he₁ he₂ hmod
 
 /-- For an integral algebra over a Henselian pair, the quotient map on
 idempotents is injective. This is the uniqueness half of the idempotent lifting
 criterion in Raynaud XI, §1 / Stacks Tag 09XI, and is the part that only uses
 the Jacobson-radical condition. -/
-theorem idempotentQuotientMap_injective_of_isIntegral {S : Type*} [CommRing S]
-    [Algebra R S] [Algebra.IsIntegral R S] {I : Ideal R} (h : IsHenselianPair R I) :
+theorem idempotentQuotientMap_injective_of_isIntegral {S : Type*} [CommRing S] [Algebra R S]
+    [Algebra.IsIntegral R S] {I : Ideal R} (h : IsHenselianPair R I) :
     Function.Injective (idempotentQuotientMapOfAlgebra (R := R) (S := S) (I := I)) :=
   idempotentQuotientMap_injective_of_isIntegral_of_le_jacobson h.le_jacobson
 
@@ -627,8 +575,7 @@ theorem idempotentQuotientMap_injective_of_isIntegral {S : Type*} [CommRing S]
 on orthogonal systems of idempotents. -/
 theorem orthogonalIdempotentsQuotientMap_injective_of_isIntegral {S : Type*}
     [CommRing S] [Algebra R S] [Algebra.IsIntegral R S] {I : Ideal R}
-    (h : IsHenselianPair R I)
-    {ι : Type*} :
+    (h : IsHenselianPair R I) {ι : Type*} :
     Function.Injective
       (orthogonalIdempotentsQuotientMapOfAlgebra (R := R) (S := S) (I := I) (ι := ι)) :=
   orthogonalIdempotentsQuotientMap_injective_of_isIntegral_of_le_jacobson h.le_jacobson
@@ -639,10 +586,8 @@ theorem completeOrthogonalIdempotentsQuotientMap_injective_of_isIntegral {S : Ty
     [CommRing S] [Algebra R S] [Algebra.IsIntegral R S] {I : Ideal R}
     (h : IsHenselianPair R I) {ι : Type*} [Fintype ι] :
     Function.Injective
-      (completeOrthogonalIdempotentsQuotientMapOfAlgebra
-        (R := R) (S := S) (I := I) (ι := ι)) :=
-  completeOrthogonalIdempotentsQuotientMap_injective_of_isIntegral_of_le_jacobson
-    h.le_jacobson
+      (completeOrthogonalIdempotentsQuotientMapOfAlgebra (R := R) (S := S) (I := I) (ι := ι)) :=
+  completeOrthogonalIdempotentsQuotientMap_injective_of_isIntegral_of_le_jacobson h.le_jacobson
 
 /-- For a finite algebra over a Henselian pair, the quotient map on idempotents
 is injective. This is the finite-algebra specialization of the integral
@@ -654,9 +599,8 @@ theorem idempotentQuotientMap_injective_of_finite {S : Type*} [CommRing S] [Alge
 
 /-- For a finite algebra over a Henselian pair, the quotient map is injective on
 orthogonal systems of idempotents. -/
-theorem orthogonalIdempotentsQuotientMap_injective_of_finite {S : Type*} [CommRing S]
-    [Algebra R S] [Module.Finite R S] {I : Ideal R} (h : IsHenselianPair R I)
-    {ι : Type*} :
+theorem orthogonalIdempotentsQuotientMap_injective_of_finite {S : Type*} [CommRing S] [Algebra R S]
+    [Module.Finite R S] {I : Ideal R} (h : IsHenselianPair R I) {ι : Type*} :
     Function.Injective
       (orthogonalIdempotentsQuotientMapOfAlgebra (R := R) (S := S) (I := I) (ι := ι)) :=
   orthogonalIdempotentsQuotientMap_injective_of_isIntegral h

--- a/FLT/Slop/HenselianPair/Polynomial.lean
+++ b/FLT/Slop/HenselianPair/Polynomial.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import Mathlib.Algebra.Polynomial.Degree.IsMonicOfDegree
+public import Mathlib.Algebra.Polynomial.Identities
+public import Mathlib.RingTheory.Henselian
+
+/-!
+# Polynomial helpers for Henselian pairs
+
+Uniqueness of simple-root lifts under only the Jacobson-radical hypothesis, together with
+small computational lemmas about the polynomial
+`X ^ n * (X - 1) + ∑ i ∈ range (n + 1), a i * X ^ i` appearing in Stacks Tag 09XI(5).
+
+## Main results
+
+* `Polynomial.root_lift_unique_of_isUnit_derivative_of_le_jacobson` — uniqueness of a simple
+  root in its congruence class, using only `I ≤ Jac(R)`.
+* `Polynomial.coeff_sum_range_C_mul_X_pow`, `Polynomial.natDegree_sum_range_C_mul_X_pow_le`,
+  `Polynomial.monic_X_pow_mul_X_sub_C_one_add_sum_range_C_mul_X_pow` — coefficient, degree and
+  monicity of the Tag 09XI(5) polynomial.
+* `Polynomial.root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one_of_le_jacobson`
+  and variants — uniqueness of the root congruent to `1` modulo `I`.
+
+## References
+
+* [Stacks Project, Tag 09XI](https://stacks.math.columbia.edu/tag/09XI)
+-/
+
+@[expose] public section
+
+open Polynomial
+
+variable {R : Type*} [CommRing R]
+
+namespace Polynomial
+
+/-- If two roots of a polynomial are congruent to the same element modulo an
+ideal contained in the Jacobson radical, and the derivative at that element is a
+unit modulo the ideal, then the roots are equal.
+
+This is the Jacobson-radical uniqueness argument for simple roots. It is the
+uniqueness half of Hensel's lemma and does not use the existence/lifting
+property. -/
+theorem root_lift_unique_of_isUnit_derivative_of_le_jacobson {I : Ideal R}
+    (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) {f : R[X]} {a₀ a b : R}
+    (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - a₀ ∈ I) (hbI : b - a₀ ∈ I)
+    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) :
+    a = b := by
+  let d : R := a - b
+  have hdI : d ∈ I := by
+    have hsum : d = (a - a₀) - (b - a₀) := by ring
+    rw [hsum]
+    exact I.sub_mem haI hbI
+  obtain ⟨k, hk⟩ := binomExpansion f b d
+  have hroot_eq : f.eval (b + d) = 0 := by
+    have hbd : b + d = a := by simp [d]
+    rw [hbd]
+    exact ha
+  have hmul : (f.derivative.eval b + k * d) * d = 0 := by
+    have hk0 := hk
+    rw [hroot_eq, hb, zero_add] at hk0
+    have : f.derivative.eval b * d + k * d ^ 2 = 0 := hk0.symm
+    convert this using 1
+    ring
+  have hbcong : b ≡ a₀ [SMOD I] := SModEq.sub_mem.mpr hbI
+  have hderivdiff : f.derivative.eval b - f.derivative.eval a₀ ∈ I :=
+    SModEq.sub_mem.mp (hbcong.eval f.derivative)
+  have hunit_factor : IsUnit (f.derivative.eval b + k * d) := by
+    haveI : IsLocalHom (Ideal.Quotient.mk I) := isLocalHom_of_le_jacobson_bot I hI
+    apply IsUnit.of_map (Ideal.Quotient.mk I)
+    have heq_deriv :
+        Ideal.Quotient.mk I (f.derivative.eval b) =
+          Ideal.Quotient.mk I (f.derivative.eval a₀) :=
+      Ideal.Quotient.eq.mpr hderivdiff
+    have hkd : Ideal.Quotient.mk I (k * d) = 0 := by
+      have hdq : Ideal.Quotient.mk I d = 0 := Ideal.Quotient.eq_zero_iff_mem.mpr hdI
+      rw [map_mul, hdq, mul_zero]
+    rw [map_add, heq_deriv, hkd, add_zero]
+    exact hderiv
+  have hd0 : d = 0 := (IsUnit.mul_right_eq_zero hunit_factor).mp hmul
+  exact sub_eq_zero.mp hd0
+
+/-- If the coefficients of `f - X ^ n * (X - 1)` all lie in `I`, then `f`
+reduces modulo `I` to `X ^ n * (X - 1)`. -/
+theorem map_eq_X_pow_mul_X_sub_C_one_of_forall_coeff_sub_mem {I : Ideal R}
+    {f : R[X]} (n : ℕ)
+    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I) :
+    f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I)) := by
+  have hmap :
+      f.map (Ideal.Quotient.mk I) =
+        (X ^ n * (X - C (1 : R))).map (Ideal.Quotient.mk I) := by
+    ext k
+    have hk : Ideal.Quotient.mk I
+        ((f - X ^ n * (X - C (1 : R))).coeff k) = 0 :=
+      Ideal.Quotient.eq_zero_iff_mem.mpr (hcoeff k)
+    have hk' : Ideal.Quotient.mk I (f.coeff k) -
+        Ideal.Quotient.mk I ((X ^ n * (X - C (1 : R))).coeff k) = 0 := by
+      simpa [coeff_sub, map_sub] using hk
+    rw [coeff_map, coeff_map]
+    exact sub_eq_zero.mp hk'
+  simpa using hmap
+
+/-- Coefficients of the finite polynomial `∑ i = 0..n, aᵢ X^i`. -/
+theorem coeff_sum_range_C_mul_X_pow (n : ℕ) (a : ℕ → R) (k : ℕ) :
+    (∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).coeff k =
+      if k ≤ n then a k else 0 := by
+  by_cases hk : k ≤ n
+  · have hcoeff :
+        (∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).coeff k = a k := by
+      rw [finsetSum_coeff]
+      simp only [coeff_C_mul_X_pow, Finset.sum_ite_eq, Finset.mem_range,
+        Nat.lt_succ_iff]
+      simp [hk]
+    rw [hcoeff, if_pos hk]
+  · have hcoeff :
+        (∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).coeff k = 0 := by
+      rw [finsetSum_coeff]
+      simp only [coeff_C_mul_X_pow]
+      apply Finset.sum_eq_zero
+      intro i hi
+      have hi_le : i ≤ n := Nat.lt_succ_iff.mp (by simpa [Finset.mem_range] using hi)
+      have hki : k ≠ i :=
+        ne_of_gt (lt_of_le_of_lt hi_le (Nat.lt_of_not_ge hk))
+      simp [hki]
+    rw [hcoeff, if_neg hk]
+
+/-- The finite polynomial `∑ i = 0..n, aᵢ X^i` has degree at most `n`. -/
+theorem natDegree_sum_range_C_mul_X_pow_le (n : ℕ) (a : ℕ → R) :
+    (∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).natDegree ≤ n := by
+  refine natDegree_sum_le_of_forall_le _ _ ?_
+  intro i hi
+  exact (natDegree_C_mul_X_pow_le (a i) i).trans
+    (Nat.lt_succ_iff.mp (by simpa [Finset.mem_range] using hi))
+
+/-- The literal Stacks Tag 09XI(5) polynomial
+`X ^ n * (X - 1) + aₙ X ^ n + ... + a₀` is monic. -/
+theorem monic_X_pow_mul_X_sub_C_one_add_sum_range_C_mul_X_pow (n : ℕ) (a : ℕ → R) :
+    (X ^ n * (X - C (1 : R)) +
+      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).Monic := by
+  rcases subsingleton_or_nontrivial R with _ | _
+  · rw [Monic.def]
+    exact Subsingleton.elim _ _
+  · have hbase :
+        IsMonicOfDegree (X ^ n * (X - C (1 : R)) : R[X]) (n + 1) := by
+      simpa [sub_eq_add_neg, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
+        (isMonicOfDegree_X_pow R n).mul (isMonicOfDegree_X_add_one (-1 : R))
+    exact (hbase.add_right
+      (Nat.lt_succ_iff.mpr (natDegree_sum_range_C_mul_X_pow_le n a))).monic
+
+/-- Jacobson-only uniqueness in the quotient form of the Stacks Tag 09XI root
+condition.
+
+If `I ≤ Jac(R)`, `f ≡ X ^ n * (X - 1) mod I`, and two roots of `f` are
+congruent to `1` modulo `I`, then the roots are equal. -/
+theorem root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one_of_le_jacobson
+    {I : Ideal R} (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) {f : R[X]} (n : ℕ)
+    (hmod : f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I)))
+    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
+    (hbI : b - 1 ∈ I) :
+    a = b := by
+  apply root_lift_unique_of_isUnit_derivative_of_le_jacobson hI ha hb haI hbI
+  rw [← eval_map_apply, ← derivative_map, hmod]
+  simp [derivative_mul, eval_mul, eval_add, eval_sub, eval_X]
+
+/-- Jacobson-only uniqueness in the coefficientwise-congruence form of the
+Stacks Tag 09XI root condition. -/
+theorem root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
+    {I : Ideal R} (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) {f : R[X]} (n : ℕ)
+    (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I)
+    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
+    (hbI : b - 1 ∈ I) :
+    a = b :=
+  root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one_of_le_jacobson hI n
+    (map_eq_X_pow_mul_X_sub_C_one_of_forall_coeff_sub_mem n hcoeff) ha hb haI hbI
+
+/-- Jacobson-only uniqueness in the perturbation form of the Stacks Tag 09XI
+root condition. -/
+theorem root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one_of_le_jacobson
+    {I : Ideal R} (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) (n : ℕ) {p : R[X]}
+    (hp : ∀ k, p.coeff k ∈ I) {a b : R}
+    (ha : (X ^ n * (X - C (1 : R)) + p).IsRoot a)
+    (hb : (X ^ n * (X - C (1 : R)) + p).IsRoot b) (haI : a - 1 ∈ I)
+    (hbI : b - 1 ∈ I) :
+    a = b := by
+  apply root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
+    hI n ?_ ha hb haI hbI
+  intro k
+  simpa [coeff_sub, coeff_add, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hp k
+
+/-- Jacobson-only uniqueness in the literal finite-coefficient form of the
+Stacks Tag 09XI root condition.
+
+This is the uniqueness assertion in Stacks Tag 09XI(5): if
+`f = X ^ n * (X - 1) + aₙ X ^ n + ... + a₀` with all `aᵢ ∈ I`, then any two
+roots of `f` in `1 + I` are equal. -/
+theorem root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
+    {I : Ideal R} (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) (n : ℕ) (a : ℕ → R)
+    (ha_coeff : ∀ i ≤ n, a i ∈ I) {x y : R}
+    (hx : (X ^ n * (X - C (1 : R)) +
+      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x)
+    (hy : (X ^ n * (X - C (1 : R)) +
+      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot y)
+    (hxI : x - 1 ∈ I) (hyI : y - 1 ∈ I) :
+    x = y := by
+  apply root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one_of_le_jacobson
+    hI n ?_ hx hy hxI hyI
+  intro k
+  rw [coeff_sum_range_C_mul_X_pow n a k]
+  split_ifs with hk
+  · exact ha_coeff k hk
+  · exact I.zero_mem
+
+end Polynomial

--- a/FLT/Slop/HenselianPair/Polynomial.lean
+++ b/FLT/Slop/HenselianPair/Polynomial.lean
@@ -47,106 +47,54 @@ This is the Jacobson-radical uniqueness argument for simple roots. It is the
 uniqueness half of Hensel's lemma and does not use the existence/lifting
 property. -/
 theorem root_lift_unique_of_isUnit_derivative_of_le_jacobson {I : Ideal R}
-    (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) {f : R[X]} {a₀ a b : R}
-    (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - a₀ ∈ I) (hbI : b - a₀ ∈ I)
-    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) :
-    a = b := by
+    (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) {f : R[X]} {a₀ a b : R} (ha : f.IsRoot a)
+    (hb : f.IsRoot b) (haI : a - a₀ ∈ I) (hbI : b - a₀ ∈ I)
+    (hderiv : IsUnit (Ideal.Quotient.mk I (f.derivative.eval a₀))) : a = b := by
   let d : R := a - b
-  have hdI : d ∈ I := by
-    have hsum : d = (a - a₀) - (b - a₀) := by ring
-    rw [hsum]
-    exact I.sub_mem haI hbI
+  have hdI : d ∈ I := by simpa only [d, sub_sub_sub_cancel_right] using I.sub_mem haI hbI
   obtain ⟨k, hk⟩ := binomExpansion f b d
-  have hroot_eq : f.eval (b + d) = 0 := by
-    have hbd : b + d = a := by simp [d]
-    rw [hbd]
-    exact ha
+  have hroot_eq : f.eval (b + d) = 0 := by simpa [d] using ha
   have hmul : (f.derivative.eval b + k * d) * d = 0 := by
-    have hk0 := hk
-    rw [hroot_eq, hb, zero_add] at hk0
-    have : f.derivative.eval b * d + k * d ^ 2 = 0 := hk0.symm
-    convert this using 1
-    ring
-  have hbcong : b ≡ a₀ [SMOD I] := SModEq.sub_mem.mpr hbI
+    rw [hroot_eq, hb, zero_add] at hk
+    linear_combination -hk
   have hderivdiff : f.derivative.eval b - f.derivative.eval a₀ ∈ I :=
-    SModEq.sub_mem.mp (hbcong.eval f.derivative)
+    SModEq.sub_mem.mp ((SModEq.sub_mem.mpr hbI).eval f.derivative)
   have hunit_factor : IsUnit (f.derivative.eval b + k * d) := by
-    haveI : IsLocalHom (Ideal.Quotient.mk I) := isLocalHom_of_le_jacobson_bot I hI
+    have : IsLocalHom (Ideal.Quotient.mk I) := isLocalHom_of_le_jacobson_bot I hI
     apply IsUnit.of_map (Ideal.Quotient.mk I)
-    have heq_deriv :
-        Ideal.Quotient.mk I (f.derivative.eval b) =
-          Ideal.Quotient.mk I (f.derivative.eval a₀) :=
-      Ideal.Quotient.eq.mpr hderivdiff
-    have hkd : Ideal.Quotient.mk I (k * d) = 0 := by
-      have hdq : Ideal.Quotient.mk I d = 0 := Ideal.Quotient.eq_zero_iff_mem.mpr hdI
-      rw [map_mul, hdq, mul_zero]
-    rw [map_add, heq_deriv, hkd, add_zero]
-    exact hderiv
-  have hd0 : d = 0 := (IsUnit.mul_right_eq_zero hunit_factor).mp hmul
-  exact sub_eq_zero.mp hd0
+    rwa [map_add, Ideal.Quotient.eq.mpr hderivdiff,
+      Ideal.Quotient.eq_zero_iff_mem.mpr (I.mul_mem_left k hdI), add_zero]
+  exact sub_eq_zero.mp ((IsUnit.mul_right_eq_zero hunit_factor).mp hmul)
 
 /-- If the coefficients of `f - X ^ n * (X - 1)` all lie in `I`, then `f`
 reduces modulo `I` to `X ^ n * (X - 1)`. -/
-theorem map_eq_X_pow_mul_X_sub_C_one_of_forall_coeff_sub_mem {I : Ideal R}
-    {f : R[X]} (n : ℕ)
+theorem map_eq_X_pow_mul_X_sub_C_one_of_forall_coeff_sub_mem {I : Ideal R} {f : R[X]} (n : ℕ)
     (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I) :
     f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I)) := by
-  have hmap :
-      f.map (Ideal.Quotient.mk I) =
-        (X ^ n * (X - C (1 : R))).map (Ideal.Quotient.mk I) := by
+  have key : (f - X ^ n * (X - C (1 : R))).map (Ideal.Quotient.mk I) = 0 := by
     ext k
-    have hk : Ideal.Quotient.mk I
-        ((f - X ^ n * (X - C (1 : R))).coeff k) = 0 :=
-      Ideal.Quotient.eq_zero_iff_mem.mpr (hcoeff k)
-    have hk' : Ideal.Quotient.mk I (f.coeff k) -
-        Ideal.Quotient.mk I ((X ^ n * (X - C (1 : R))).coeff k) = 0 := by
-      simpa [coeff_sub, map_sub] using hk
-    rw [coeff_map, coeff_map]
-    exact sub_eq_zero.mp hk'
-  simpa using hmap
+    rw [coeff_map, coeff_zero]
+    exact Ideal.Quotient.eq_zero_iff_mem.mpr (hcoeff k)
+  simpa [Polynomial.map_sub, sub_eq_zero] using key
 
 /-- Coefficients of the finite polynomial `∑ i = 0..n, aᵢ X^i`. -/
 theorem coeff_sum_range_C_mul_X_pow (n : ℕ) (a : ℕ → R) (k : ℕ) :
-    (∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).coeff k =
-      if k ≤ n then a k else 0 := by
-  by_cases hk : k ≤ n
-  · have hcoeff :
-        (∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).coeff k = a k := by
-      rw [finsetSum_coeff]
-      simp only [coeff_C_mul_X_pow, Finset.sum_ite_eq, Finset.mem_range,
-        Nat.lt_succ_iff]
-      simp [hk]
-    rw [hcoeff, if_pos hk]
-  · have hcoeff :
-        (∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).coeff k = 0 := by
-      rw [finsetSum_coeff]
-      simp only [coeff_C_mul_X_pow]
-      apply Finset.sum_eq_zero
-      intro i hi
-      have hi_le : i ≤ n := Nat.lt_succ_iff.mp (by simpa [Finset.mem_range] using hi)
-      have hki : k ≠ i :=
-        ne_of_gt (lt_of_le_of_lt hi_le (Nat.lt_of_not_ge hk))
-      simp [hki]
-    rw [hcoeff, if_neg hk]
+    (∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).coeff k = if k ≤ n then a k else 0 := by
+  simp
 
 /-- The finite polynomial `∑ i = 0..n, aᵢ X^i` has degree at most `n`. -/
 theorem natDegree_sum_range_C_mul_X_pow_le (n : ℕ) (a : ℕ → R) :
-    (∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).natDegree ≤ n := by
-  refine natDegree_sum_le_of_forall_le _ _ ?_
-  intro i hi
-  exact (natDegree_C_mul_X_pow_le (a i) i).trans
-    (Nat.lt_succ_iff.mp (by simpa [Finset.mem_range] using hi))
+    (∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).natDegree ≤ n :=
+  natDegree_sum_le_of_forall_le _ _ fun i hi ↦
+    (natDegree_C_mul_X_pow_le (a i) i).trans (Nat.lt_succ_iff.mp (Finset.mem_range.mp hi))
 
 /-- The literal Stacks Tag 09XI(5) polynomial
 `X ^ n * (X - 1) + aₙ X ^ n + ... + a₀` is monic. -/
 theorem monic_X_pow_mul_X_sub_C_one_add_sum_range_C_mul_X_pow (n : ℕ) (a : ℕ → R) :
-    (X ^ n * (X - C (1 : R)) +
-      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).Monic := by
+    (X ^ n * (X - C (1 : R)) + ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i : R[X]).Monic := by
   rcases subsingleton_or_nontrivial R with _ | _
-  · rw [Monic.def]
-    exact Subsingleton.elim _ _
-  · have hbase :
-        IsMonicOfDegree (X ^ n * (X - C (1 : R)) : R[X]) (n + 1) := by
+  · exact Subsingleton.elim _ _
+  · have hbase : IsMonicOfDegree (X ^ n * (X - C (1 : R)) : R[X]) (n + 1) := by
       simpa [sub_eq_add_neg, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
         (isMonicOfDegree_X_pow R n).mul (isMonicOfDegree_X_add_one (-1 : R))
     exact (hbase.add_right
@@ -160,9 +108,7 @@ congruent to `1` modulo `I`, then the roots are equal. -/
 theorem root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one_of_le_jacobson
     {I : Ideal R} (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) {f : R[X]} (n : ℕ)
     (hmod : f.map (Ideal.Quotient.mk I) = X ^ n * (X - C (1 : R ⧸ I)))
-    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
-    (hbI : b - 1 ∈ I) :
-    a = b := by
+    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I) (hbI : b - 1 ∈ I) : a = b := by
   apply root_lift_unique_of_isUnit_derivative_of_le_jacobson hI ha hb haI hbI
   rw [← eval_map_apply, ← derivative_map, hmod]
   simp [derivative_mul, eval_mul, eval_add, eval_sub, eval_X]
@@ -172,9 +118,7 @@ Stacks Tag 09XI root condition. -/
 theorem root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
     {I : Ideal R} (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) {f : R[X]} (n : ℕ)
     (hcoeff : ∀ k, (f - X ^ n * (X - C (1 : R))).coeff k ∈ I)
-    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I)
-    (hbI : b - 1 ∈ I) :
-    a = b :=
+    {a b : R} (ha : f.IsRoot a) (hb : f.IsRoot b) (haI : a - 1 ∈ I) (hbI : b - 1 ∈ I) : a = b :=
   root_one_mod_unique_of_map_eq_X_pow_mul_X_sub_C_one_of_le_jacobson hI n
     (map_eq_X_pow_mul_X_sub_C_one_of_forall_coeff_sub_mem n hcoeff) ha hb haI hbI
 
@@ -182,14 +126,10 @@ theorem root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one_of_le_
 root condition. -/
 theorem root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one_of_le_jacobson
     {I : Ideal R} (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) (n : ℕ) {p : R[X]}
-    (hp : ∀ k, p.coeff k ∈ I) {a b : R}
-    (ha : (X ^ n * (X - C (1 : R)) + p).IsRoot a)
-    (hb : (X ^ n * (X - C (1 : R)) + p).IsRoot b) (haI : a - 1 ∈ I)
-    (hbI : b - 1 ∈ I) :
-    a = b := by
-  apply root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
-    hI n ?_ ha hb haI hbI
-  intro k
+    (hp : ∀ k, p.coeff k ∈ I) {a b : R} (ha : (X ^ n * (X - C (1 : R)) + p).IsRoot a)
+    (hb : (X ^ n * (X - C (1 : R)) + p).IsRoot b) (haI : a - 1 ∈ I) (hbI : b - 1 ∈ I) : a = b := by
+  refine root_one_mod_unique_of_forall_coeff_sub_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
+    hI n (fun k ↦ ?_) ha hb haI hbI
   simpa [coeff_sub, coeff_add, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hp k
 
 /-- Jacobson-only uniqueness in the literal finite-coefficient form of the
@@ -201,15 +141,11 @@ roots of `f` in `1 + I` are equal. -/
 theorem root_one_mod_unique_of_sum_range_coeff_mem_X_pow_mul_X_sub_C_one_of_le_jacobson
     {I : Ideal R} (hI : I ≤ Ideal.jacobson (⊥ : Ideal R)) (n : ℕ) (a : ℕ → R)
     (ha_coeff : ∀ i ≤ n, a i ∈ I) {x y : R}
-    (hx : (X ^ n * (X - C (1 : R)) +
-      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x)
-    (hy : (X ^ n * (X - C (1 : R)) +
-      ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot y)
-    (hxI : x - 1 ∈ I) (hyI : y - 1 ∈ I) :
-    x = y := by
-  apply root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one_of_le_jacobson
-    hI n ?_ hx hy hxI hyI
-  intro k
+    (hx : (X ^ n * (X - C (1 : R)) + ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot x)
+    (hy : (X ^ n * (X - C (1 : R)) + ∑ i ∈ Finset.range (n + 1), C (a i) * X ^ i).IsRoot y)
+    (hxI : x - 1 ∈ I) (hyI : y - 1 ∈ I) : x = y := by
+  refine root_one_mod_unique_of_forall_coeff_mem_add_X_pow_mul_X_sub_C_one_of_le_jacobson
+    hI n (fun k ↦ ?_) hx hy hxI hyI
   rw [coeff_sum_range_C_mul_X_pow n a k]
   split_ifs with hk
   · exact ha_coeff k hk

--- a/FLT/Slop/HenselianPair/Quotient.lean
+++ b/FLT/Slop/HenselianPair/Quotient.lean
@@ -1,0 +1,258 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.HenselianPair.Idempotents
+
+/-!
+# Quotients, subideals and enlargement of Henselian pairs
+
+Stability of the Henselian-pair condition under passing to quotients `R ⧸ J` for `J ≤ I`,
+under shrinking the ideal, and the converse gluing statement: `(R, I)` is Henselian as soon as
+`(R, K)` and `(R ⧸ K, I ⧸ K)` are, for `K ≤ I`.
+
+## Main results
+
+* `IsHenselianPair.quotient` — `(R ⧸ J, I · (R ⧸ J))` is Henselian for `J ≤ I` (Tag 09XG).
+* `IsHenselianPair.of_le` — `(R, I)` is Henselian whenever `(R, J)` is and `I ≤ J`.
+* `IsHenselianPair.of_quotient` — the converse gluing statement (Tag 0DYD).
+* `IsHenselianPair.iff_of_le_quotient` — the resulting characterisation.
+* `IsHenselianPair.factorization_unique_of_le_jacobson` — uniqueness of the lifted
+  coprime factorisation.
+
+## References
+
+* [Stacks Project, Tag 09XG](https://stacks.math.columbia.edu/tag/09XG)
+* [Stacks Project, Tag 0DYD](https://stacks.math.columbia.edu/tag/0DYD)
+-/
+
+@[expose] public section
+
+open Polynomial
+
+variable {R : Type*} [CommRing R]
+
+namespace IsHenselianPair
+
+/-- **Quotient stability** (Stacks Tag 09XG). If `(R, I)` is a Henselian pair and
+`J ≤ I`, then `(R ⧸ J, I·(R ⧸ J))` is again a Henselian pair. -/
+@[stacks 09XG]
+theorem quotient {I J : Ideal R} (h : IsHenselianPair R I) (hJI : J ≤ I) :
+    IsHenselianPair (R ⧸ J) (I.map (Ideal.Quotient.mk J)) where
+  le_jacobson := by
+    have h1 : I ≤ J.jacobson := le_trans h.le_jacobson (Ideal.jacobson_mono bot_le)
+    calc I.map (Ideal.Quotient.mk J)
+        ≤ J.jacobson.map (Ideal.Quotient.mk J) := Ideal.map_mono h1
+      _ = (J.map (Ideal.Quotient.mk J)).jacobson :=
+            Ideal.map_jacobson_of_surjective Ideal.Quotient.mk_surjective
+              (le_of_eq Ideal.mk_ker)
+      _ = Ideal.jacobson ⊥ := by rw [Ideal.map_quotient_self]
+  exists_lift_factorization := by
+    intro F hF g₀ h₀ hg₀ hh₀ hcop hFfact
+    -- `e : (R ⧸ J) ⧸ I' ≃+* R ⧸ I`, where `I' = I·(R ⧸ J)`.
+    set e := DoubleQuot.quotQuotEquivQuotOfLE hJI with he
+    -- the composite `(R ⧸ J) ⧸ I' ≃ R ⧸ I` identifies the two projections of `R`.
+    have hcomp :
+        (e.toRingHom.comp
+          (Ideal.Quotient.mk (I.map (Ideal.Quotient.mk J)))).comp (Ideal.Quotient.mk J)
+          = Ideal.Quotient.mk I := by
+      ext r; exact DoubleQuot.quotQuotEquivQuotOfLE_quotQuotMk r hJI
+    -- lift the monic `F` over `R ⧸ J` to a monic `f` over `R`.
+    obtain ⟨f, hfmap, -, hfmonic⟩ :=
+      Polynomial.lifts_and_natDegree_eq_and_monic
+        (Polynomial.mem_lifts_of_surjective Ideal.Quotient.mk_surjective F) hF
+    -- transport the factorisation of `F mod I'` to a factorisation of `f mod I`.
+    have hcop' : IsCoprime (g₀.map e.toRingHom) (h₀.map e.toRingHom) := by
+      simpa using hcop.map (Polynomial.mapRingHom e.toRingHom)
+    have ha : f.map (Ideal.Quotient.mk I) = g₀.map e.toRingHom * h₀.map e.toRingHom := by
+      rw [← hcomp, ← Polynomial.map_map, ← Polynomial.map_map, hfmap, hFfact,
+        Polynomial.map_mul]
+    obtain ⟨g, hh, hgm, hhm, hfgh, hgmap, hhmap⟩ :=
+      h.exists_lift_factorization f hfmonic (hg₀.map _) (hh₀.map _) hcop' ha
+    -- push the lifted factorisation down to `R ⧸ J`.
+    refine ⟨g.map (Ideal.Quotient.mk J), hh.map (Ideal.Quotient.mk J), hgm.map _, hhm.map _,
+      ?_, ?_, ?_⟩
+    · rw [← Polynomial.map_mul, ← hfgh, hfmap]
+    · apply Polynomial.map_injective e.toRingHom e.injective
+      rw [Polynomial.map_map, Polynomial.map_map, hcomp, hgmap]
+    · apply Polynomial.map_injective e.toRingHom e.injective
+      rw [Polynomial.map_map, Polynomial.map_map, hcomp, hhmap]
+
+/-- If `K ≤ Jac(R)` and `I/K ≤ Jac(R/K)`, then `I ≤ Jac(R)`. -/
+theorem le_jacobson_bot_of_map_le_jacobson {K I : Ideal R}
+    (hK : K ≤ Ideal.jacobson (⊥ : Ideal R))
+    (hI : I.map (Ideal.Quotient.mk K) ≤ Ideal.jacobson (⊥ : Ideal (R ⧸ K))) :
+    I ≤ Ideal.jacobson (⊥ : Ideal R) := by
+  intro x hx
+  rw [Ideal.mem_jacobson_bot]
+  intro y
+  haveI : IsLocalHom (Ideal.Quotient.mk K) := isLocalHom_of_le_jacobson_bot K hK
+  refine IsUnit.of_map (Ideal.Quotient.mk K) _ ?_
+  have hxq : Ideal.Quotient.mk K x ∈ I.map (Ideal.Quotient.mk K) :=
+    Ideal.mem_map_of_mem _ hx
+  have hunit := (Ideal.mem_jacobson_bot.mp (hI hxq)) (Ideal.Quotient.mk K y)
+  simpa [map_mul] using hunit
+
+/-- **Dévissage for Henselian pairs along a quotient ideal** (Stacks Tag 0DYD,
+hard direction).  Suppose `K ≤ I`, `(R, K)` is a Henselian pair, and
+`(R ⧸ K, I·(R ⧸ K))` is a Henselian pair.  Then `(R, I)` is a Henselian pair.
+
+Given a coprime monic factorisation of `f mod I`, first lift it to `R ⧸ K`
+using the quotient pair.  The intermediate factors are coprime over `R ⧸ K`
+because their reductions are coprime modulo an ideal in the Jacobson radical
+and both factors are monic; this is where the resultant/Jacobson lemma enters.
+Then lift the factorisation from `R ⧸ K` to `R` using `(R, K)`. -/
+@[stacks 0DYD]
+theorem of_quotient {K I : Ideal R} (hKI : K ≤ I)
+    (hRK : IsHenselianPair R K)
+    (hquot : IsHenselianPair (R ⧸ K) (I.map (Ideal.Quotient.mk K))) :
+    IsHenselianPair R I where
+  le_jacobson := le_jacobson_bot_of_map_le_jacobson hRK.le_jacobson hquot.le_jacobson
+  exists_lift_factorization := by
+    intro f hf g₀ h₀ hg₀ hh₀ hcop hfact
+    set e := DoubleQuot.quotQuotEquivQuotOfLE hKI with he
+    -- `e : (R ⧸ K) ⧸ (I·(R ⧸ K)) ≃+* R ⧸ I` identifies the two projections of `R`.
+    have hcomp : (e.toRingHom.comp (Ideal.Quotient.mk (I.map (Ideal.Quotient.mk K)))).comp
+        (Ideal.Quotient.mk K) = Ideal.Quotient.mk I := by
+      ext r; exact DoubleQuot.quotQuotEquivQuotOfLE_quotQuotMk r hKI
+    have hee : e.toRingHom.comp e.symm.toRingHom = RingHom.id (R ⧸ I) :=
+      RingHom.ext fun x => by
+        rw [RingHom.comp_apply, RingHom.id_apply]; exact e.apply_symm_apply x
+    have hmap3 : ∀ p : R[X],
+        ((p.map (Ideal.Quotient.mk K)).map
+          (Ideal.Quotient.mk (I.map (Ideal.Quotient.mk K)))).map e.toRingHom
+          = p.map (Ideal.Quotient.mk I) := fun p => by
+      rw [Polynomial.map_map, Polynomial.map_map, hcomp]
+    -- Pull the given factorisation of `f mod I` back along `e` to `(R ⧸ K) ⧸ (I·)`.
+    have hcop' : IsCoprime (g₀.map e.symm.toRingHom) (h₀.map e.symm.toRingHom) := by
+      obtain ⟨a, b, hab⟩ := hcop
+      exact ⟨a.map e.symm.toRingHom, b.map e.symm.toRingHom, by
+        rw [← Polynomial.map_mul, ← Polynomial.map_mul, ← Polynomial.map_add, hab,
+          Polynomial.map_one]⟩
+    have hf1fact : (f.map (Ideal.Quotient.mk K)).map
+        (Ideal.Quotient.mk (I.map (Ideal.Quotient.mk K)))
+        = g₀.map e.symm.toRingHom * h₀.map e.symm.toRingHom := by
+      apply Polynomial.map_injective e.toRingHom e.injective
+      rw [hmap3 f, hfact, Polynomial.map_mul, Polynomial.map_map, Polynomial.map_map, hee]
+      simp only [Polynomial.map_id]
+    -- Step 1: lift the factorisation to `R ⧸ K` using the henselian quotient pair.
+    obtain ⟨g₁, h₁, hg₁mon, hh₁mon, hf1, hg₁map, hh₁map⟩ :=
+      hquot.exists_lift_factorization (f.map (Ideal.Quotient.mk K)) (hf.map _)
+        (hg₀.map _) (hh₀.map _) hcop' hf1fact
+    -- Coprimality of `g₁, h₁` over `R ⧸ K`, lifted across the Jacobson quotient.
+    have hcop1 : IsCoprime g₁ h₁ :=
+      isCoprime_of_monic_of_isCoprime_map_quotient_of_le_jacobson hquot.le_jacobson
+        hg₁mon hh₁mon (by rw [hg₁map, hh₁map]; exact hcop')
+    -- Step 2: lift from `R ⧸ K` to `R` using the Henselian pair `(R, K)`.
+    obtain ⟨g, q, hgmon, hqmon, hfgh, hgmapK, hqmapK⟩ :=
+      hRK.exists_lift_factorization f hf hg₁mon hh₁mon hcop1 hf1
+    refine ⟨g, q, hgmon, hqmon, hfgh, ?_, ?_⟩
+    · rw [← hmap3 g, hgmapK, hg₁map, Polynomial.map_map, hee, Polynomial.map_id]
+    · rw [← hmap3 q, hqmapK, hh₁map, Polynomial.map_map, hee, Polynomial.map_id]
+
+/-- **Uniqueness of a Henselian coprime monic factorisation lift across a
+Jacobson-radical quotient.**  This is the uniqueness half used to shrink the
+ideal of a Henselian pair.
+
+If `I ≤ Jac(R)`, two monic factorisations with the same product and the same
+coprime reductions modulo `I` are equal. -/
+theorem factorization_unique_of_le_jacobson {I : Ideal R}
+    (hI : I ≤ Ideal.jacobson (⊥ : Ideal R))
+    {g h g' h' : R[X]} (hgmon : g.Monic) (hhmon : h.Monic)
+    (hg'mon : g'.Monic) (hh'mon : h'.Monic)
+    (hcop : IsCoprime (g.map (Ideal.Quotient.mk I)) (h.map (Ideal.Quotient.mk I)))
+    (hg' : g.map (Ideal.Quotient.mk I) = g'.map (Ideal.Quotient.mk I))
+    (hhh' : h.map (Ideal.Quotient.mk I) = h'.map (Ideal.Quotient.mk I))
+    (hgh : g * h = g' * h') : g = g' ∧ h = h' := by
+  have hcop_gh' : IsCoprime g h' :=
+    isCoprime_of_monic_of_isCoprime_map_quotient_of_le_jacobson hI hgmon hh'mon
+      (by rw [← hhh']; exact hcop)
+  have hcop_g'h : IsCoprime g' h :=
+    isCoprime_of_monic_of_isCoprime_map_quotient_of_le_jacobson hI hg'mon hhmon
+      (show IsCoprime (g'.map (Ideal.Quotient.mk I)) (h.map (Ideal.Quotient.mk I)) by
+        rw [← hg']; exact hcop)
+  -- `g ∣ g'` and `g' ∣ g`, hence (both monic) `g = g'`.
+  have hdvd1 : g ∣ g' := hcop_gh'.dvd_of_dvd_mul_right ⟨h, hgh.symm⟩
+  have hdvd2 : g' ∣ g := hcop_g'h.dvd_of_dvd_mul_right ⟨h', hgh⟩
+  obtain ⟨c, hc⟩ := hdvd1
+  obtain ⟨d, hd⟩ := hdvd2
+  have cmon : c.Monic := hgmon.of_mul_monic_left (hc ▸ hg'mon)
+  have hg_cd : g * (c * d) = g := by rw [← mul_assoc, ← hc, ← hd]
+  have hcd1 : c * d = 1 :=
+    sub_eq_zero.mp (hgmon.mul_right_eq_zero_iff.mp (by rw [mul_sub, mul_one, hg_cd, sub_self]))
+  have hcunit : IsUnit c := ⟨⟨c, d, hcd1, by rw [mul_comm]; exact hcd1⟩, rfl⟩
+  have hgeq : g = g' := by
+    rw [hc, cmon.eq_one_of_isUnit hcunit, mul_one]
+  -- Monic cancellation of `g` gives `h = h'`.
+  have hheq : h = h' :=
+    sub_eq_zero.mp (hgmon.mul_right_eq_zero_iff.mp (by rw [mul_sub, hgh, hgeq, sub_self]))
+  exact ⟨hgeq, hheq⟩
+
+/-- **Shrinking the ideal of a Henselian pair** (one direction of Stacks Tag
+0DYD).  If `(R, J)` is a Henselian pair and `I ≤ J`, then `(R, I)` is a
+Henselian pair. -/
+theorem of_le {I J : Ideal R} (h : IsHenselianPair R J) (hIJ : I ≤ J) :
+    IsHenselianPair R I where
+  le_jacobson := le_trans hIJ h.le_jacobson
+  exists_lift_factorization := by
+    intro f hf g₀ h₀ hg₀ hh₀ hcop hfact
+    set K : Ideal (R ⧸ I) := J.map (Ideal.Quotient.mk I) with hK
+    set e := DoubleQuot.quotQuotEquivQuotOfLE hIJ with he
+    set q : R ⧸ I →+* R ⧸ J := e.toRingHom.comp (Ideal.Quotient.mk K) with hq
+    have hcomp : q.comp (Ideal.Quotient.mk I) = Ideal.Quotient.mk J := by
+      ext r
+      exact DoubleQuot.quotQuotEquivQuotOfLE_quotQuotMk r hIJ
+    have hKjac : K ≤ Ideal.jacobson (⊥ : Ideal (R ⧸ I)) := by
+      rw [hK]
+      exact (h.quotient hIJ).le_jacobson
+    have hcopJ : IsCoprime (g₀.map q) (h₀.map q) :=
+      hcop.map (Polynomial.mapRingHom q)
+    have hfactJ : f.map (Ideal.Quotient.mk J) = g₀.map q * h₀.map q := by
+      rw [← hcomp, ← Polynomial.map_map, hfact, Polynomial.map_mul]
+    obtain ⟨g, h', hgmon, hhmon, hfgh, hgJ, hhJ⟩ :=
+      h.exists_lift_factorization f hf (hg₀.map _) (hh₀.map _) hcopJ hfactJ
+    have hprodI : g₀ * h₀ =
+        g.map (Ideal.Quotient.mk I) * h'.map (Ideal.Quotient.mk I) := by
+      rw [← hfact, hfgh, Polynomial.map_mul]
+    have hcopK :
+        IsCoprime (g₀.map (Ideal.Quotient.mk K)) (h₀.map (Ideal.Quotient.mk K)) := by
+      obtain ⟨a, b, hab⟩ := hcop
+      exact ⟨a.map (Ideal.Quotient.mk K), b.map (Ideal.Quotient.mk K), by
+        rw [← Polynomial.map_mul, ← Polynomial.map_mul, ← Polynomial.map_add, hab,
+          Polynomial.map_one]⟩
+    have hgK : g₀.map (Ideal.Quotient.mk K) =
+        (g.map (Ideal.Quotient.mk I)).map (Ideal.Quotient.mk K) := by
+      apply Polynomial.map_injective e.toRingHom e.injective
+      rw [Polynomial.map_map, Polynomial.map_map, ← hq, Polynomial.map_map, hcomp, hgJ]
+    have hhK : h₀.map (Ideal.Quotient.mk K) =
+        (h'.map (Ideal.Quotient.mk I)).map (Ideal.Quotient.mk K) := by
+      apply Polynomial.map_injective e.toRingHom e.injective
+      rw [Polynomial.map_map, Polynomial.map_map, ← hq, Polynomial.map_map, hcomp, hhJ]
+    obtain ⟨hgI, hhI⟩ :=
+      factorization_unique_of_le_jacobson hKjac hg₀ hh₀ (hgmon.map _) (hhmon.map _)
+        hcopK hgK hhK hprodI
+    exact ⟨g, h', hgmon, hhmon, hfgh, hgI.symm, hhI.symm⟩
+
+/-- **Two-step criterion for Henselian pairs** (Stacks Tag 0DYD).  For `I ≤ J`,
+if `(R, I)` and `(R ⧸ I, J·(R ⧸ I))` are Henselian pairs, then `(R, J)` is a
+Henselian pair. -/
+theorem of_le_of_quotient {I J : Ideal R} (hIJ : I ≤ J)
+    (hI : IsHenselianPair R I)
+    (hquot : IsHenselianPair (R ⧸ I) (J.map (Ideal.Quotient.mk I))) :
+    IsHenselianPair R J :=
+  of_quotient hIJ hI hquot
+
+/-- **Stacks Tag 0DYD.**  For `I ≤ J`, the pair `(R, J)` is Henselian iff
+`(R, I)` is Henselian and the quotient pair
+`(R ⧸ I, J·(R ⧸ I))` is Henselian. -/
+@[stacks 0DYD]
+theorem iff_of_le_quotient {I J : Ideal R} (hIJ : I ≤ J) :
+    IsHenselianPair R J ↔
+      IsHenselianPair R I ∧ IsHenselianPair (R ⧸ I) (J.map (Ideal.Quotient.mk I)) :=
+  ⟨fun h => ⟨h.of_le hIJ, h.quotient hIJ⟩,
+    fun h => of_le_of_quotient hIJ h.1 h.2⟩
+
+end IsHenselianPair

--- a/FLT/Slop/HenselianPair/Quotient.lean
+++ b/FLT/Slop/HenselianPair/Quotient.lean
@@ -53,7 +53,7 @@ theorem quotient {I J : Ideal R} (h : IsHenselianPair R I) (hJI : J ≤ I) :
   exists_lift_factorization := by
     intro F hF g₀ h₀ hg₀ hh₀ hcop hFfact
     -- `e : (R ⧸ J) ⧸ I' ≃+* R ⧸ I`, where `I' = I·(R ⧸ J)`.
-    set e := DoubleQuot.quotQuotEquivQuotOfLE hJI with he
+    set e := DoubleQuot.quotQuotEquivQuotOfLE hJI
     -- the composite `(R ⧸ J) ⧸ I' ≃ R ⧸ I` identifies the two projections of `R`.
     have hcomp :
         (e.toRingHom.comp
@@ -86,52 +86,38 @@ theorem le_jacobson_bot_of_map_le_jacobson {K I : Ideal R}
     (hK : K ≤ Ideal.jacobson (⊥ : Ideal R))
     (hI : I.map (Ideal.Quotient.mk K) ≤ Ideal.jacobson (⊥ : Ideal (R ⧸ K))) :
     I ≤ Ideal.jacobson (⊥ : Ideal R) := by
-  intro x hx
-  rw [Ideal.mem_jacobson_bot]
-  intro y
-  haveI : IsLocalHom (Ideal.Quotient.mk K) := isLocalHom_of_le_jacobson_bot K hK
-  refine IsUnit.of_map (Ideal.Quotient.mk K) _ ?_
-  have hxq : Ideal.Quotient.mk K x ∈ I.map (Ideal.Quotient.mk K) :=
-    Ideal.mem_map_of_mem _ hx
-  have hunit := (Ideal.mem_jacobson_bot.mp (hI hxq)) (Ideal.Quotient.mk K y)
-  simpa [map_mul] using hunit
+  calc I ≤ (I.map (Ideal.Quotient.mk K)).comap (Ideal.Quotient.mk K) := Ideal.le_comap_map
+    _ ≤ (Ideal.jacobson ⊥).comap (Ideal.Quotient.mk K) := Ideal.comap_mono hI
+    _ = Ideal.jacobson (Ideal.comap (Ideal.Quotient.mk K) ⊥) :=
+        Ideal.comap_jacobson_of_surjective Ideal.Quotient.mk_surjective
+    _ = K.jacobson := by rw [← RingHom.ker_eq_comap_bot, Ideal.mk_ker]
+    _ ≤ Ideal.jacobson ⊥ := (Ideal.jacobson_mono hK).trans Ideal.jacobson_idem.le
 
 /-- **Dévissage for Henselian pairs along a quotient ideal** (Stacks Tag 0DYD,
 hard direction).  Suppose `K ≤ I`, `(R, K)` is a Henselian pair, and
-`(R ⧸ K, I·(R ⧸ K))` is a Henselian pair.  Then `(R, I)` is a Henselian pair.
-
-Given a coprime monic factorisation of `f mod I`, first lift it to `R ⧸ K`
-using the quotient pair.  The intermediate factors are coprime over `R ⧸ K`
-because their reductions are coprime modulo an ideal in the Jacobson radical
-and both factors are monic; this is where the resultant/Jacobson lemma enters.
-Then lift the factorisation from `R ⧸ K` to `R` using `(R, K)`. -/
+`(R ⧸ K, I·(R ⧸ K))` is a Henselian pair.  Then `(R, I)` is a Henselian pair. -/
 @[stacks 0DYD]
-theorem of_quotient {K I : Ideal R} (hKI : K ≤ I)
-    (hRK : IsHenselianPair R K)
+theorem of_quotient {K I : Ideal R} (hKI : K ≤ I) (hRK : IsHenselianPair R K)
     (hquot : IsHenselianPair (R ⧸ K) (I.map (Ideal.Quotient.mk K))) :
     IsHenselianPair R I where
   le_jacobson := le_jacobson_bot_of_map_le_jacobson hRK.le_jacobson hquot.le_jacobson
   exists_lift_factorization := by
     intro f hf g₀ h₀ hg₀ hh₀ hcop hfact
-    set e := DoubleQuot.quotQuotEquivQuotOfLE hKI with he
+    set e := DoubleQuot.quotQuotEquivQuotOfLE hKI
     -- `e : (R ⧸ K) ⧸ (I·(R ⧸ K)) ≃+* R ⧸ I` identifies the two projections of `R`.
     have hcomp : (e.toRingHom.comp (Ideal.Quotient.mk (I.map (Ideal.Quotient.mk K)))).comp
         (Ideal.Quotient.mk K) = Ideal.Quotient.mk I := by
-      ext r; exact DoubleQuot.quotQuotEquivQuotOfLE_quotQuotMk r hKI
-    have hee : e.toRingHom.comp e.symm.toRingHom = RingHom.id (R ⧸ I) :=
-      RingHom.ext fun x => by
-        rw [RingHom.comp_apply, RingHom.id_apply]; exact e.apply_symm_apply x
+      ext r
+      exact DoubleQuot.quotQuotEquivQuotOfLE_quotQuotMk r hKI
+    have hee := e.toRingHom_comp_symm_toRingHom
     have hmap3 : ∀ p : R[X],
         ((p.map (Ideal.Quotient.mk K)).map
           (Ideal.Quotient.mk (I.map (Ideal.Quotient.mk K)))).map e.toRingHom
-          = p.map (Ideal.Quotient.mk I) := fun p => by
+          = p.map (Ideal.Quotient.mk I) := fun p ↦ by
       rw [Polynomial.map_map, Polynomial.map_map, hcomp]
     -- Pull the given factorisation of `f mod I` back along `e` to `(R ⧸ K) ⧸ (I·)`.
     have hcop' : IsCoprime (g₀.map e.symm.toRingHom) (h₀.map e.symm.toRingHom) := by
-      obtain ⟨a, b, hab⟩ := hcop
-      exact ⟨a.map e.symm.toRingHom, b.map e.symm.toRingHom, by
-        rw [← Polynomial.map_mul, ← Polynomial.map_mul, ← Polynomial.map_add, hab,
-          Polynomial.map_one]⟩
+      simpa using hcop.map (Polynomial.mapRingHom e.symm.toRingHom)
     have hf1fact : (f.map (Ideal.Quotient.mk K)).map
         (Ideal.Quotient.mk (I.map (Ideal.Quotient.mk K)))
         = g₀.map e.symm.toRingHom * h₀.map e.symm.toRingHom := by
@@ -145,7 +131,7 @@ theorem of_quotient {K I : Ideal R} (hKI : K ≤ I)
     -- Coprimality of `g₁, h₁` over `R ⧸ K`, lifted across the Jacobson quotient.
     have hcop1 : IsCoprime g₁ h₁ :=
       isCoprime_of_monic_of_isCoprime_map_quotient_of_le_jacobson hquot.le_jacobson
-        hg₁mon hh₁mon (by rw [hg₁map, hh₁map]; exact hcop')
+        hg₁mon hh₁mon (by rwa [hg₁map, hh₁map])
     -- Step 2: lift from `R ⧸ K` to `R` using the Henselian pair `(R, K)`.
     obtain ⟨g, q, hgmon, hqmon, hfgh, hgmapK, hqmapK⟩ :=
       hRK.exists_lift_factorization f hf hg₁mon hh₁mon hcop1 hf1
@@ -179,13 +165,11 @@ theorem factorization_unique_of_le_jacobson {I : Ideal R}
   have hdvd2 : g' ∣ g := hcop_g'h.dvd_of_dvd_mul_right ⟨h', hgh⟩
   obtain ⟨c, hc⟩ := hdvd1
   obtain ⟨d, hd⟩ := hdvd2
-  have cmon : c.Monic := hgmon.of_mul_monic_left (hc ▸ hg'mon)
-  have hg_cd : g * (c * d) = g := by rw [← mul_assoc, ← hc, ← hd]
   have hcd1 : c * d = 1 :=
-    sub_eq_zero.mp (hgmon.mul_right_eq_zero_iff.mp (by rw [mul_sub, mul_one, hg_cd, sub_self]))
-  have hcunit : IsUnit c := ⟨⟨c, d, hcd1, by rw [mul_comm]; exact hcd1⟩, rfl⟩
-  have hgeq : g = g' := by
-    rw [hc, cmon.eq_one_of_isUnit hcunit, mul_one]
+    sub_eq_zero.mp (hgmon.mul_right_eq_zero_iff.mp
+      (by rw [mul_sub, mul_one, ← mul_assoc, ← hc, ← hd, sub_self]))
+  have hgeq : g = g' :=
+    eq_of_monic_of_associated hgmon hg'mon ⟨⟨c, d, hcd1, by rw [mul_comm]; exact hcd1⟩, hc.symm⟩
   -- Monic cancellation of `g` gives `h = h'`.
   have hheq : h = h' :=
     sub_eq_zero.mp (hgmon.mul_right_eq_zero_iff.mp (by rw [mul_sub, hgh, hgeq, sub_self]))
@@ -194,13 +178,12 @@ theorem factorization_unique_of_le_jacobson {I : Ideal R}
 /-- **Shrinking the ideal of a Henselian pair** (one direction of Stacks Tag
 0DYD).  If `(R, J)` is a Henselian pair and `I ≤ J`, then `(R, I)` is a
 Henselian pair. -/
-theorem of_le {I J : Ideal R} (h : IsHenselianPair R J) (hIJ : I ≤ J) :
-    IsHenselianPair R I where
-  le_jacobson := le_trans hIJ h.le_jacobson
+theorem of_le {I J : Ideal R} (h : IsHenselianPair R J) (hIJ : I ≤ J) : IsHenselianPair R I where
+  le_jacobson := hIJ.trans h.le_jacobson
   exists_lift_factorization := by
     intro f hf g₀ h₀ hg₀ hh₀ hcop hfact
     set K : Ideal (R ⧸ I) := J.map (Ideal.Quotient.mk I) with hK
-    set e := DoubleQuot.quotQuotEquivQuotOfLE hIJ with he
+    set e := DoubleQuot.quotQuotEquivQuotOfLE hIJ
     set q : R ⧸ I →+* R ⧸ J := e.toRingHom.comp (Ideal.Quotient.mk K) with hq
     have hcomp : q.comp (Ideal.Quotient.mk I) = Ideal.Quotient.mk J := by
       ext r
@@ -217,8 +200,7 @@ theorem of_le {I J : Ideal R} (h : IsHenselianPair R J) (hIJ : I ≤ J) :
     have hprodI : g₀ * h₀ =
         g.map (Ideal.Quotient.mk I) * h'.map (Ideal.Quotient.mk I) := by
       rw [← hfact, hfgh, Polynomial.map_mul]
-    have hcopK :
-        IsCoprime (g₀.map (Ideal.Quotient.mk K)) (h₀.map (Ideal.Quotient.mk K)) := by
+    have hcopK : IsCoprime (g₀.map (Ideal.Quotient.mk K)) (h₀.map (Ideal.Quotient.mk K)) := by
       obtain ⟨a, b, hab⟩ := hcop
       exact ⟨a.map (Ideal.Quotient.mk K), b.map (Ideal.Quotient.mk K), by
         rw [← Polynomial.map_mul, ← Polynomial.map_mul, ← Polynomial.map_add, hab,
@@ -239,10 +221,8 @@ theorem of_le {I J : Ideal R} (h : IsHenselianPair R J) (hIJ : I ≤ J) :
 /-- **Two-step criterion for Henselian pairs** (Stacks Tag 0DYD).  For `I ≤ J`,
 if `(R, I)` and `(R ⧸ I, J·(R ⧸ I))` are Henselian pairs, then `(R, J)` is a
 Henselian pair. -/
-theorem of_le_of_quotient {I J : Ideal R} (hIJ : I ≤ J)
-    (hI : IsHenselianPair R I)
-    (hquot : IsHenselianPair (R ⧸ I) (J.map (Ideal.Quotient.mk I))) :
-    IsHenselianPair R J :=
+theorem of_le_of_quotient {I J : Ideal R} (hIJ : I ≤ J) (hI : IsHenselianPair R I)
+    (hquot : IsHenselianPair (R ⧸ I) (J.map (Ideal.Quotient.mk I))) : IsHenselianPair R J :=
   of_quotient hIJ hI hquot
 
 /-- **Stacks Tag 0DYD.**  For `I ≤ J`, the pair `(R, J)` is Henselian iff
@@ -252,7 +232,7 @@ theorem of_le_of_quotient {I J : Ideal R} (hIJ : I ≤ J)
 theorem iff_of_le_quotient {I J : Ideal R} (hIJ : I ≤ J) :
     IsHenselianPair R J ↔
       IsHenselianPair R I ∧ IsHenselianPair (R ⧸ I) (J.map (Ideal.Quotient.mk I)) :=
-  ⟨fun h => ⟨h.of_le hIJ, h.quotient hIJ⟩,
-    fun h => of_le_of_quotient hIJ h.1 h.2⟩
+  ⟨fun h ↦ ⟨h.of_le hIJ, h.quotient hIJ⟩,
+    fun h ↦ of_le_of_quotient hIJ h.1 h.2⟩
 
 end IsHenselianPair

--- a/FLT/Slop/HenselianPair/README.md
+++ b/FLT/Slop/HenselianPair/README.md
@@ -1,0 +1,108 @@
+# Henselian Pairs
+
+This folder develops the theory of **Henselian pairs** `(R, I)` — the notion that
+underlies Hensel's lemma in its factorisation form. Mathlib has `HenselianRing R I`
+(a simple root of a monic polynomial over `R ⧸ I` lifts to a root over `R`) and
+`HenselianLocalRing R`, but it has **no** notion of a Henselian pair. This folder
+supplies one, following the Stacks Project (More on Algebra, §15.11, tag 09XD onwards),
+and is packaged so it can be upstreamed to Mathlib.
+
+## The definition
+
+```lean
+class IsHenselianPair (R : Type*) [CommRing R] (I : Ideal R) : Prop where
+  le_jacobson : I ≤ Ideal.jacobson ⊥
+  exists_lift_factorization : ∀ (f : R[X]), f.Monic →
+    ∀ {g₀ h₀ : (R ⧸ I)[X]}, g₀.Monic → h₀.Monic → IsCoprime g₀ h₀ →
+      f.map (Ideal.Quotient.mk I) = g₀ * h₀ →
+      ∃ g h : R[X], g.Monic ∧ h.Monic ∧ f = g * h ∧
+        g.map (Ideal.Quotient.mk I) = g₀ ∧ h.map (Ideal.Quotient.mk I) = h₀
+```
+
+`(R, I)` is a Henselian pair if `I` lies in the Jacobson radical and every monic
+polynomial whose reduction modulo `I` factors as a product of two monic *coprime*
+polynomials lifts to a matching factorisation over `R` (Stacks tag 09XE).
+
+It is declared as a `class` to match Mathlib's neighbours `HenselianRing` and
+`HenselianLocalRing`, but the API takes it as an explicit hypothesis
+`(h : IsHenselianPair R I)` rather than an instance binder.
+
+## File Guide
+
+- `Coprime.lean` — coprimality of monic polynomials descends along Jacobson-radical
+  quotients, via the resultant.
+- `Polynomial.lean` — polynomial helpers; uniqueness of simple-root lifts from
+  `I ≤ Jac(R)` alone.
+- `HenselianRing.lean` — uniqueness of root lifts for Mathlib's `HenselianRing`.
+- `Defs.lean` — `IsHenselianPair`; the bridge `IsHenselianPair.henselianRing` to
+  Mathlib's predicate; the examples `(R, ⊥)` and the local-ring case.
+- `Idempotents.lean` — idempotents of `R ⧸ I` lift uniquely (Stacks tag 09XI(2));
+  the converse Jacobson criteria.
+- `Quotient.lean` — quotient and subideal stability (Stacks tags 09XG, 0DYD).
+- `HenselianPair.lean` (parent) re-exports the folder.
+
+## What Is Proved
+
+- `IsHenselianPair.henselianRing` — a Henselian pair is Henselian in Mathlib's
+  root-lifting sense; the factorisation definition is not a self-serving weakening.
+- `IsHenselianPair.henselianLocalRing` — a local ring Henselian at its maximal ideal
+  is a `HenselianLocalRing`.
+- `IsHenselianPair.bot` — `(R, ⊥)` is a Henselian pair; in particular `(K, ⊥)` for a
+  field `K`.
+- `IsHenselianPair.existsUnique_root_lift_of_isUnit_derivative` — the simple-root lift
+  is unique in its congruence class.
+- `IsHenselianPair.existsUnique_isIdempotentElem_lift` and the orthogonal /
+  complete-orthogonal systems — idempotents lift uniquely (Stacks tag 09XI(2)).
+- `IsHenselianPair.quotient`, `IsHenselianPair.of_le`, `IsHenselianPair.of_quotient`
+  and `iff_of_le_quotient` — quotient stability (tag 09XG), unconditional shrinking
+  of the ideal, and the gluing statement (tag 0DYD).
+
+## What Is Not Proved Here
+
+Deliberately out of scope in this folder:
+
+- The henselization `(Rʰ, Iʰ)` of a pair and the theorem that it is a Henselian pair
+  (Stacks tag 0A02), and its universal property (tag 0A02.1).
+- `Henselian pair ⟹ étale sections lift` (tag 09XI (1) ⇒ (2)), which needs Zariski's
+  Main Theorem.
+- The étale-lifting characterisation of Henselian *local* rings (tag 04GG), which is
+  the subject of in-flight Mathlib PR #41086.
+
+## Verification
+
+`lake build FLT.Slop.HenselianPair` compiles with no errors, no `sorry`, and no
+warnings, and
+
+```lean
+#print axioms IsHenselianPair.henselianRing
+#print axioms IsHenselianPair.of_quotient
+#print axioms IsHenselianPair.existsUnique_isIdempotentElem_lift
+-- [propext, Classical.choice, Quot.sound]
+```
+
+reports only the three standard axioms.
+
+## Relation to existing formalizations
+
+Nothing here duplicates current Mathlib: `IsHenselianPair`,
+`isCoprime_X_sub_C_of_isUnit_eval` and
+`isCoprime_of_monic_of_isCoprime_map_quotient_of_le_jacobson` have zero occurrences
+in Mathlib. `Coprime.lean`'s two general polynomial facts are the natural candidates
+to be rehomed (to `Mathlib/Algebra/Polynomial/RingDivision.lean` and near
+`Mathlib/RingTheory/Polynomial/Resultant/Basic.lean`) if this is upstreamed.
+
+Stacks citations use Mathlib's `@[stacks TAG]` attribute rather than markdown links.
+
+## Sources
+
+The Stacks Project, More on Algebra, §15.11–15.12
+([tag 09XD](https://stacks.math.columbia.edu/tag/09XD) onwards); the
+coprime-factorisation definition is [tag 09XE](https://stacks.math.columbia.edu/tag/09XE)
+and the idempotent-lifting characterisation is
+[tag 09XI](https://stacks.math.columbia.edu/tag/09XI).
+
+## Possible next steps
+
+- The henselization of a pair and its universal property (tags 0A02, 0A02.1).
+- The hard direction of tag 09XI via Zariski's Main Theorem.
+- Upstream the pair theory to Mathlib.


### PR DESCRIPTION
Adds `FLT.Slop.HenselianPair`: the theory of **Henselian pairs** `(R, I)` in the
coprime-factorisation form of [Stacks tag 09XE](https://stacks.math.columbia.edu/tag/09XE).
Mathlib has `HenselianRing` and `HenselianLocalRing` but no notion of a Henselian pair;
this fills that gap and is packaged so the files can be lifted to mathlib with only a
change of module prefix.

## What it adds

`IsHenselianPair` is a `Prop`-valued `class`, bridged to mathlib's `HenselianRing` via
`IsHenselianPair.henselianRing`, so it is tied to the existing root-lifting predicate
rather than floating free.

| File | Content |
| --- | --- |
| `Coprime` | Coprimality of monics descends along Jacobson-radical quotients (via the resultant) |
| `Polynomial` | Polynomial helpers; uniqueness of simple-root lifts from `I ≤ Jac(R)` |
| `HenselianRing` | Root-lift uniqueness for mathlib's `HenselianRing` |
| `Defs` | `IsHenselianPair`; bridge to `HenselianRing`; `(R, ⊥)`; the local-ring case |
| `Idempotents` | Idempotents lift uniquely (tag 09XI(2)); converse Jacobson criteria |
| `Quotient` | Quotient and subideal stability (tags 09XG, 0DYD) |

Main results include `IsHenselianPair.henselianRing`, `.henselianLocalRing`, `.bot`,
`.existsUnique_isIdempotentElem_lift`, `.quotient`, `.of_le`, and `.of_quotient`.
See `FLT/Slop/HenselianPair/README.md` for the full overview and what is deliberately
out of scope (the henselization of a pair, tag 09XI (1)⇒(2), tag 04GG).

## Verification

`lake build FLT.Slop.HenselianPair` compiles with **no `sorry` and no warnings**, and

```lean
#print axioms IsHenselianPair.henselianRing
#print axioms IsHenselianPair.of_quotient
#print axioms IsHenselianPair.existsUnique_isIdempotentElem_lift
-- [propext, Classical.choice, Quot.sound]
```

reports only the three standard axioms. Verified against the mathlib revision this branch
targets. The `HenselianPair/` files depend only on mathlib (no other FLT module).
