### PR TITLE
refactor: move the exact-couple and spectral-sequence libraries into the Slop namespace

### DIFF
--- a/FLT.lean
+++ b/FLT.lean
@@ -230,6 +230,7 @@ public import FLT.Slop.PGL2.FiniteSubgroups.WildClassification
 public import FLT.Slop.RepresentationTheory.OddAbsIrredOrig
 public import FLT.Slop.RepresentationTheory.OddAbsIrredSlop
 public import FLT.Slop.SpectralSequence
+public import FLT.Slop.SpectralSequence.CategoryTheory
 public import FLT.Slop.SpectralSequence.DoubleComplex
 public import FLT.Slop.SpectralSequence.ExactCoupleBridge
 public import FLT.Slop.SpectralSequence.FilteredComplex

--- a/FLT.lean
+++ b/FLT.lean
@@ -229,4 +229,10 @@ public import FLT.Slop.PGL2.FiniteSubgroups.TameClassification
 public import FLT.Slop.PGL2.FiniteSubgroups.WildClassification
 public import FLT.Slop.RepresentationTheory.OddAbsIrredOrig
 public import FLT.Slop.RepresentationTheory.OddAbsIrredSlop
+public import FLT.Slop.SpectralSequence
+public import FLT.Slop.SpectralSequence.DoubleComplex
+public import FLT.Slop.SpectralSequence.ExactCoupleBridge
+public import FLT.Slop.SpectralSequence.FilteredComplex
+public import FLT.Slop.SpectralSequence.FilteredModule
+public import FLT.Slop.SpectralSequence.FiveTerm
 public import FLT.TateCurve.TateCurve

--- a/FLT.lean
+++ b/FLT.lean
@@ -211,6 +211,9 @@ public import FLT.Slop.DimensionTheorem.DimLeGrowth
 public import FLT.Slop.DimensionTheorem.GrowthLeDelta
 public import FLT.Slop.DimensionTheorem.Main
 public import FLT.Slop.DimensionTheorem.Numeric
+public import FLT.Slop.ExactCouple
+public import FLT.Slop.ExactCouple.Basic
+public import FLT.Slop.ExactCouple.Graded
 public import FLT.Slop.NumberTheory.TsumDivisorsAntidiagonal
 public import FLT.Slop.PGL2.FiniteSubgroups.CyclicPartition
 public import FLT.Slop.PGL2.FiniteSubgroups.DicksonClassification

--- a/FLT/Slop/ExactCouple.lean
+++ b/FLT/Slop/ExactCouple.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.ExactCouple.Graded
+
+/-!
+# Exact couples and their spectral sequences
+
+Umbrella module for the `FLT.Slop.ExactCouple` library.  See
+`FLT/Slop/ExactCouple/README.md` for an overview and sources.
+
+An exact couple (Massey, 1952) is the most economical input datum for a
+spectral sequence: modules `D`, `E` with maps `i : D → D`, `j : D → E`,
+`k : E → D`, exact at each vertex.  The main results:
+
+* `ExactCouple.derivedCouple` (`FLT/Slop/ExactCouple/Basic.lean`) — the
+  derived-couple theorem: `D' = im i`, `E' = ker(jk)/im(jk)` with the induced
+  maps again form an exact couple; iterating gives the pages of a spectral
+  sequence with `E_{r+1} = H(E_r, d_r)` holding by construction
+  (`ExactCouple.pageSuccEquiv` is definitionally the identity).
+* `GradedExactCouple.gradedDerived` (`FLT/Slop/ExactCouple/Graded.lean`) — the
+  graded upgrade: if `D`, `E` are graded by an abelian group of degrees and
+  `i, j, k` are homogeneous of degrees `di, dj, dk`, each derived couple is
+  again graded and the `r`-th page differential is homogeneous of degree
+  `(dj + dk) - r • di` (`GradedExactCouple.gradedDerived_homog_d`) — the
+  classical bidegree bookkeeping (for the couple of a filtered complex, whose
+  page `0` is the classical `E₁`, this degree is `(r + 1, -r)`, the bidegree
+  of the classical `d_{r+1}`).
+-/

--- a/FLT/Slop/ExactCouple.lean
+++ b/FLT/Slop/ExactCouple.lean
@@ -20,12 +20,13 @@ spectral sequence: modules `D`, `E` with maps `i : D → D`, `j : D → E`,
 * `ExactCouple.derivedCouple` (`FLT/Slop/ExactCouple/Basic.lean`) — the
   derived-couple theorem: `D' = im i`, `E' = ker(jk)/im(jk)` with the induced
   maps again form an exact couple; iterating gives the pages of a spectral
-  sequence with `E_{r+1} = H(E_r, d_r)` holding by construction
+  sequence with `page (r + 1) = H(page r, d_r)` holding by construction
   (`ExactCouple.pageSuccEquiv` is definitionally the identity).
 * `GradedExactCouple.gradedDerived` (`FLT/Slop/ExactCouple/Graded.lean`) — the
-  graded upgrade: if `D`, `E` are graded by an abelian group of degrees and
-  `i, j, k` are homogeneous of degrees `di, dj, dk`, each derived couple is
-  again graded and the `r`-th page differential is homogeneous of degree
+  graded upgrade: if `D`, `E` are internal direct sums graded by an abelian
+  group of degrees and `i, j, k` are homogeneous of degrees `di, dj, dk`, each
+  derived couple is again graded and the `r`-th page differential is homogeneous
+  of degree
   `(dj + dk) - r • di` (`GradedExactCouple.gradedDerived_homog_d`) — the
   classical bidegree bookkeeping (for the couple of a filtered complex, whose
   page `0` is the classical `E₁`, this degree is `(r + 1, -r)`, the bidegree

--- a/FLT/Slop/ExactCouple/Basic.lean
+++ b/FLT/Slop/ExactCouple/Basic.lean
@@ -63,6 +63,8 @@ exact couple, derived couple, spectral sequence
 
 @[expose] public section
 
+namespace Slop
+
 open LinearMap Submodule Function
 
 universe u
@@ -405,3 +407,5 @@ noncomputable def pageSuccEquiv (r : ℕ) :
     (C.pageSuccEquiv r).symm x = x := rfl
 
 end ExactCouple
+
+end Slop

--- a/FLT/Slop/ExactCouple/Basic.lean
+++ b/FLT/Slop/ExactCouple/Basic.lean
@@ -24,9 +24,9 @@ spectral sequence: two modules `D`, `E` and three maps
 ```
       i
   D ─────→ D
-   ↖      ╱
-  k ╲    ╱ j
-     ╲  ↙
+   ↖      /
+  k  \    / j
+      \  ↙
       E
 ```
 
@@ -38,7 +38,8 @@ which are exact at each of the three vertices (`im i = ker j`, `im j = ker k`,
 * `E' = ker d / im d = H(E, d)`,
 
 is again an exact couple.  Iterating produces the pages `E, E', E'', …` of a
-spectral sequence, with `E_{r+1}` the homology of `(E_r, d_r)` by construction.
+spectral sequence, with each page the homology of the preceding one.  Our
+zero-based `page r` is the conventionally indexed `E_{r+1}` page.
 
 ## Main definitions and results
 
@@ -51,7 +52,7 @@ spectral sequence, with `E_{r+1}` the homology of `(E_r, d_r)` by construction.
 * `ExactCouple.derived : ℕ → ExactCouple R`, `ExactCouple.page`,
   `ExactCouple.pageDiff` : the spectral sequence obtained by iterating, with
   `pageDiff_comp_pageDiff` (`d_r ∘ d_r = 0`) and `pageSuccEquiv`
-  (`E_{r+1} ≃ₗ ker d_r / im d_r`, definitionally the identity).
+  (`page (r + 1) ≃ₗ ker d_r / im d_r`, definitionally the identity).
 
 Everything is at the level of modules over an arbitrary ring `R`.
 
@@ -105,11 +106,11 @@ variable {R : Type*} [Ring R] (C : ExactCouple.{u} R)
 
 @[simp] lemma i_k (x : C.E) : C.i (C.k x) = 0 := C.exact_ki.apply_apply_eq_zero x
 
-lemma j_comp_i : C.j ∘ₗ C.i = 0 := by ext x; simp
+@[simp] lemma j_comp_i : C.j ∘ₗ C.i = 0 := by ext x; simp
 
-lemma k_comp_j : C.k ∘ₗ C.j = 0 := by ext x; simp
+@[simp] lemma k_comp_j : C.k ∘ₗ C.j = 0 := by ext x; simp
 
-lemma i_comp_k : C.i ∘ₗ C.k = 0 := by ext x; simp
+@[simp] lemma i_comp_k : C.i ∘ₗ C.k = 0 := by ext x; simp
 
 /-! ## The differential `d = j ∘ k` on `E` -/
 
@@ -122,6 +123,29 @@ def d : C.E →ₗ[R] C.E := C.j ∘ₗ C.k
 lemma d_d (x : C.E) : C.d (C.d x) = 0 := by simp [d]
 
 lemma d_comp_d : C.d ∘ₗ C.d = 0 := by ext x; simp
+
+/-- The image of `d` is contained in its kernel. -/
+lemma range_d_le_ker_d : LinearMap.range C.d ≤ LinearMap.ker C.d := by
+  rintro _ ⟨x, rfl⟩
+  simp [LinearMap.mem_ker]
+
+/-- The cycles are the inverse image under `k` of `range i = ker j`. -/
+lemma ker_d_eq_comap_range_i : LinearMap.ker C.d =
+    (LinearMap.range C.i).comap C.k := by
+  ext x
+  change C.k x ∈ LinearMap.ker C.j ↔ C.k x ∈ LinearMap.range C.i
+  rw [← LinearMap.exact_iff.mp C.exact_ij]
+
+/-- The boundaries are the image under `j` of `ker i = range k`. -/
+lemma range_d_eq_map_ker_i : LinearMap.range C.d =
+    (LinearMap.ker C.i).map C.j := by
+  ext x
+  constructor
+  · rintro ⟨e, rfl⟩
+    exact ⟨C.k e, (C.exact_ki _).mpr ⟨e, rfl⟩, rfl⟩
+  · rintro ⟨y, hy, rfl⟩
+    obtain ⟨e, rfl⟩ := (C.exact_ki y).mp hy
+    exact ⟨e, rfl⟩
 
 /-! ## The pieces of the derived couple
 
@@ -222,9 +246,14 @@ lemma imd_le_ker_derKAux : C.imd ≤ LinearMap.ker C.derKAux := by
 def derK : C.derE →ₗ[R] C.derD :=
   Submodule.liftQ C.imd C.derKAux C.imd_le_ker_derKAux
 
-@[simp] lemma derK_mk (e : LinearMap.ker C.d) :
+lemma coe_derK_mk (e : LinearMap.ker C.d) :
     (C.derK (Submodule.Quotient.mk e) : C.D) = C.k (e : C.E) := by
   rw [derK, Submodule.liftQ_apply, derKAux_coe]
+
+/-- The derived `k'` agrees with its auxiliary map on representatives. -/
+@[simp] lemma derK_mk (e : LinearMap.ker C.d) :
+    C.derK (Submodule.Quotient.mk e) = C.derKAux e := by
+  rw [derK, Submodule.liftQ_apply]
 
 /-! ## The derived couple is exact
 
@@ -267,7 +296,7 @@ theorem derived_exact_jk : Function.Exact C.derJ C.derK := by
     rw [LinearMap.mem_ker] at hξ
     have hke : C.k (e : C.E) = 0 := by
       have := congrArg (Subtype.val) hξ
-      rwa [derK_mk, Submodule.coe_zero] at this
+      rwa [coe_derK_mk, Submodule.coe_zero] at this
     obtain ⟨a, ha⟩ := (C.exact_jk (e : C.E)).mp hke
     refine ⟨a, ?_⟩
     rw [derJAux_apply]
@@ -277,7 +306,7 @@ theorem derived_exact_jk : Function.Exact C.derJ C.derK := by
     rintro _ ⟨a, rfl⟩
     rw [LinearMap.mem_ker, derJAux_apply]
     apply Subtype.ext
-    rw [derK_mk, Submodule.coe_zero]
+    rw [coe_derK_mk, Submodule.coe_zero]
     simp
 
 /-- Exactness of the derived couple at the source `D'`:  `im k' = ker i'`. -/
@@ -297,18 +326,18 @@ theorem derived_exact_ki : Function.Exact C.derK C.derI := by
       rw [LinearMap.mem_ker, d_apply, he]; simp
     refine ⟨Submodule.Quotient.mk ⟨e, hedk⟩, ?_⟩
     apply Subtype.ext
-    rw [derK_mk, he]
+    rw [coe_derK_mk, he]
   · -- im k' ⊆ ker i'
     intro y hy
     obtain ⟨ξ, rfl⟩ := hy
     obtain ⟨e, rfl⟩ := Submodule.Quotient.mk_surjective _ ξ
     rw [LinearMap.mem_ker]
     apply Subtype.ext
-    rw [derI_coe, derK_mk, Submodule.coe_zero]
+    rw [derI_coe, coe_derK_mk, Submodule.coe_zero]
     simp
 
 /-- The **derived couple** of an exact couple. -/
-@[stacks 011P]
+@[stacks 011R]
 noncomputable def derivedCouple : ExactCouple.{u} R where
   D := C.derD
   E := C.derE
@@ -319,10 +348,18 @@ noncomputable def derivedCouple : ExactCouple.{u} R where
   exact_jk := C.derived_exact_jk
   exact_ki := C.derived_exact_ki
 
+@[simp] lemma derivedCouple_i : C.derivedCouple.i = C.derI := rfl
+
+@[simp] lemma derivedCouple_j : C.derivedCouple.j = C.derJ := rfl
+
+@[simp] lemma derivedCouple_k : C.derivedCouple.k = C.derK := rfl
+
 /-! ## The spectral sequence of an exact couple
 
 Iterating the derived-couple construction yields the pages of a spectral
-sequence:  `E_0 = E`, `E_{r+1} = ker d_r / im d_r`. -/
+sequence.  We use zero-based internal indexing: `page 0 = E` and
+`page (r + 1) = ker d_r / im d_r`, so `page r` corresponds to the customary
+page `E_{r+1}`. -/
 
 /-- The `r`-th derived couple (`derived 0 = C`). -/
 noncomputable def derived (C : ExactCouple.{u} R) : ℕ → ExactCouple.{u} R
@@ -346,12 +383,25 @@ noncomputable def pageDiff (r : ℕ) : C.page r →ₗ[R] C.page r := (C.derived
 theorem pageDiff_comp_pageDiff (r : ℕ) : C.pageDiff r ∘ₗ C.pageDiff r = 0 :=
   (C.derived r).d_comp_d
 
-/-- By construction, `E_{r+1}` is the homology of `(E_r, d_r)`: the identity
-map is a linear equivalence `E_{r+1} ≃ₗ ker d_r / im d_r`. -/
+/-- Pointwise, `d_r² = 0`. -/
+@[simp] theorem pageDiff_pageDiff (r : ℕ) (x : C.page r) :
+    C.pageDiff r (C.pageDiff r x) = 0 :=
+  (C.derived r).d_d x
+
+/-- By construction, `page (r + 1)` is the homology of `(page r, d_r)`: the
+identity map is a linear equivalence with `ker d_r / im d_r`. -/
 noncomputable def pageSuccEquiv (r : ℕ) :
     C.page (r + 1) ≃ₗ[R]
       (LinearMap.ker (C.pageDiff r) ⧸
         (LinearMap.range (C.pageDiff r)).comap (LinearMap.ker (C.pageDiff r)).subtype) :=
   LinearEquiv.refl R _
+
+@[simp] lemma pageSuccEquiv_apply (r : ℕ) (x : C.page (r + 1)) :
+    C.pageSuccEquiv r x = x := rfl
+
+@[simp] lemma pageSuccEquiv_symm_apply (r : ℕ)
+    (x : LinearMap.ker (C.pageDiff r) ⧸
+      (LinearMap.range (C.pageDiff r)).comap (LinearMap.ker (C.pageDiff r)).subtype) :
+    (C.pageSuccEquiv r).symm x = x := rfl
 
 end ExactCouple

--- a/FLT/Slop/ExactCouple/Basic.lean
+++ b/FLT/Slop/ExactCouple/Basic.lean
@@ -1,0 +1,357 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import Mathlib.LinearAlgebra.Isomorphisms
+public import Mathlib.Algebra.Exact.Basic
+public import Mathlib.Tactic.CrossRefAttribute
+
+/-!
+# Exact couples and their derived couples
+
+This file formalizes **exact couples** and the **derived couple** construction,
+following the Stacks Project (tag 011P) and the classical references (Weibel,
+*An Introduction to Homological Algebra*, §5.9; McCleary, *A User's Guide to
+Spectral Sequences*, §2.2; exact couples originate with Massey, *Exact couples
+in algebraic topology*, Ann. of Math. 56 (1952)).
+
+An exact couple is the most economical packaging of the data that produces a
+spectral sequence: two modules `D`, `E` and three maps
+
+```
+      i
+  D ─────→ D
+   ↖      ╱
+  k ╲    ╱ j
+     ╲  ↙
+      E
+```
+
+which are exact at each of the three vertices (`im i = ker j`, `im j = ker k`,
+`im k = ker i`).  Setting `d = j ∘ k : E → E` one has `d ∘ d = 0` (because
+`k ∘ j = 0`), and the **derived couple** `(D', E', i', j', k')` with
+
+* `D' = im i`,
+* `E' = ker d / im d = H(E, d)`,
+
+is again an exact couple.  Iterating produces the pages `E, E', E'', …` of a
+spectral sequence, with `E_{r+1}` the homology of `(E_r, d_r)` by construction.
+
+## Main definitions and results
+
+* `ExactCouple R` : the structure (two `R`-modules and three exact maps).
+* `ExactCouple.d`, `ExactCouple.d_comp_d` : the differential `d = j ∘ k` and
+  `d ∘ d = 0`.
+* `ExactCouple.derivedCouple : ExactCouple R` : the derived couple, whose three
+  exactness conditions (`derived_exact_ij`, `derived_exact_jk`,
+  `derived_exact_ki`) are the content of the derived-couple theorem.
+* `ExactCouple.derived : ℕ → ExactCouple R`, `ExactCouple.page`,
+  `ExactCouple.pageDiff` : the spectral sequence obtained by iterating, with
+  `pageDiff_comp_pageDiff` (`d_r ∘ d_r = 0`) and `pageSuccEquiv`
+  (`E_{r+1} ≃ₗ ker d_r / im d_r`, definitionally the identity).
+
+Everything is at the level of modules over an arbitrary ring `R`.
+
+## Tags
+
+exact couple, derived couple, spectral sequence
+-/
+
+@[expose] public section
+
+open LinearMap Submodule Function
+
+universe u
+
+/-- An **exact couple** of `R`-modules: modules `D`, `E` with maps
+`i : D → D`, `j : D → E`, `k : E → D` that are exact at each vertex. -/
+structure ExactCouple (R : Type*) [Ring R] where
+  /-- The module on the two `i`-related vertices. -/
+  D : Type u
+  /-- The module on the `E`-vertex. -/
+  E : Type u
+  [addCommGroupD : AddCommGroup D]
+  [moduleD : Module R D]
+  [addCommGroupE : AddCommGroup E]
+  [moduleE : Module R E]
+  /-- The self-map `i : D → D`. -/
+  i : D →ₗ[R] D
+  /-- The map `j : D → E`. -/
+  j : D →ₗ[R] E
+  /-- The map `k : E → D`. -/
+  k : E →ₗ[R] D
+  /-- Exactness at the target `D`:  `im i = ker j`. -/
+  exact_ij : Function.Exact i j
+  /-- Exactness at `E`:  `im j = ker k`. -/
+  exact_jk : Function.Exact j k
+  /-- Exactness at the source `D`:  `im k = ker i`. -/
+  exact_ki : Function.Exact k i
+
+attribute [instance] ExactCouple.addCommGroupD ExactCouple.moduleD
+  ExactCouple.addCommGroupE ExactCouple.moduleE
+
+namespace ExactCouple
+
+variable {R : Type*} [Ring R] (C : ExactCouple.{u} R)
+
+/-! ## The three "consecutive composites vanish" facts -/
+
+@[simp] lemma j_i (x : C.D) : C.j (C.i x) = 0 := C.exact_ij.apply_apply_eq_zero x
+
+@[simp] lemma k_j (x : C.D) : C.k (C.j x) = 0 := C.exact_jk.apply_apply_eq_zero x
+
+@[simp] lemma i_k (x : C.E) : C.i (C.k x) = 0 := C.exact_ki.apply_apply_eq_zero x
+
+lemma j_comp_i : C.j ∘ₗ C.i = 0 := by ext x; simp
+
+lemma k_comp_j : C.k ∘ₗ C.j = 0 := by ext x; simp
+
+lemma i_comp_k : C.i ∘ₗ C.k = 0 := by ext x; simp
+
+/-! ## The differential `d = j ∘ k` on `E` -/
+
+/-- The differential `d = j ∘ k : E → E`. -/
+def d : C.E →ₗ[R] C.E := C.j ∘ₗ C.k
+
+@[simp] lemma d_apply (x : C.E) : C.d x = C.j (C.k x) := rfl
+
+/-- `d ∘ d = 0`, because `k ∘ j = 0`. -/
+lemma d_d (x : C.E) : C.d (C.d x) = 0 := by simp [d]
+
+lemma d_comp_d : C.d ∘ₗ C.d = 0 := by ext x; simp
+
+/-! ## The pieces of the derived couple
+
+`D' = im i`, and `E' = ker d / im d` (`im d ≤ ker d` since `d² = 0`).  We model
+`im d` inside `ker d` as `imd`, the comap of `range d` along the inclusion. -/
+
+/-- `D' = im i`, the module on the two `i'`-related vertices of the derived couple. -/
+abbrev derD : Submodule R C.D := LinearMap.range C.i
+
+/-- `im d`, viewed as a submodule of `ker d`. -/
+abbrev imd : Submodule R (LinearMap.ker C.d) :=
+  (LinearMap.range C.d).comap (LinearMap.ker C.d).subtype
+
+/-- `E' = ker d / im d`, the homology of `(E, d)`; the `E`-vertex of the derived couple. -/
+abbrev derE : Type u := (LinearMap.ker C.d) ⧸ C.imd
+
+/-- The quotient map `ker d → E'`. -/
+abbrev derEmk : (LinearMap.ker C.d) →ₗ[R] C.derE := (C.imd).mkQ
+
+/-! ### The derived map `i' : D' → D'` -/
+
+/-- `i' : D' → D'`, the restriction of `i` (which maps `im i` into `im i`). -/
+def derI : C.derD →ₗ[R] C.derD :=
+  C.i.restrict (fun y _ ↦ ⟨y, rfl⟩)
+
+@[simp] lemma derI_coe (y : C.derD) : (C.derI y : C.D) = C.i (y : C.D) :=
+  rfl
+
+/-! ### The universal map `J : D → E'` and the derived map `j'` -/
+
+/-- The auxiliary map `J : D → E'`, `x ↦ [j x]`, used to construct the derived
+map `j'`.  Note `j x ∈ ker d` for every `x` (as `k (j x) = 0`), so this is
+defined on all of `D`; it vanishes on `ker i = im k`, hence descends to
+`j' : D' → E'`. -/
+def derJAux : C.D →ₗ[R] C.derE :=
+  C.derEmk ∘ₗ C.j.codRestrict (LinearMap.ker C.d) (fun x ↦ by simp [LinearMap.mem_ker])
+
+@[simp] lemma derJAux_apply (x : C.D) :
+    C.derJAux x = Submodule.Quotient.mk ⟨C.j x, by simp [LinearMap.mem_ker]⟩ := rfl
+
+/-- `J` vanishes on `ker i = im k`. -/
+lemma ker_i_le_ker_derJAux : LinearMap.ker C.i ≤ LinearMap.ker C.derJAux := by
+  intro x hx
+  obtain ⟨e, rfl⟩ := (C.exact_ki x).mp hx
+  rw [LinearMap.mem_ker, derJAux_apply]
+  refine (Submodule.Quotient.mk_eq_zero _).mpr ?_
+  rw [Submodule.mem_comap]
+  exact ⟨e, by simp⟩
+
+/-- `j' : D' → E'`, induced by `J : D → E'` via the first isomorphism theorem. -/
+noncomputable def derJ : C.derD →ₗ[R] C.derE :=
+  (Submodule.liftQ (LinearMap.ker C.i) C.derJAux C.ker_i_le_ker_derJAux).comp
+    (C.i.quotKerEquivRange).symm.toLinearMap
+
+@[simp] lemma derJ_apply (x : C.D) : C.derJ ⟨C.i x, ⟨x, rfl⟩⟩ = C.derJAux x := by
+  rw [derJ, LinearMap.comp_apply]
+  have : (C.i.quotKerEquivRange).symm ⟨C.i x, ⟨x, rfl⟩⟩ = (LinearMap.ker C.i).mkQ x :=
+    C.i.quotKerEquivRange_symm_apply_image x _
+  rw [LinearEquiv.coe_coe, this]
+  exact Submodule.liftQ_apply _ _ _
+
+/-- `range j' = range J`: every element of `D' = im i` is `i x`, and
+`j' (i x) = J x`. -/
+lemma range_derJ : LinearMap.range C.derJ = LinearMap.range C.derJAux := by
+  apply le_antisymm
+  · rintro _ ⟨⟨y, x, rfl⟩, rfl⟩
+    exact ⟨x, (C.derJ_apply x).symm⟩
+  · rintro _ ⟨x, rfl⟩
+    exact ⟨⟨C.i x, x, rfl⟩, C.derJ_apply x⟩
+
+/-! ### The derived map `k' : E' → D'` -/
+
+/-- `k` maps `ker d` into `D' = im i`:  if `d e = 0` then `j (k e) = 0`, so
+`k e ∈ ker j = im i`. -/
+lemma k_mem_derD {e : C.E} (he : e ∈ LinearMap.ker C.d) : C.k e ∈ C.derD :=
+  (C.exact_ij _).mp (by simpa [LinearMap.mem_ker] using he)
+
+/-- The auxiliary map for the derived `k'`: the map `k` restricted to `ker d`,
+corestricted to `D' = im i`. -/
+def derKAux : (LinearMap.ker C.d) →ₗ[R] C.derD :=
+  C.k.restrict (fun _e he ↦ C.k_mem_derD he)
+
+@[simp] lemma derKAux_coe (e : LinearMap.ker C.d) : (C.derKAux e : C.D) = C.k (e : C.E) :=
+  rfl
+
+/-- `derKAux` vanishes on `im d`, so it descends to `k' : E' → D'`. -/
+lemma imd_le_ker_derKAux : C.imd ≤ LinearMap.ker C.derKAux := by
+  intro e he
+  rw [Submodule.mem_comap] at he
+  obtain ⟨e0, he0⟩ := he
+  have he0' : (↑e : C.E) = C.d e0 := he0.symm
+  rw [LinearMap.mem_ker]
+  apply Subtype.ext
+  rw [derKAux_coe, Submodule.coe_zero, he0']
+  simp
+
+/-- `k' : E' → D'`, induced by `derKAux` on the quotient. -/
+def derK : C.derE →ₗ[R] C.derD :=
+  Submodule.liftQ C.imd C.derKAux C.imd_le_ker_derKAux
+
+@[simp] lemma derK_mk (e : LinearMap.ker C.d) :
+    (C.derK (Submodule.Quotient.mk e) : C.D) = C.k (e : C.E) := by
+  rw [derK, Submodule.liftQ_apply, derKAux_coe]
+
+/-! ## The derived couple is exact
+
+The three diagram chases below are the content of the derived-couple theorem. -/
+
+/-- Exactness of the derived couple at the target `D'`:  `im i' = ker j'`. -/
+theorem derived_exact_ij : Function.Exact C.derI C.derJ := by
+  rw [LinearMap.exact_iff]
+  apply le_antisymm
+  · -- ker j' ⊆ im i'
+    rintro ⟨y, x, rfl⟩ hy
+    rw [LinearMap.mem_ker, derJ_apply, derJAux_apply] at hy
+    -- `[j x] = 0`  means  `j x ∈ im d`, i.e. `j x = j (k w)` for some `w`
+    obtain ⟨w, hw⟩ := (Submodule.Quotient.mk_eq_zero _).mp hy
+    -- `hw : C.d w = C.j x`
+    have hw' : C.j (C.k w) = C.j x := by have h := hw; simp only [d_apply] at h; exact h
+    -- so `j (x - k w) = 0`, hence `x - k w = i x'`
+    have hxke : C.j (x - C.k w) = 0 := by rw [map_sub, hw']; simp
+    obtain ⟨x', hx'⟩ := (C.exact_ij _).mp hxke
+    -- then `i x = i (i x')`, i.e. `⟨i x, _⟩ = i' ⟨i x', _⟩`
+    refine ⟨⟨C.i x', ⟨x', rfl⟩⟩, ?_⟩
+    apply Subtype.ext
+    change C.i (C.i x') = C.i x
+    rw [hx', map_sub, i_k, sub_zero]
+  · -- im i' ⊆ ker j'
+    rintro _ ⟨⟨y, x, rfl⟩, rfl⟩
+    rw [LinearMap.mem_ker]
+    change C.derJ ⟨C.i (C.i x), ⟨C.i x, rfl⟩⟩ = 0
+    rw [derJ_apply, derJAux_apply]
+    -- `j (i x) = 0`, so this class is literally zero
+    exact (Submodule.Quotient.mk_eq_zero _).mpr (Submodule.mem_comap.mpr ⟨0, by simp⟩)
+
+/-- Exactness of the derived couple at `E'`:  `im j' = ker k'`. -/
+theorem derived_exact_jk : Function.Exact C.derJ C.derK := by
+  rw [LinearMap.exact_iff, range_derJ]
+  apply le_antisymm
+  · -- ker k' ⊆ im J
+    intro ξ hξ
+    obtain ⟨e, rfl⟩ := Submodule.Quotient.mk_surjective _ ξ
+    rw [LinearMap.mem_ker] at hξ
+    have hke : C.k (e : C.E) = 0 := by
+      have := congrArg (Subtype.val) hξ
+      rwa [derK_mk, Submodule.coe_zero] at this
+    obtain ⟨a, ha⟩ := (C.exact_jk (e : C.E)).mp hke
+    refine ⟨a, ?_⟩
+    rw [derJAux_apply]
+    apply congrArg
+    exact Subtype.ext ha
+  · -- im J ⊆ ker k'
+    rintro _ ⟨a, rfl⟩
+    rw [LinearMap.mem_ker, derJAux_apply]
+    apply Subtype.ext
+    rw [derK_mk, Submodule.coe_zero]
+    simp
+
+/-- Exactness of the derived couple at the source `D'`:  `im k' = ker i'`. -/
+theorem derived_exact_ki : Function.Exact C.derK C.derI := by
+  rw [LinearMap.exact_iff]
+  apply le_antisymm
+  · -- ker i' ⊆ im k'
+    rintro ⟨y, x, rfl⟩ hy
+    rw [LinearMap.mem_ker] at hy
+    have hiy : C.i (C.i x) = 0 := by
+      have := congrArg (Subtype.val) hy
+      rwa [derI_coe, Submodule.coe_zero] at this
+    -- `i (i x) = 0`, so `i x ∈ ker i = im k`, say `i x = k e`
+    obtain ⟨e, he⟩ := (C.exact_ki _).mp hiy
+    -- and `e ∈ ker d`, since `d e = j (k e) = j (i x) = 0`
+    have hedk : e ∈ LinearMap.ker C.d := by
+      rw [LinearMap.mem_ker, d_apply, he]; simp
+    refine ⟨Submodule.Quotient.mk ⟨e, hedk⟩, ?_⟩
+    apply Subtype.ext
+    rw [derK_mk, he]
+  · -- im k' ⊆ ker i'
+    intro y hy
+    obtain ⟨ξ, rfl⟩ := hy
+    obtain ⟨e, rfl⟩ := Submodule.Quotient.mk_surjective _ ξ
+    rw [LinearMap.mem_ker]
+    apply Subtype.ext
+    rw [derI_coe, derK_mk, Submodule.coe_zero]
+    simp
+
+/-- The **derived couple** of an exact couple. -/
+@[stacks 011P]
+noncomputable def derivedCouple : ExactCouple.{u} R where
+  D := C.derD
+  E := C.derE
+  i := C.derI
+  j := C.derJ
+  k := C.derK
+  exact_ij := C.derived_exact_ij
+  exact_jk := C.derived_exact_jk
+  exact_ki := C.derived_exact_ki
+
+/-! ## The spectral sequence of an exact couple
+
+Iterating the derived-couple construction yields the pages of a spectral
+sequence:  `E_0 = E`, `E_{r+1} = ker d_r / im d_r`. -/
+
+/-- The `r`-th derived couple (`derived 0 = C`). -/
+noncomputable def derived (C : ExactCouple.{u} R) : ℕ → ExactCouple.{u} R
+  | 0 => C
+  | (n + 1) => (C.derived n).derivedCouple
+
+@[simp] lemma derived_zero : C.derived 0 = C := rfl
+
+@[simp] lemma derived_succ (r : ℕ) :
+    C.derived (r + 1) = (C.derived r).derivedCouple := rfl
+
+/-- The `r`-th page `E_r` of the spectral sequence of the exact couple. -/
+noncomputable abbrev page (r : ℕ) : Type u := (C.derived r).E
+
+/-- The `r`-th differential `d_r : E_r → E_r`. -/
+noncomputable def pageDiff (r : ℕ) : C.page r →ₗ[R] C.page r := (C.derived r).d
+
+@[simp] lemma pageDiff_zero : C.pageDiff 0 = C.d := rfl
+
+/-- `d_r ∘ d_r = 0`. -/
+theorem pageDiff_comp_pageDiff (r : ℕ) : C.pageDiff r ∘ₗ C.pageDiff r = 0 :=
+  (C.derived r).d_comp_d
+
+/-- By construction, `E_{r+1}` is the homology of `(E_r, d_r)`: the identity
+map is a linear equivalence `E_{r+1} ≃ₗ ker d_r / im d_r`. -/
+noncomputable def pageSuccEquiv (r : ℕ) :
+    C.page (r + 1) ≃ₗ[R]
+      (LinearMap.ker (C.pageDiff r) ⧸
+        (LinearMap.range (C.pageDiff r)).comap (LinearMap.ker (C.pageDiff r)).subtype) :=
+  LinearEquiv.refl R _
+
+end ExactCouple

--- a/FLT/Slop/ExactCouple/Graded.lean
+++ b/FLT/Slop/ExactCouple/Graded.lean
@@ -7,6 +7,7 @@ module
 
 public import FLT.Slop.ExactCouple.Basic
 public import Mathlib.Algebra.DirectSum.Decomposition
+public import Mathlib.Tactic.Abel
 
 /-!
 # Graded exact couples and the bidegree of the differentials
@@ -38,8 +39,8 @@ familiar bidegree of the classical `d_{r+1} : E_{r+1}^{p,q} → E_{r+1}^{p+r+1, 
 
 ## Main definitions and results
 
-* `GradedExactCouple R ι` : an `ExactCouple R` together with `ι`-gradings of `D`
-  and `E` (the `D`-grading internally direct) and homogeneity of `i, j, k`.
+* `GradedExactCouple R ι` : an `ExactCouple R` together with internal direct-sum
+  `ι`-gradings of `D` and `E`, and homogeneity of `i, j, k`.
 * `GradedExactCouple.homog_d` : `d = j ∘ k` is homogeneous of degree `dj + dk`.
 * `DirectSum.IsInternal.inf_range_le_map` : the key linear-algebra lemma —
   a homogeneous element in the image of a homogeneous map is the image of a
@@ -49,8 +50,8 @@ familiar bidegree of the classical `d_{r+1} : E_{r+1}^{p,q} → E_{r+1}^{p+r+1, 
 * `GradedExactCouple.derivedCouple_homog_d` : the derived differential
   `d' = j' ∘ k'` is homogeneous of degree `(dj + dk) - di` — the bidegree drop.
 * `GradedExactCouple.derivedGraded`, `gradedDerived` : the derived couple is
-  again a graded exact couple (the new ingredient being `isInternal_derGradD`:
-  `im i` is a graded submodule), and the iteration, with the closed form
+  again a graded exact couple (`isInternal_derGradD` and `isInternal_derGradE`),
+  and the iteration, with the closed form
   `gradedDerived_homog_d` : `deg d_r = (dj + dk) - r • di`.
 
 All of `ExactCouple`'s content (the derived couple is exact, `d² = 0`, the pages)
@@ -67,58 +68,139 @@ open LinearMap Submodule Function DirectSum
 
 universe u
 
-/-! ## The homogeneous-image lemma -/
+/-! ## General lemmas about homogeneous maps -/
 
-/-- If a grading `𝒟` of `M` is internally direct and `i : M → M` is homogeneous
-of degree `a` (i.e. `i (𝒟 s) ⊆ 𝒟 (s + a)`), then a homogeneous element of degree
-`q` lying in `range i` already lies in `i (𝒟 (q - a))`.  Equivalently:
-`𝒟 q ⊓ range i ≤ (𝒟 (q - a)).map i`.  This is the algebraic heart of the
-degree-shift of the derived `j'` of a graded exact couple. -/
-theorem DirectSum.IsInternal.inf_range_le_map {ι R M : Type*} [DecidableEq ι]
-    [AddGroup ι] [Ring R] [AddCommGroup M] [Module R M] {𝒟 : ι → Submodule R M}
-    (hint : DirectSum.IsInternal 𝒟) {a : ι} {i : M →ₗ[R] M}
-    (hi : ∀ s, (𝒟 s).map i ≤ 𝒟 (s + a)) (q : ι) :
-    𝒟 q ⊓ LinearMap.range i ≤ (𝒟 (q - a)).map i := by
+private theorem decomposeMapHomogeneous
+    {ι R M N : Type*} [DecidableEq ι] [AddGroup ι]
+    [Semiring R] [AddCommMonoid M] [Module R M]
+    [AddCommMonoid N] [Module R N]
+    (A : ι → Submodule R M) [DirectSum.Decomposition A]
+    (B : ι → Submodule R N) [DirectSum.Decomposition B]
+    {a : ι} {f : M →ₗ[R] N} (hf : ∀ p, (A p).map f ≤ B (p + a))
+    (x : M) (p : ι) :
+    (DirectSum.decompose B (f x) (p + a) : N) =
+      f (DirectSum.decompose A x p : M) := by
   classical
-  letI := hint.chooseDecomposition
-  rintro y ⟨hyq, x, rfl⟩
-  refine ⟨(DirectSum.decompose 𝒟 x (q - a) : M), (DirectSum.decompose 𝒟 x (q - a)).2, ?_⟩
-  have hmem : ∀ s, i ((DirectSum.decompose 𝒟 x s : M)) ∈ 𝒟 (s + a) :=
-    fun s ↦ hi s ⟨_, (DirectSum.decompose 𝒟 x s).2, rfl⟩
-  have hix : i x = ∑ s ∈ (DirectSum.decompose 𝒟 x).support,
-      i ((DirectSum.decompose 𝒟 x s : M)) := by
-    conv_lhs => rw [← DirectSum.sum_support_decompose 𝒟 x, map_sum]
-  have key0 : (DirectSum.decompose 𝒟 (i x)) q
-      = ∑ s ∈ (DirectSum.decompose 𝒟 x).support,
-          (DirectSum.decompose 𝒟 (i ((DirectSum.decompose 𝒟 x s : M)))) q := by
-    rw [hix, DirectSum.decompose_sum, DirectSum.sum_apply]
-  have key : i x = ∑ s ∈ (DirectSum.decompose 𝒟 x).support,
-      ((DirectSum.decompose 𝒟 (i ((DirectSum.decompose 𝒟 x s : M)))) q : M) := by
-    rw [← DirectSum.decompose_of_mem_same 𝒟 hyq, key0, AddSubmonoidClass.coe_finsetSum]
-  have hterm : ∀ s ∈ (DirectSum.decompose 𝒟 x).support,
-      ((DirectSum.decompose 𝒟 (i ((DirectSum.decompose 𝒟 x s : M)))) q : M)
-        = if s = q - a then i ((DirectSum.decompose 𝒟 x s : M)) else 0 := by
-    intro s _
-    by_cases h : s = q - a
-    · have h' : s + a = q := by rw [h, sub_add_cancel]
-      rw [if_pos h, ← h']; exact DirectSum.decompose_of_mem_same 𝒟 (hmem s)
-    · have h' : s + a ≠ q := fun hc ↦ h (by rw [← hc, add_sub_cancel_right])
-      rw [if_neg h]; exact DirectSum.decompose_of_mem_ne 𝒟 (hmem s) h'
+  have hmem : ∀ q, f (DirectSum.decompose A x q : M) ∈ B (q + a) :=
+    fun q ↦ hf q ⟨_, (DirectSum.decompose A x q).2, rfl⟩
+  have hfx : f x = ∑ q ∈ (DirectSum.decompose A x).support,
+      f (DirectSum.decompose A x q : M) := by
+    conv_lhs => rw [← DirectSum.sum_support_decompose A x, map_sum]
+  have key0 : DirectSum.decompose B (f x) (p + a) =
+      ∑ q ∈ (DirectSum.decompose A x).support,
+        DirectSum.decompose B (f (DirectSum.decompose A x q : M)) (p + a) := by
+    rw [hfx, DirectSum.decompose_sum, DirectSum.sum_apply]
+  have key : (DirectSum.decompose B (f x) (p + a) : N) =
+      ∑ q ∈ (DirectSum.decompose A x).support,
+        (DirectSum.decompose B (f (DirectSum.decompose A x q : M)) (p + a) : N) := by
+    rw [key0, AddSubmonoidClass.coe_finsetSum]
+  have hterm : ∀ q ∈ (DirectSum.decompose A x).support,
+      (DirectSum.decompose B (f (DirectSum.decompose A x q : M)) (p + a) : N) =
+        if q = p then f (DirectSum.decompose A x q : M) else 0 := by
+    intro q _
+    by_cases h : q = p
+    · rw [if_pos h, h]
+      exact DirectSum.decompose_of_mem_same B (hmem p)
+    · rw [if_neg h]
+      exact DirectSum.decompose_of_mem_ne B (hmem q) (fun h' ↦ h (add_right_cancel h'))
   rw [Finset.sum_congr rfl hterm, Finset.sum_ite_eq'] at key
-  by_cases hs : q - a ∈ (DirectSum.decompose 𝒟 x).support
-  · rw [if_pos hs] at key; exact key.symm
-  · rw [if_neg hs] at key
-    have hz : (DirectSum.decompose 𝒟 x (q - a) : M) = 0 := by
-      rw [DFinsupp.notMem_support_iff.mp hs]; rfl
-    rw [hz, map_zero]; exact key.symm
+  by_cases hp : p ∈ (DirectSum.decompose A x).support
+  · rwa [if_pos hp] at key
+  · rw [if_neg hp] at key
+    have hz : (DirectSum.decompose A x p : M) = 0 := by
+      rw [DFinsupp.notMem_support_iff.mp hp]
+      rfl
+    rwa [hz, map_zero]
+
+/-- Let `f : M → N` be homogeneous of degree `a` for internal gradings `A` and
+`B`. A degree-`q` element in `range f` is the image of an element of degree
+`q - a`. -/
+theorem DirectSum.IsInternal.inf_range_le_map {ι R M N : Type*} [DecidableEq ι]
+    [AddGroup ι] [Semiring R] [AddCommMonoid M] [Module R M]
+    [AddCommMonoid N] [Module R N] {A : ι → Submodule R M}
+    {B : ι → Submodule R N} (hA : DirectSum.IsInternal A)
+    (hB : DirectSum.IsInternal B) {a : ι} {f : M →ₗ[R] N}
+    (hf : ∀ p, (A p).map f ≤ B (p + a)) (q : ι) :
+    B q ⊓ LinearMap.range f ≤ (A (q - a)).map f := by
+  classical
+  letI := hA.chooseDecomposition
+  letI := hB.chooseDecomposition
+  rintro _ ⟨hy, x, rfl⟩
+  refine ⟨(DirectSum.decompose A x (q - a) : M),
+    (DirectSum.decompose A x (q - a)).2, ?_⟩
+  calc
+    f (DirectSum.decompose A x (q - a) : M) =
+        (DirectSum.decompose B (f x) ((q - a) + a) : N) :=
+      (decomposeMapHomogeneous A B hf x (q - a)).symm
+    _ = f x := by
+      rw [sub_add_cancel]
+      exact DirectSum.decompose_of_mem_same B hy
+
+private theorem isInternalComapSubtypeOfIsHomogeneous
+    {ι R M : Type*} [DecidableEq ι] [Ring R] [AddCommGroup M] [Module R M]
+    (A : ι → Submodule R M) [DirectSum.Decomposition A]
+    (S : Submodule R M) (hS : DirectSum.SetLike.IsHomogeneous A S) :
+    DirectSum.IsInternal (fun p ↦ (A p).comap S.subtype) := by
+  classical
+  have hsub : Function.Injective S.subtype := S.subtype_injective
+  have hind : iSupIndep (fun p ↦ S ⊓ A p) :=
+    (DirectSum.Decomposition.isInternal (ℳ := A)).submodule_iSupIndep.mono
+      (fun _ ↦ inf_le_right)
+  rw [DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top]
+  refine ⟨iSupIndep_def.mpr (fun p ↦ ?_), ?_⟩
+  · rw [disjoint_iff, ← (Submodule.map_injective_of_injective hsub).eq_iff,
+      Submodule.map_inf S.subtype hsub, Submodule.map_bot]
+    simp only [Submodule.map_iSup, Submodule.map_comap_subtype]
+    exact disjoint_iff.mp (iSupIndep_def.mp hind p)
+  · rw [← (Submodule.map_injective_of_injective hsub).eq_iff,
+      Submodule.map_subtype_top]
+    simp only [Submodule.map_iSup, Submodule.map_comap_subtype]
+    apply le_antisymm (iSup_le (fun _ ↦ inf_le_left))
+    intro x hx
+    rw [← DirectSum.sum_support_decompose A x]
+    exact Submodule.sum_mem _ fun p _ ↦
+      Submodule.mem_iSup_of_mem p ⟨hS p hx, (DirectSum.decompose A x p).2⟩
+
+private theorem isInternalMapMkQOfIsHomogeneous
+    {ι R M : Type*} [DecidableEq ι] [Ring R] [AddCommGroup M] [Module R M]
+    (A : ι → Submodule R M) [DirectSum.Decomposition A]
+    (B : Submodule R M) (hB : DirectSum.SetLike.IsHomogeneous A B) :
+    DirectSum.IsInternal (fun p ↦ (A p).map B.mkQ) := by
+  rw [DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top]
+  refine ⟨iSupIndep_def.mpr (fun p ↦ ?_), ?_⟩
+  · rw [Submodule.disjoint_def]
+    intro ξ hξp hξrest
+    obtain ⟨a, ha, haξ⟩ := Submodule.mem_map.mp hξp
+    have hξrest' : ξ ∈ ⨆ q : {q // q ≠ p}, (A q).map B.mkQ := by
+      simpa [iSup_subtype] using hξrest
+    rw [← Submodule.map_iSup] at hξrest'
+    obtain ⟨b, hb, hbξ⟩ := Submodule.mem_map.mp hξrest'
+    have hb0 : (DirectSum.decompose A b p : M) = 0 := by
+      refine Submodule.iSup_induction (fun q : {q // q ≠ p} ↦ A q)
+        (motive := fun x ↦ (DirectSum.decompose A x p : M) = 0) hb ?_ ?_ ?_
+      · intro q x hx
+        exact DirectSum.decompose_of_mem_ne A hx q.property
+      · simp
+      · intro x y hx hy
+        simp [hx, hy]
+    have hc : a - b ∈ B := by
+      rw [← Submodule.ker_mkQ B, LinearMap.mem_ker, map_sub, haξ, hbξ, sub_self]
+    have hcproj : (DirectSum.decompose A (a - b) p : M) ∈ B := hB p hc
+    have haB : a ∈ B := by
+      simpa [DirectSum.decompose_sub, DirectSum.decompose_of_mem_same A ha, hb0] using hcproj
+    calc
+      ξ = B.mkQ a := haξ.symm
+      _ = 0 := (Submodule.Quotient.mk_eq_zero B).mpr haB
+  · rw [← Submodule.map_iSup,
+      (DirectSum.Decomposition.isInternal (ℳ := A)).submodule_iSup_eq_top,
+      Submodule.map_top, Submodule.range_mkQ]
 
 /-! ## Graded exact couples -/
 
 /-- A **graded exact couple** of `R`-modules over the degree group `ι`: an
-`ExactCouple R` with `ι`-gradings `gradD`, `gradE` of its two modules, such that
-`gradD` is internally direct and the three maps `i, j, k` are homogeneous of
-degrees `di, dj, dk`.  (Only the `D`-grading is required to be internally direct;
-that is all the derived-couple degree bookkeeping needs.) -/
+`ExactCouple R` with internal direct-sum `ι`-gradings `gradD`, `gradE` of its two
+modules, such that the three maps `i, j, k` are homogeneous of degrees
+`di, dj, dk`. -/
 structure GradedExactCouple (R : Type*) [Ring R] (ι : Type*) [AddCommGroup ι]
     [DecidableEq ι] extends ExactCouple.{u} R where
   /-- Degree of `i`. -/
@@ -133,6 +215,8 @@ structure GradedExactCouple (R : Type*) [Ring R] (ι : Type*) [AddCommGroup ι]
   gradE : ι → Submodule R toExactCouple.E
   /-- `D` is internally direct-sum decomposed by `gradD`. -/
   internalD : DirectSum.IsInternal gradD
+  /-- `E` is internally direct-sum decomposed by `gradE`. -/
+  internalE : DirectSum.IsInternal gradE
   /-- `i` is homogeneous of degree `di`. -/
   homog_i : ∀ p, (gradD p).map toExactCouple.i ≤ gradD (p + di)
   /-- `j` is homogeneous of degree `dj`. -/
@@ -190,7 +274,7 @@ theorem derK_homog (p : ι) :
   simp only [Submodule.mem_comap, Submodule.coe_subtype] at he
   simp only [derGradD, Submodule.mem_comap, Submodule.coe_subtype]
   rw [show C.derK (C.derEmk e) = C.derK (Submodule.Quotient.mk e) from rfl,
-    ExactCouple.derK_mk]
+    ExactCouple.coe_derK_mk]
   exact C.homog_k p ⟨(e : C.E), he, rfl⟩
 
 /-- `j'` is homogeneous of degree `dj - di`.  This is the step that uses the
@@ -204,7 +288,7 @@ theorem derJ_homog (p : ι) :
   -- (y : D) ∈ gradD p and ∈ range i (it is in the subtype derD)
   have hyr : (y : C.D) ∈ LinearMap.range C.i := y.2
   obtain ⟨x', hx'mem, hx'⟩ :=
-    C.internalD.inf_range_le_map C.homog_i p ⟨hy, hyr⟩
+    C.internalD.inf_range_le_map C.internalD C.homog_i p ⟨hy, hyr⟩
   -- x' ∈ gradD (p - di), i x' = (y : D)
   have hyeq : y = ⟨C.i x', ⟨x', rfl⟩⟩ := Subtype.ext hx'.symm
   rw [hyeq, ExactCouple.derJ_apply]
@@ -232,13 +316,13 @@ theorem derivedCouple_homog_d (p : ι) :
 
 The last thing needed to turn a graded exact couple into a *graded* spectral
 sequence is to package `derivedCouple` back into a `GradedExactCouple`, with the
-derived gradings `derGradD`, `derGradE` and degrees `di, dj - di, dk`.  The only
-new fact required is that `derGradD` is internally direct, i.e. that `im i` is a
-graded submodule of `D`.  This holds because `im i = ⨆ s, i (gradD s)` and each
-`i (gradD s)` lands in `gradD (s + di) ⊓ im i` (homogeneity of `i`). -/
+derived gradings `derGradD`, `derGradE` and degrees `di, dj - di, dk`.  The image
+`im i` is graded because `i` is homogeneous.  The homology `ker d / im d` is
+graded because the kernel and image of a homogeneous map are homogeneous and an
+internal grading descends through a homogeneous quotient. -/
 
 /-- `im i = range C.i` is a graded submodule: the derived `D`-grading `derGradD`
-is internally direct.  This is the only new ingredient needed to iterate. -/
+is internally direct. -/
 theorem isInternal_derGradD : DirectSum.IsInternal C.derGradD := by
   classical
   have hsub : Function.Injective C.derD.subtype := C.derD.subtype_injective
@@ -265,6 +349,48 @@ theorem isInternal_derGradD : DirectSum.IsInternal C.derGradD := by
     refine le_trans (le_inf ?_ (C.homog_i s)) (le_iSup (fun i ↦ C.derD ⊓ C.gradD i) (s + C.di))
     rintro _ ⟨x, _, rfl⟩; exact ⟨x, rfl⟩
 
+/-- The homology `ker d / im d` inherits an internal grading from `E`: the
+derived `E`-grading `derGradE` is internally direct. -/
+theorem isInternal_derGradE : DirectSum.IsInternal C.derGradE := by
+  letI : DirectSum.Decomposition C.gradE := C.internalE.chooseDecomposition
+  let Z : ι → Submodule R (LinearMap.ker C.d) :=
+    fun p ↦ (C.gradE p).comap (LinearMap.ker C.d).subtype
+  have hker : DirectSum.SetLike.IsHomogeneous C.gradE (LinearMap.ker C.d) := by
+    intro p x hx
+    rw [LinearMap.mem_ker] at hx ⊢
+    rw [← decomposeMapHomogeneous C.gradE C.gradE C.homog_d x p, hx]
+    simp
+  have hZ : DirectSum.IsInternal Z :=
+    isInternalComapSubtypeOfIsHomogeneous C.gradE (LinearMap.ker C.d) hker
+  letI : DirectSum.Decomposition Z := hZ.chooseDecomposition
+  have hsubtype : ∀ p, (Z p).map (LinearMap.ker C.d).subtype ≤ C.gradE (p + 0) := by
+    intro p
+    rintro _ ⟨z, hz, rfl⟩
+    simpa [Z] using hz
+  have hdecomp_coe (e : LinearMap.ker C.d) (p : ι) :
+      ((DirectSum.decompose Z e p : LinearMap.ker C.d) : C.E) =
+        (DirectSum.decompose C.gradE (e : C.E) p : C.E) := by
+    have h := (decomposeMapHomogeneous Z C.gradE hsubtype e p).symm
+    rw [add_zero] at h
+    exact h
+  have himd : DirectSum.SetLike.IsHomogeneous Z C.imd := by
+    intro p e he
+    rw [Submodule.mem_comap] at he ⊢
+    obtain ⟨x, hx⟩ := he
+    change C.d x = (e : C.E) at hx
+    refine ⟨(DirectSum.decompose C.gradE x (p - (C.dj + C.dk)) : C.E), ?_⟩
+    have hmap := decomposeMapHomogeneous
+      C.gradE C.gradE C.homog_d x (p - (C.dj + C.dk))
+    rw [sub_add_cancel] at hmap
+    calc
+      C.d (DirectSum.decompose C.gradE x (p - (C.dj + C.dk)) : C.E) =
+          (DirectSum.decompose C.gradE (C.d x) p : C.E) := hmap.symm
+      _ = (DirectSum.decompose C.gradE (e : C.E) p : C.E) := by rw [hx]
+      _ = ((DirectSum.decompose Z e p : LinearMap.ker C.d) : C.E) :=
+        (hdecomp_coe e p).symm
+  change DirectSum.IsInternal (fun p ↦ (Z p).map C.imd.mkQ)
+  exact isInternalMapMkQOfIsHomogeneous Z C.imd himd
+
 /-- The **derived graded exact couple**: `derivedCouple` regraded by `derGradD`,
 `derGradE`, with degrees `di`, `dj - di`, `dk`.  Iterating this gives the pages
 of the associated graded spectral sequence. -/
@@ -277,9 +403,13 @@ noncomputable def derivedGraded (C : GradedExactCouple.{u} R ι) :
   gradD := C.derGradD
   gradE := C.derGradE
   internalD := C.isInternal_derGradD
+  internalE := C.isInternal_derGradE
   homog_i := C.derI_homog
   homog_j := C.derJ_homog
   homog_k := C.derK_homog
+
+@[simp] theorem derivedGraded_toExactCouple :
+    C.derivedGraded.toExactCouple = C.toExactCouple.derivedCouple := rfl
 
 /-- The `r`-th derived graded couple (`gradedDerived 0 = C`), grading the pages of
 the spectral sequence of a graded exact couple. -/
@@ -297,7 +427,7 @@ noncomputable def gradedDerived (C : GradedExactCouple.{u} R ι) :
 `r`-th derived couple: the graded and the ungraded iterations agree, so the
 degree information of `gradedDerived` applies to the pages `ExactCouple.page`
 of the underlying couple. -/
-theorem gradedDerived_toExactCouple (r : ℕ) :
+@[simp] theorem gradedDerived_toExactCouple (r : ℕ) :
     (C.gradedDerived r).toExactCouple = C.toExactCouple.derived r := by
   induction r with
   | zero => rfl
@@ -305,6 +435,21 @@ theorem gradedDerived_toExactCouple (r : ℕ) :
     change ((C.gradedDerived n).toExactCouple).derivedCouple =
       (C.toExactCouple.derived n).derivedCouple
     rw [ih]
+
+/-- The module on the `r`-th page, equipped below with `pageGrading`. -/
+noncomputable abbrev gradedPage (r : ℕ) : Type u := (C.gradedDerived r).E
+
+/-- The internal grading on the `r`-th page. -/
+noncomputable abbrev pageGrading (r : ℕ) (p : ι) : Submodule R (C.gradedPage r) :=
+  (C.gradedDerived r).gradE p
+
+/-- Every page grading is an internal direct sum. -/
+theorem pageGrading_isInternal (r : ℕ) : DirectSum.IsInternal (C.pageGrading r) :=
+  (C.gradedDerived r).internalE
+
+/-- The differential on the `r`-th graded page. -/
+noncomputable abbrev gradedPageDiff (r : ℕ) : C.gradedPage r →ₗ[R] C.gradedPage r :=
+  (C.gradedDerived r).d
 
 @[simp] theorem gradedDerived_di (r : ℕ) : (C.gradedDerived r).di = C.di := by
   induction r with
@@ -333,5 +478,12 @@ theorem gradedDerived_homog_d (r : ℕ) (p : ι) :
   have h := (C.gradedDerived r).homog_d p
   rw [gradedDerived_dj, gradedDerived_dk] at h
   rwa [show p + ((C.dj - r • C.di) + C.dk) = p + ((C.dj + C.dk) - r • C.di) by abel] at h
+
+/-- The differential on `gradedPage r` is homogeneous of degree
+`(dj + dk) - r • di` for its internal page grading. -/
+theorem pageGrading_homog_diff (r : ℕ) (p : ι) :
+    (C.pageGrading r p).map (C.gradedPageDiff r) ≤
+      C.pageGrading r (p + ((C.dj + C.dk) - r • C.di)) :=
+  C.gradedDerived_homog_d r p
 
 end GradedExactCouple

--- a/FLT/Slop/ExactCouple/Graded.lean
+++ b/FLT/Slop/ExactCouple/Graded.lean
@@ -64,6 +64,8 @@ exact couple, graded exact couple, spectral sequence, bidegree
 
 @[expose] public section
 
+namespace Slop
+
 open LinearMap Submodule Function DirectSum
 
 universe u
@@ -288,7 +290,7 @@ theorem derJ_homog (p : ι) :
   -- (y : D) ∈ gradD p and ∈ range i (it is in the subtype derD)
   have hyr : (y : C.D) ∈ LinearMap.range C.i := y.2
   obtain ⟨x', hx'mem, hx'⟩ :=
-    C.internalD.inf_range_le_map C.internalD C.homog_i p ⟨hy, hyr⟩
+    DirectSum.IsInternal.inf_range_le_map C.internalD C.internalD C.homog_i p ⟨hy, hyr⟩
   -- x' ∈ gradD (p - di), i x' = (y : D)
   have hyeq : y = ⟨C.i x', ⟨x', rfl⟩⟩ := Subtype.ext hx'.symm
   rw [hyeq, ExactCouple.derJ_apply]
@@ -487,3 +489,5 @@ theorem pageGrading_homog_diff (r : ℕ) (p : ι) :
   C.gradedDerived_homog_d r p
 
 end GradedExactCouple
+
+end Slop

--- a/FLT/Slop/ExactCouple/Graded.lean
+++ b/FLT/Slop/ExactCouple/Graded.lean
@@ -1,0 +1,337 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.ExactCouple.Basic
+public import Mathlib.Algebra.DirectSum.Decomposition
+
+/-!
+# Graded exact couples and the bidegree of the differentials
+
+This file upgrades `FLT.Slop.ExactCouple.Basic` to the **graded** setting,
+following the classical bookkeeping of Weibel (*An Introduction to Homological
+Algebra*, §5.9) and McCleary (*A User's Guide to Spectral Sequences*, §2.2).
+
+In every exact couple that occurs in nature the modules `D`, `E` carry a grading
+(by an abelian group `ι` of "degrees" — a single degree `ℤ`, a bidegree `ℤ × ℤ`,
+etc.) and the three maps `i, j, k` are **homogeneous** of fixed degrees
+`di, dj, dk`.  The differential `d = j ∘ k` is then homogeneous of degree
+`dj + dk`, and — this is the whole point of gradings — the derived couple is
+again graded, with `i'` of degree `di`, `j'` of degree `dj - di`, and `k'` of
+degree `dk`.  Consequently the differential of the derived couple,
+`d' = j' ∘ k'`, has degree
+
+```
+    deg d' = (dj - di) + dk = (dj + dk) - di = deg d - di.
+```
+
+Iterating, the `r`-th derived differential has degree `deg d - r • di`:
+**each derivation drops the differential's degree by `di`.**  This degree-shift
+is the defining structural feature of a graded spectral sequence.  For example,
+the exact couple of a filtered complex has bidegrees `di = (-1, 1)`,
+`dj = (0, 0)`, `dk = (1, 0)`, and its page `r` is the classical page `E_{r+1}`;
+the closed form gives its `r`-th differential the degree `(r + 1, -r)`, the
+familiar bidegree of the classical `d_{r+1} : E_{r+1}^{p,q} → E_{r+1}^{p+r+1, q-r}`.
+
+## Main definitions and results
+
+* `GradedExactCouple R ι` : an `ExactCouple R` together with `ι`-gradings of `D`
+  and `E` (the `D`-grading internally direct) and homogeneity of `i, j, k`.
+* `GradedExactCouple.homog_d` : `d = j ∘ k` is homogeneous of degree `dj + dk`.
+* `DirectSum.IsInternal.inf_range_le_map` : the key linear-algebra lemma —
+  a homogeneous element in the image of a homogeneous map is the image of a
+  homogeneous element (this is *why* the derived `j'` drops degree by `di`).
+* `GradedExactCouple.derI_homog`, `derK_homog`, `derJ_homog` : the derived maps
+  are homogeneous of degrees `di`, `dk`, `dj - di` for the derived gradings.
+* `GradedExactCouple.derivedCouple_homog_d` : the derived differential
+  `d' = j' ∘ k'` is homogeneous of degree `(dj + dk) - di` — the bidegree drop.
+* `GradedExactCouple.derivedGraded`, `gradedDerived` : the derived couple is
+  again a graded exact couple (the new ingredient being `isInternal_derGradD`:
+  `im i` is a graded submodule), and the iteration, with the closed form
+  `gradedDerived_homog_d` : `deg d_r = (dj + dk) - r • di`.
+
+All of `ExactCouple`'s content (the derived couple is exact, `d² = 0`, the pages)
+is inherited verbatim; this file adds only the degree bookkeeping.
+
+## Tags
+
+exact couple, graded exact couple, spectral sequence, bidegree
+-/
+
+@[expose] public section
+
+open LinearMap Submodule Function DirectSum
+
+universe u
+
+/-! ## The homogeneous-image lemma -/
+
+/-- If a grading `𝒟` of `M` is internally direct and `i : M → M` is homogeneous
+of degree `a` (i.e. `i (𝒟 s) ⊆ 𝒟 (s + a)`), then a homogeneous element of degree
+`q` lying in `range i` already lies in `i (𝒟 (q - a))`.  Equivalently:
+`𝒟 q ⊓ range i ≤ (𝒟 (q - a)).map i`.  This is the algebraic heart of the
+degree-shift of the derived `j'` of a graded exact couple. -/
+theorem DirectSum.IsInternal.inf_range_le_map {ι R M : Type*} [DecidableEq ι]
+    [AddGroup ι] [Ring R] [AddCommGroup M] [Module R M] {𝒟 : ι → Submodule R M}
+    (hint : DirectSum.IsInternal 𝒟) {a : ι} {i : M →ₗ[R] M}
+    (hi : ∀ s, (𝒟 s).map i ≤ 𝒟 (s + a)) (q : ι) :
+    𝒟 q ⊓ LinearMap.range i ≤ (𝒟 (q - a)).map i := by
+  classical
+  letI := hint.chooseDecomposition
+  rintro y ⟨hyq, x, rfl⟩
+  refine ⟨(DirectSum.decompose 𝒟 x (q - a) : M), (DirectSum.decompose 𝒟 x (q - a)).2, ?_⟩
+  have hmem : ∀ s, i ((DirectSum.decompose 𝒟 x s : M)) ∈ 𝒟 (s + a) :=
+    fun s ↦ hi s ⟨_, (DirectSum.decompose 𝒟 x s).2, rfl⟩
+  have hix : i x = ∑ s ∈ (DirectSum.decompose 𝒟 x).support,
+      i ((DirectSum.decompose 𝒟 x s : M)) := by
+    conv_lhs => rw [← DirectSum.sum_support_decompose 𝒟 x, map_sum]
+  have key0 : (DirectSum.decompose 𝒟 (i x)) q
+      = ∑ s ∈ (DirectSum.decompose 𝒟 x).support,
+          (DirectSum.decompose 𝒟 (i ((DirectSum.decompose 𝒟 x s : M)))) q := by
+    rw [hix, DirectSum.decompose_sum, DirectSum.sum_apply]
+  have key : i x = ∑ s ∈ (DirectSum.decompose 𝒟 x).support,
+      ((DirectSum.decompose 𝒟 (i ((DirectSum.decompose 𝒟 x s : M)))) q : M) := by
+    rw [← DirectSum.decompose_of_mem_same 𝒟 hyq, key0, AddSubmonoidClass.coe_finsetSum]
+  have hterm : ∀ s ∈ (DirectSum.decompose 𝒟 x).support,
+      ((DirectSum.decompose 𝒟 (i ((DirectSum.decompose 𝒟 x s : M)))) q : M)
+        = if s = q - a then i ((DirectSum.decompose 𝒟 x s : M)) else 0 := by
+    intro s _
+    by_cases h : s = q - a
+    · have h' : s + a = q := by rw [h, sub_add_cancel]
+      rw [if_pos h, ← h']; exact DirectSum.decompose_of_mem_same 𝒟 (hmem s)
+    · have h' : s + a ≠ q := fun hc ↦ h (by rw [← hc, add_sub_cancel_right])
+      rw [if_neg h]; exact DirectSum.decompose_of_mem_ne 𝒟 (hmem s) h'
+  rw [Finset.sum_congr rfl hterm, Finset.sum_ite_eq'] at key
+  by_cases hs : q - a ∈ (DirectSum.decompose 𝒟 x).support
+  · rw [if_pos hs] at key; exact key.symm
+  · rw [if_neg hs] at key
+    have hz : (DirectSum.decompose 𝒟 x (q - a) : M) = 0 := by
+      rw [DFinsupp.notMem_support_iff.mp hs]; rfl
+    rw [hz, map_zero]; exact key.symm
+
+/-! ## Graded exact couples -/
+
+/-- A **graded exact couple** of `R`-modules over the degree group `ι`: an
+`ExactCouple R` with `ι`-gradings `gradD`, `gradE` of its two modules, such that
+`gradD` is internally direct and the three maps `i, j, k` are homogeneous of
+degrees `di, dj, dk`.  (Only the `D`-grading is required to be internally direct;
+that is all the derived-couple degree bookkeeping needs.) -/
+structure GradedExactCouple (R : Type*) [Ring R] (ι : Type*) [AddCommGroup ι]
+    [DecidableEq ι] extends ExactCouple.{u} R where
+  /-- Degree of `i`. -/
+  di : ι
+  /-- Degree of `j`. -/
+  dj : ι
+  /-- Degree of `k`. -/
+  dk : ι
+  /-- The grading of `D`. -/
+  gradD : ι → Submodule R toExactCouple.D
+  /-- The grading of `E`. -/
+  gradE : ι → Submodule R toExactCouple.E
+  /-- `D` is internally direct-sum decomposed by `gradD`. -/
+  internalD : DirectSum.IsInternal gradD
+  /-- `i` is homogeneous of degree `di`. -/
+  homog_i : ∀ p, (gradD p).map toExactCouple.i ≤ gradD (p + di)
+  /-- `j` is homogeneous of degree `dj`. -/
+  homog_j : ∀ p, (gradD p).map toExactCouple.j ≤ gradE (p + dj)
+  /-- `k` is homogeneous of degree `dk`. -/
+  homog_k : ∀ p, (gradE p).map toExactCouple.k ≤ gradD (p + dk)
+
+namespace GradedExactCouple
+
+variable {R : Type*} [Ring R] {ι : Type*} [AddCommGroup ι] [DecidableEq ι]
+  (C : GradedExactCouple.{u} R ι)
+
+/-- The differential `d = j ∘ k` is homogeneous of degree `dj + dk`. -/
+theorem homog_d (p : ι) :
+    (C.gradE p).map C.d ≤ C.gradE (p + (C.dj + C.dk)) := by
+  rintro _ ⟨e, he, rfl⟩
+  have h1 : C.k e ∈ C.gradD (p + C.dk) := C.homog_k p ⟨e, he, rfl⟩
+  have h2 : C.j (C.k e) ∈ C.gradE ((p + C.dk) + C.dj) := C.homog_j _ ⟨_, h1, rfl⟩
+  rw [show C.d e = C.j (C.k e) from rfl]
+  rwa [show (p + C.dk) + C.dj = p + (C.dj + C.dk) by abel] at h2
+
+/-! ## The derived gradings and homogeneity of the derived maps
+
+The derived couple (from `FLT.Slop.ExactCouple.Basic`) has `D' = im i` (the subtype
+`C.derD`) and `E' = ker d / im d` (`C.derE`).  We grade them by:
+
+* `derGradD p = (gradD p).comap derD.subtype`  (the part of `gradD p` lying in
+  `im i`, viewed inside the subtype `derD`);
+* `derGradE p = ((gradE p) ∩ ker d).image in derE`.
+
+Then `i'` has degree `di`, `k'` has degree `dk`, and — using the homogeneous-image
+lemma — `j'` has degree `dj - di`. -/
+
+/-- The grading of `D' = im i` (a submodule of the subtype `C.derD`). -/
+def derGradD (p : ι) : Submodule R C.derD := (C.gradD p).comap C.derD.subtype
+
+/-- The grading of `E' = ker d / im d`. -/
+def derGradE (p : ι) : Submodule R C.derE :=
+  ((C.gradE p).comap (LinearMap.ker C.d).subtype).map C.derEmk
+
+/-- `i'` is homogeneous of degree `di`. -/
+theorem derI_homog (p : ι) :
+    (C.derGradD p).map C.derI ≤ C.derGradD (p + C.di) := by
+  rintro _ ⟨y, hy, rfl⟩
+  simp only [derGradD, Submodule.mem_comap, Submodule.coe_subtype] at hy ⊢
+  rw [ExactCouple.derI_coe]
+  exact C.homog_i p ⟨(y : C.D), hy, rfl⟩
+
+/-- `k'` is homogeneous of degree `dk`. -/
+theorem derK_homog (p : ι) :
+    (C.derGradE p).map C.derK ≤ C.derGradD (p + C.dk) := by
+  rintro _ ⟨ξ, hξ, rfl⟩
+  simp only [derGradE] at hξ
+  obtain ⟨e, he, rfl⟩ := Submodule.mem_map.mp hξ
+  simp only [Submodule.mem_comap, Submodule.coe_subtype] at he
+  simp only [derGradD, Submodule.mem_comap, Submodule.coe_subtype]
+  rw [show C.derK (C.derEmk e) = C.derK (Submodule.Quotient.mk e) from rfl,
+    ExactCouple.derK_mk]
+  exact C.homog_k p ⟨(e : C.E), he, rfl⟩
+
+/-- `j'` is homogeneous of degree `dj - di`.  This is the step that uses the
+homogeneous-image lemma: an element of `derGradD p = gradD p ∩ im i` is
+`i` of a homogeneous element of degree `p - di`, on which `j` lands in degree
+`(p - di) + dj = p + (dj - di)`. -/
+theorem derJ_homog (p : ι) :
+    (C.derGradD p).map C.derJ ≤ C.derGradE (p + (C.dj - C.di)) := by
+  rintro _ ⟨y, hy, rfl⟩
+  simp only [derGradD] at hy
+  -- (y : D) ∈ gradD p and ∈ range i (it is in the subtype derD)
+  have hyr : (y : C.D) ∈ LinearMap.range C.i := y.2
+  obtain ⟨x', hx'mem, hx'⟩ :=
+    C.internalD.inf_range_le_map C.homog_i p ⟨hy, hyr⟩
+  -- x' ∈ gradD (p - di), i x' = (y : D)
+  have hyeq : y = ⟨C.i x', ⟨x', rfl⟩⟩ := Subtype.ext hx'.symm
+  rw [hyeq, ExactCouple.derJ_apply]
+  -- derJ y = derJAux x' = [j x']
+  have hjmem : C.j x' ∈ C.gradE ((p - C.di) + C.dj) := C.homog_j _ ⟨x', hx'mem, rfl⟩
+  simp only [derGradE, ExactCouple.derJAux_apply, Submodule.mem_map]
+  refine ⟨⟨C.j x', by simp [LinearMap.mem_ker]⟩, ?_, ?_⟩
+  · simp only [Submodule.mem_comap, Submodule.coe_subtype]
+    rwa [show (p - C.di) + C.dj = p + (C.dj - C.di) by abel] at hjmem
+  · rfl
+
+/-- **The bidegree drop.**  The derived differential `d' = j' ∘ k'` is
+homogeneous of degree `(dj + dk) - di = deg d - di`: passing to the derived
+couple drops the differential's degree by `di`. -/
+theorem derivedCouple_homog_d (p : ι) :
+    (C.derGradE p).map C.derivedCouple.d ≤ C.derGradE (p + ((C.dj + C.dk) - C.di)) := by
+  rintro _ ⟨w, hw, rfl⟩
+  -- d' w = j' (k' w); k' w has degree p + dk, then j' drops by di
+  rw [show C.derivedCouple.d w = C.derJ (C.derK w) from rfl]
+  have h1 : C.derK w ∈ C.derGradD (p + C.dk) := C.derK_homog p ⟨w, hw, rfl⟩
+  have h2 := C.derJ_homog (p + C.dk) ⟨C.derK w, h1, rfl⟩
+  rwa [show (p + C.dk) + (C.dj - C.di) = p + ((C.dj + C.dk) - C.di) by abel] at h2
+
+/-! ## Iterating: the derived couple is again a graded exact couple
+
+The last thing needed to turn a graded exact couple into a *graded* spectral
+sequence is to package `derivedCouple` back into a `GradedExactCouple`, with the
+derived gradings `derGradD`, `derGradE` and degrees `di, dj - di, dk`.  The only
+new fact required is that `derGradD` is internally direct, i.e. that `im i` is a
+graded submodule of `D`.  This holds because `im i = ⨆ s, i (gradD s)` and each
+`i (gradD s)` lands in `gradD (s + di) ⊓ im i` (homogeneity of `i`). -/
+
+/-- `im i = range C.i` is a graded submodule: the derived `D`-grading `derGradD`
+is internally direct.  This is the only new ingredient needed to iterate. -/
+theorem isInternal_derGradD : DirectSum.IsInternal C.derGradD := by
+  classical
+  have hsub : Function.Injective C.derD.subtype := C.derD.subtype_injective
+  -- The images `gradD p ⊓ im i` of the derived grading, viewed back in `D`.
+  have hGind : iSupIndep (fun p ↦ C.derD ⊓ C.gradD p) :=
+    (C.internalD.submodule_iSupIndep).mono (fun p ↦ inf_le_right)
+  rw [DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top]
+  refine ⟨iSupIndep_def.mpr (fun p ↦ ?_), ?_⟩
+  · -- Independence: reflect along the injective `subtype`.
+    rw [disjoint_iff, ← (Submodule.map_injective_of_injective hsub).eq_iff,
+      Submodule.map_inf C.derD.subtype hsub, Submodule.map_bot]
+    simp only [Submodule.map_iSup, derGradD, Submodule.map_comap_subtype]
+    exact disjoint_iff.mp (iSupIndep_def.mp hGind p)
+  · -- `⨆ p, derGradD p = ⊤`: reflect along `subtype`;
+    -- this reduces to `⨆ p, im i ⊓ gradD p = im i`.
+    rw [← (Submodule.map_injective_of_injective hsub).eq_iff, Submodule.map_subtype_top]
+    simp only [Submodule.map_iSup, derGradD, Submodule.map_comap_subtype]
+    refine le_antisymm (iSup_le (fun _ ↦ inf_le_left)) ?_
+    have hDtop : C.derD = ⨆ s, (C.gradD s).map C.i := by
+      change LinearMap.range C.i = _
+      rw [← Submodule.map_top, ← C.internalD.submodule_iSup_eq_top, Submodule.map_iSup]
+    nth_rewrite 1 [hDtop]
+    refine iSup_le (fun s ↦ ?_)
+    refine le_trans (le_inf ?_ (C.homog_i s)) (le_iSup (fun i ↦ C.derD ⊓ C.gradD i) (s + C.di))
+    rintro _ ⟨x, _, rfl⟩; exact ⟨x, rfl⟩
+
+/-- The **derived graded exact couple**: `derivedCouple` regraded by `derGradD`,
+`derGradE`, with degrees `di`, `dj - di`, `dk`.  Iterating this gives the pages
+of the associated graded spectral sequence. -/
+noncomputable def derivedGraded (C : GradedExactCouple.{u} R ι) :
+    GradedExactCouple.{u} R ι where
+  toExactCouple := C.derivedCouple
+  di := C.di
+  dj := C.dj - C.di
+  dk := C.dk
+  gradD := C.derGradD
+  gradE := C.derGradE
+  internalD := C.isInternal_derGradD
+  homog_i := C.derI_homog
+  homog_j := C.derJ_homog
+  homog_k := C.derK_homog
+
+/-- The `r`-th derived graded couple (`gradedDerived 0 = C`), grading the pages of
+the spectral sequence of a graded exact couple. -/
+noncomputable def gradedDerived (C : GradedExactCouple.{u} R ι) :
+    ℕ → GradedExactCouple.{u} R ι
+  | 0 => C
+  | (n + 1) => (C.gradedDerived n).derivedGraded
+
+@[simp] theorem gradedDerived_zero : C.gradedDerived 0 = C := rfl
+
+@[simp] theorem gradedDerived_succ (r : ℕ) :
+    C.gradedDerived (r + 1) = (C.gradedDerived r).derivedGraded := rfl
+
+/-- The underlying exact couple of the `r`-th derived graded couple is the
+`r`-th derived couple: the graded and the ungraded iterations agree, so the
+degree information of `gradedDerived` applies to the pages `ExactCouple.page`
+of the underlying couple. -/
+theorem gradedDerived_toExactCouple (r : ℕ) :
+    (C.gradedDerived r).toExactCouple = C.toExactCouple.derived r := by
+  induction r with
+  | zero => rfl
+  | succ n ih =>
+    change ((C.gradedDerived n).toExactCouple).derivedCouple =
+      (C.toExactCouple.derived n).derivedCouple
+    rw [ih]
+
+@[simp] theorem gradedDerived_di (r : ℕ) : (C.gradedDerived r).di = C.di := by
+  induction r with
+  | zero => rfl
+  | succ n ih => rw [gradedDerived, derivedGraded, ih]
+
+@[simp] theorem gradedDerived_dk (r : ℕ) : (C.gradedDerived r).dk = C.dk := by
+  induction r with
+  | zero => rfl
+  | succ n ih => rw [gradedDerived, derivedGraded, ih]
+
+/-- The `j`-degree drops by `di` at every page: `dj_r = dj - r • di`. -/
+@[simp] theorem gradedDerived_dj (r : ℕ) : (C.gradedDerived r).dj = C.dj - r • C.di := by
+  induction r with
+  | zero => change C.dj = C.dj - (0 : ℕ) • C.di; rw [zero_smul, sub_zero]
+  | succ n ih =>
+    change (C.gradedDerived n).dj - (C.gradedDerived n).di = C.dj - (n + 1) • C.di
+    rw [ih, gradedDerived_di, succ_nsmul]; abel
+
+/-- **Closed form for the page differentials' degree.**  The differential
+`d_r = j_r ∘ k_r` of the `r`-th page is homogeneous of degree
+`(dj + dk) - r • di`: each derivation drops the differential's degree by `di`. -/
+theorem gradedDerived_homog_d (r : ℕ) (p : ι) :
+    ((C.gradedDerived r).gradE p).map (C.gradedDerived r).d ≤
+      (C.gradedDerived r).gradE (p + ((C.dj + C.dk) - r • C.di)) := by
+  have h := (C.gradedDerived r).homog_d p
+  rw [gradedDerived_dj, gradedDerived_dk] at h
+  rwa [show p + ((C.dj - r • C.di) + C.dk) = p + ((C.dj + C.dk) - r • C.di) by abel] at h
+
+end GradedExactCouple

--- a/FLT/Slop/ExactCouple/README.md
+++ b/FLT/Slop/ExactCouple/README.md
@@ -25,7 +25,7 @@ noncomputable def ExactCouple.pageSuccEquiv (r : ℕ) :
 
 In the graded upgrade, `D` and `E` carry gradings by an arbitrary abelian
 group `ι` of degrees (`ℤ`, `ℤ × ℤ`, …), with `i, j, k` homogeneous of degrees
-`di, dj, dk` and the `D`-grading internally direct. Then each derived couple
+`di, dj, dk`, with both gradings internal direct sums. Then each derived couple
 is again graded, `j'` drops degree by `di`, and
 
 ```lean
@@ -55,10 +55,11 @@ degree `(r + 1, -r)` — the familiar bidegree of the classical
   `DirectSum.IsInternal.inf_range_le_map` (a homogeneous element in the
   image of a homogeneous endomorphism is the image of a homogeneous element —
   the reason `j'` drops degree), the homogeneity of the derived maps, the
-  bidegree drop `derivedCouple_homog_d`, the fact that `im i` is a graded
-  submodule (`isInternal_derGradD` — what makes the construction iterable),
-  and the iteration `gradedDerived` with the closed form
-  `gradedDerived_homog_d`. The graded and ungraded iterations agree
+  bidegree drop `derivedCouple_homog_d`, the facts that `im i` and
+  `ker d / im d` inherit internal gradings (`isInternal_derGradD` and
+  `isInternal_derGradE`), and the iteration `gradedDerived` with the closed form
+  `gradedDerived_homog_d`. `pageGrading` exposes the resulting internal grading
+  on every page. The graded and ungraded iterations agree
   (`gradedDerived_toExactCouple`), so the degree information applies to the
   pages of the underlying couple.
 
@@ -72,21 +73,22 @@ a common universe independent of the universe of `R`:
 - The iterated pages form a spectral sequence in the literal sense that
   `E_{r+1}` **is** (definitionally) the homology `ker d_r / im d_r` of the
   previous page.
-- In the graded setting, only internal directness of the `D`-grading is
-  needed; the `E`-grading may be arbitrary. Each derivation preserves the
-  degrees of `i` and `k`, drops the degree of `j` by `di`, and the `r`-th
-  differential is homogeneous of degree `(dj + dk) - r • di`.
+- In the graded setting, both modules are internal direct sums. The derived
+  homology inherits an internal grading; each derivation preserves the degrees
+  of `i` and `k`, drops the degree of `j` by `di`, and the `r`-th differential
+  is homogeneous of degree `(dj + dk) - r • di`.
 
 ## What Is Not Proved Here
 
 - No concrete exact couple is constructed in this folder (no instance from a
   filtered complex, a double complex, or a Bockstein short exact sequence).
-  A construction of the per-degree exact couple of a filtered differential
-  module (`D^p = H(F^p M)`, `E^p = E₁^p`, with the three exactness
-  statements) exists in draft form outside this repository; assembling it
-  into a `GradedExactCouple` on `⨁_p H(F^p M)` and reconciling the resulting
-  pages with the classical `Z_r/B_r` description is the natural next step.
+  The sibling `FLT/Slop/SpectralSequence/ExactCoupleBridge.lean` proves the
+  per-degree maps and exactness statements for a filtered differential module
+  (`D^p = H(F^p M)`, `E^p = E₁^p`). Assembling them into a
+  `GradedExactCouple` on `⨁_p H(F^p M)` and reconciling its derived pages with
+  the classical `Z_r/B_r` description remains the natural next step.
 - Nothing about convergence or abutments.
+- No morphisms of exact couples or functoriality of the derived pages.
 - No comparison with Mathlib's abstract `SpectralObject` framework.
 
 ## Verification
@@ -106,19 +108,22 @@ no `sorry`, and
 
 1. W. S. Massey, *Exact couples in algebraic topology*, Ann. of Math. 56
    (1952), 363–396 — the origin of exact couples and the derived couple.
-2. Stacks Project, tag 011P (exact couples and their spectral sequences); the
-   construction here follows the Stacks presentation at module level, and
-   `ExactCouple.derivedCouple` carries the `@[stacks 011P]` attribute.
+2. Stacks Project, section tag 011P (exact couples and their spectral
+   sequences); the construction here follows the Stacks presentation at module
+   level, and `ExactCouple.derivedCouple` carries the `@[stacks 011R]` attribute
+   for the derived-couple lemma.
 3. C. Weibel, *An Introduction to Homological Algebra*, §5.9; J. McCleary,
    *A User's Guide to Spectral Sequences*, §2.2 — for the graded/bidegree
    bookkeeping.
 4. Deviations: the couple is ungraded by default, with the grading added as a
    layer (`GradedExactCouple`) rather than baked in; degrees live in an
    arbitrary abelian group `ι` rather than `ℤ × ℤ`, so single gradings,
-   bigradings, and multigradings are all instances. Only the `D`-grading is
-   required to be internally direct — the textbooks assume both, but the
-   derived-couple degree bookkeeping never uses directness of the
-   `E`-grading, and weakening the hypothesis makes the iteration cleaner.
+   bigradings, and multigradings are all instances.
+
+The declarations intentionally remain in the root `ExactCouple` and
+`GradedExactCouple` namespaces because this folder mirrors an upstream mathlib
+candidate. If the code becomes FLT-specific rather than upstream-bound, it
+should move under `FLT.Slop` to avoid future name collisions.
 
 ## Relation to existing formalizations
 

--- a/FLT/Slop/ExactCouple/README.md
+++ b/FLT/Slop/ExactCouple/README.md
@@ -1,0 +1,144 @@
+# Exact couples and their spectral sequences
+
+This folder formalizes exact couples, the derived-couple theorem, and the
+resulting spectral sequence, together with the graded (bidegree) bookkeeping.
+
+An exact couple consists of `R`-modules `D`, `E` and maps `i : D → D`,
+`j : D → E`, `k : E → D`, exact at each vertex of the triangle. The
+differential `d = j ∘ k` satisfies `d² = 0`, and the derived couple
+
+```lean
+noncomputable def ExactCouple.derivedCouple : ExactCouple R
+-- D' = im i,  E' = ker d / im d,  with the induced maps i', j', k'
+```
+
+is again an exact couple — the three exactness proofs
+(`derived_exact_ij`, `derived_exact_jk`, `derived_exact_ki`) are the
+derived-couple theorem. Iterating yields the spectral sequence:
+
+```lean
+noncomputable def ExactCouple.derived : ℕ → ExactCouple R
+noncomputable def ExactCouple.pageSuccEquiv (r : ℕ) :
+    C.page (r + 1) ≃ₗ[R] (ker (C.pageDiff r) ⧸ (range (C.pageDiff r)).comap _)
+-- E_{r+1} ≃ ker d_r / im d_r, definitionally the identity map
+```
+
+In the graded upgrade, `D` and `E` carry gradings by an arbitrary abelian
+group `ι` of degrees (`ℤ`, `ℤ × ℤ`, …), with `i, j, k` homogeneous of degrees
+`di, dj, dk` and the `D`-grading internally direct. Then each derived couple
+is again graded, `j'` drops degree by `di`, and
+
+```lean
+theorem GradedExactCouple.gradedDerived_homog_d (r : ℕ) (p : ι) :
+    ((C.gradedDerived r).gradE p).map (C.gradedDerived r).d ≤
+      (C.gradedDerived r).gradE (p + ((C.dj + C.dk) - r • C.di))
+-- deg d_r = (dj + dk) - r • di
+```
+
+For the exact couple of a filtered complex one has `ι = ℤ × ℤ` and
+`di = (-1, 1)`, `dj = (0, 0)`, `dk = (1, 0)`, and page `r` of the couple is
+the classical page `E_{r+1}`; the closed form gives its differential the
+degree `(r + 1, -r)` — the familiar bidegree of the classical
+`d_{r+1} : E_{r+1}^{p,q} → E_{r+1}^{p+r+1, q-r}`.
+
+## File Guide
+
+- `Basic.lean` defines `ExactCouple R` (a bundled structure: two modules and
+  three exact maps), the differential `d = j ∘ k` with `d² = 0`, the derived
+  couple (`D' = im i`; `E' = ker d / im d`; `i'` the restriction of `i`; `j'`
+  induced via the first isomorphism theorem from `x ↦ [j x]`, which kills
+  `ker i = im k`; `k'` induced by `[e] ↦ k e`), the three exactness proofs,
+  and the iterated pages `derived`, `page`, `pageDiff` with
+  `pageDiff_comp_pageDiff` (`d_r² = 0`) and `pageSuccEquiv`.
+- `Graded.lean` defines `GradedExactCouple R ι` (extending `ExactCouple R` by
+  gradings and degree data), proves the homogeneous-image lemma
+  `DirectSum.IsInternal.inf_range_le_map` (a homogeneous element in the
+  image of a homogeneous endomorphism is the image of a homogeneous element —
+  the reason `j'` drops degree), the homogeneity of the derived maps, the
+  bidegree drop `derivedCouple_homog_d`, the fact that `im i` is a graded
+  submodule (`isInternal_derGradD` — what makes the construction iterable),
+  and the iteration `gradedDerived` with the closed form
+  `gradedDerived_homog_d`. The graded and ungraded iterations agree
+  (`gradedDerived_toExactCouple`), so the degree information applies to the
+  pages of the underlying couple.
+
+## What Is Proved
+
+Over an arbitrary (not necessarily commutative) ring `R`, with `D` and `E` in
+a common universe independent of the universe of `R`:
+
+- The derived couple of an exact couple is an exact couple (Massey's
+  derived-couple theorem).
+- The iterated pages form a spectral sequence in the literal sense that
+  `E_{r+1}` **is** (definitionally) the homology `ker d_r / im d_r` of the
+  previous page.
+- In the graded setting, only internal directness of the `D`-grading is
+  needed; the `E`-grading may be arbitrary. Each derivation preserves the
+  degrees of `i` and `k`, drops the degree of `j` by `di`, and the `r`-th
+  differential is homogeneous of degree `(dj + dk) - r • di`.
+
+## What Is Not Proved Here
+
+- No concrete exact couple is constructed in this folder (no instance from a
+  filtered complex, a double complex, or a Bockstein short exact sequence).
+  A construction of the per-degree exact couple of a filtered differential
+  module (`D^p = H(F^p M)`, `E^p = E₁^p`, with the three exactness
+  statements) exists in draft form outside this repository; assembling it
+  into a `GradedExactCouple` on `⨁_p H(F^p M)` and reconciling the resulting
+  pages with the classical `Z_r/B_r` description is the natural next step.
+- Nothing about convergence or abutments.
+- No comparison with Mathlib's abstract `SpectralObject` framework.
+
+## Verification
+
+`lake build FLT.Slop.ExactCouple` compiles with no errors, no warnings, and
+no `sorry`, and
+
+```lean
+#print axioms ExactCouple.derivedCouple
+-- [propext, Classical.choice, Quot.sound]
+
+#print axioms GradedExactCouple.gradedDerived_homog_d
+-- [propext, Classical.choice, Quot.sound]
+```
+
+## Sources, and how the formalization deviates from them
+
+1. W. S. Massey, *Exact couples in algebraic topology*, Ann. of Math. 56
+   (1952), 363–396 — the origin of exact couples and the derived couple.
+2. Stacks Project, tag 011P (exact couples and their spectral sequences); the
+   construction here follows the Stacks presentation at module level, and
+   `ExactCouple.derivedCouple` carries the `@[stacks 011P]` attribute.
+3. C. Weibel, *An Introduction to Homological Algebra*, §5.9; J. McCleary,
+   *A User's Guide to Spectral Sequences*, §2.2 — for the graded/bidegree
+   bookkeeping.
+4. Deviations: the couple is ungraded by default, with the grading added as a
+   layer (`GradedExactCouple`) rather than baked in; degrees live in an
+   arbitrary abelian group `ι` rather than `ℤ × ℤ`, so single gradings,
+   bigradings, and multigradings are all instances. Only the `D`-grading is
+   required to be internally direct — the textbooks assume both, but the
+   derived-couple degree bookkeeping never uses directness of the
+   `E`-grading, and weakening the hypothesis makes the iteration cleaner.
+
+## Relation to existing formalizations
+
+Mathlib has an abstract `SpectralObject` framework
+(`Mathlib/Algebra/Homology/SpectralObject/`), with instances coming from
+t-structures on triangulated categories and from the mapping-cone spectral
+object of a functor `ι ⥤ CochainComplex C ℤ` in the homotopy category
+(`Mathlib/Algebra/Homology/HomotopyCategory/SpectralObject.lean`). It also
+has an abstract `CategoryTheory.SpectralSequence` structure
+(`Mathlib/Algebra/Homology/SpectralSequence/Basic.lean`) recording pages
+together with isomorphisms `E_{r+1} ≅ H(E_r)`. Neither development contains
+exact couples, and no spectral sequence of a filtered complex of modules is
+derived from them in mathlib. This folder is independent of both; packaging
+the pages of an `ExactCouple` as a `CategoryTheory.SpectralSequence` in
+`ModuleCat R` would be a natural compatibility layer when upstreaming.
+
+## Possible next steps
+
+- The exact couple of a filtered differential module / filtered complex, as a
+  `GradedExactCouple` over `ι = ℤ`, and the identification of its pages with
+  the classical `Z_r^p / B_r^p`.
+- The Bockstein exact couple of `0 → ℤ/p → ℤ/p² → ℤ/p → 0`.
+- Convergence statements (bounded filtrations, `E_∞` and the abutment).

--- a/FLT/Slop/ExactCouple/README.md
+++ b/FLT/Slop/ExactCouple/README.md
@@ -82,14 +82,14 @@ a common universe independent of the universe of `R`:
 
 - No concrete exact couple is constructed in this folder (no instance from a
   filtered complex, a double complex, or a Bockstein short exact sequence).
-  The sibling `FLT/Slop/SpectralSequence/ExactCoupleBridge.lean` proves the
-  per-degree maps and exactness statements for a filtered differential module
-  (`D^p = H(F^p M)`, `E^p = E₁^p`). Assembling them into a
-  `GradedExactCouple` on `⨁_p H(F^p M)` and reconciling its derived pages with
-  the classical `Z_r/B_r` description remains the natural next step.
+  The sibling `FLT/Slop/SpectralSequence/ExactCoupleBridge.lean` constructs
+  the exact couple of a filtered differential module and assembles it into a
+  `GradedExactCouple` on `⨁_p H(F^p M)`. Reconciling its derived pages with the
+  classical `Z_r/B_r` description remains future work.
 - Nothing about convergence or abutments.
 - No morphisms of exact couples or functoriality of the derived pages.
-- No comparison with Mathlib's abstract `SpectralObject` framework.
+- No comparison between the iterated exact-couple pages and Mathlib's abstract
+  `SpectralObject` framework.
 
 ## Verification
 
@@ -136,14 +136,14 @@ has an abstract `CategoryTheory.SpectralSequence` structure
 (`Mathlib/Algebra/Homology/SpectralSequence/Basic.lean`) recording pages
 together with isomorphisms `E_{r+1} ≅ H(E_r)`. Neither development contains
 exact couples, and no spectral sequence of a filtered complex of modules is
-derived from them in mathlib. This folder is independent of both; packaging
-the pages of an `ExactCouple` as a `CategoryTheory.SpectralSequence` in
-`ModuleCat R` would be a natural compatibility layer when upstreaming.
+derived from them in mathlib. This folder is independent of both. The sibling
+`FLT/Slop/SpectralSequence/CategoryTheory.lean` packages the concrete filtered-
+complex construction in `CategoryTheory.SpectralSequence`; packaging the pages
+of an arbitrary `ExactCouple` remains a separate compatibility layer.
 
 ## Possible next steps
 
-- The exact couple of a filtered differential module / filtered complex, as a
-  `GradedExactCouple` over `ι = ℤ`, and the identification of its pages with
-  the classical `Z_r^p / B_r^p`.
+- Identify the pages of the filtered differential module's graded exact couple
+  with the classical `Z_r^p / B_r^p` construction.
 - The Bockstein exact couple of `0 → ℤ/p → ℤ/p² → ℤ/p → 0`.
 - Convergence statements (bounded filtrations, `E_∞` and the abutment).

--- a/FLT/Slop/ExactCouple/README.md
+++ b/FLT/Slop/ExactCouple/README.md
@@ -52,7 +52,7 @@ degree `(r + 1, -r)` — the familiar bidegree of the classical
   `pageDiff_comp_pageDiff` (`d_r² = 0`) and `pageSuccEquiv`.
 - `Graded.lean` defines `GradedExactCouple R ι` (extending `ExactCouple R` by
   gradings and degree data), proves the homogeneous-image lemma
-  `DirectSum.IsInternal.inf_range_le_map` (a homogeneous element in the
+  `Slop.DirectSum.IsInternal.inf_range_le_map` (a homogeneous element in the
   image of a homogeneous endomorphism is the image of a homogeneous element —
   the reason `j'` drops degree), the homogeneity of the derived maps, the
   bidegree drop `derivedCouple_homog_d`, the facts that `im i` and
@@ -97,10 +97,10 @@ a common universe independent of the universe of `R`:
 no `sorry`, and
 
 ```lean
-#print axioms ExactCouple.derivedCouple
+#print axioms Slop.ExactCouple.derivedCouple
 -- [propext, Classical.choice, Quot.sound]
 
-#print axioms GradedExactCouple.gradedDerived_homog_d
+#print axioms Slop.GradedExactCouple.gradedDerived_homog_d
 -- [propext, Classical.choice, Quot.sound]
 ```
 
@@ -120,10 +120,9 @@ no `sorry`, and
    arbitrary abelian group `ι` rather than `ℤ × ℤ`, so single gradings,
    bigradings, and multigradings are all instances.
 
-The declarations intentionally remain in the root `ExactCouple` and
-`GradedExactCouple` namespaces because this folder mirrors an upstream mathlib
-candidate. If the code becomes FLT-specific rather than upstream-bound, it
-should move under `FLT.Slop` to avoid future name collisions.
+All declarations live under the `Slop` namespace (`Slop.ExactCouple`,
+`Slop.GradedExactCouple`), following the `FLT/Slop` convention and avoiding
+collisions with future mathlib; an upstream mathlib PR would drop the prefix.
 
 ## Relation to existing formalizations
 

--- a/FLT/Slop/SpectralSequence.lean
+++ b/FLT/Slop/SpectralSequence.lean
@@ -5,6 +5,7 @@ Authors: Akhil Mathew
 -/
 module
 
+public import FLT.Slop.SpectralSequence.CategoryTheory
 public import FLT.Slop.SpectralSequence.DoubleComplex
 public import FLT.Slop.SpectralSequence.ExactCoupleBridge
 
@@ -28,6 +29,9 @@ following the Stacks Project (tags 012A and 012K).
   `DoubleComplex.rowPageOneEquiv`, `DoubleComplex.colFiltered_five_term_exact`).
 * `FLT.Slop.SpectralSequence.ExactCoupleBridge` — the exact couple of a
   filtered differential module
-  (`FilteredDifferentialModule.range_iMap_eq_ker_jMap` and companions),
-  bridging to `FLT.Slop.ExactCouple`.
+  (`FilteredDifferentialModule.gradedExactCouple`), bridging to
+  `FLT.Slop.ExactCouple`.
+* `FLT.Slop.SpectralSequence.CategoryTheory` — packages the concrete pages as
+  mathlib's `CategoryTheory.CohomologicalSpectralSequence` via
+  `FilteredComplex.toCohomologicalSpectralSequence`.
 -/

--- a/FLT/Slop/SpectralSequence.lean
+++ b/FLT/Slop/SpectralSequence.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.SpectralSequence.DoubleComplex
+public import FLT.Slop.SpectralSequence.ExactCoupleBridge
+
+/-!
+# The spectral sequence of a filtered complex
+
+Umbrella module for the `FLT.Slop.SpectralSequence` library: the spectral
+sequence of a filtered differential module and of a filtered cochain complex,
+following the Stacks Project (tags 012A and 012K).
+
+* `FLT.Slop.SpectralSequence.FilteredModule` — the pages, differentials,
+  `E_{r+1} ≅ H(E_r, d_r)` (`FilteredDifferentialModule.pageSuccEquiv`) and the
+  convergence theory of a filtered differential module.
+* `FLT.Slop.SpectralSequence.FilteredComplex` — the graded refinement for a
+  filtered cochain complex (`FilteredComplex.pageSuccEquiv`,
+  `FilteredComplex.pageEquivGrHOfBounded`).
+* `FLT.Slop.SpectralSequence.FiveTerm` — the five-term exact sequence of
+  low-degree terms (`FilteredComplex.five_term_exact`).
+* `FLT.Slop.SpectralSequence.DoubleComplex` — the two spectral sequences of a
+  first-quadrant double complex (`DoubleComplex.colPageOneEquiv`,
+  `DoubleComplex.rowPageOneEquiv`, `DoubleComplex.colFiltered_five_term_exact`).
+* `FLT.Slop.SpectralSequence.ExactCoupleBridge` — the exact couple of a
+  filtered differential module
+  (`FilteredDifferentialModule.range_iMap_eq_ker_jMap` and companions),
+  bridging to `FLT.Slop.ExactCouple`.
+-/

--- a/FLT/Slop/SpectralSequence/CategoryTheory.lean
+++ b/FLT/Slop/SpectralSequence/CategoryTheory.lean
@@ -24,6 +24,8 @@ categorical homology of the page complex with the explicit quotient
 
 @[expose] public section
 
+namespace Slop
+
 open CategoryTheory
 open Submodule LinearMap
 
@@ -227,3 +229,5 @@ noncomputable def toCohomologicalSpectralSequence (r₀ : ℤ) :
     exact K.pageHomologyIso r b
 
 end FilteredComplex
+
+end Slop

--- a/FLT/Slop/SpectralSequence/CategoryTheory.lean
+++ b/FLT/Slop/SpectralSequence/CategoryTheory.lean
@@ -1,0 +1,229 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.SpectralSequence.FilteredComplex
+public import Mathlib.Algebra.Homology.SpectralSequence.Basic
+import Mathlib.Algebra.Homology.ShortComplex.ModuleCat
+
+/-!
+# The categorical spectral sequence of a filtered complex
+
+This file packages the concrete pages of a `FilteredComplex` as mathlib's
+`CategoryTheory.CohomologicalSpectralSequence` in `ModuleCat`.
+
+At page `r`, the object in bidegree `(p, q)` is
+`FilteredComplex.pageBigraded r p q`, and the differential has bidegree
+`(r, 1 - r)`.  The successor isomorphism is obtained by comparing the
+categorical homology of the page complex with the explicit quotient
+`ker dᵣ / range dᵣ`, then applying `FilteredComplex.pageSuccEquiv`.
+-/
+
+@[expose] public section
+
+open CategoryTheory
+open Submodule LinearMap
+
+universe u v
+
+namespace FilteredComplex
+
+variable {R : Type u} [Ring R] (K : FilteredComplex.{u, v} R)
+
+/-- The differential on the categorical `r`-page.  It is the concrete page
+differential when the two bidegrees differ by `(r, 1 - r)`, and zero otherwise. -/
+def pageDifferential (r : ℤ) (a b : ℤ × ℤ) :
+    K.pageBigraded r a.1 a.2 →ₗ[R] K.pageBigraded r b.1 b.2 :=
+  if h : a + (⟨r, 1 - r⟩ : ℤ × ℤ) = b then
+    K.dPageAux r a.1 b.1 (a.1 + a.2) (b.1 + b.2)
+      (by
+        have h1 := congrArg Prod.fst h
+        simpa using h1.symm)
+      (by
+        have h1 := congrArg Prod.fst h
+        have h2 := congrArg Prod.snd h
+        dsimp at h1 h2
+        omega)
+  else 0
+
+/-- If two bidegrees differ by `(r, 1 - r)`, `pageDifferential` is the
+corresponding concrete page differential. -/
+@[simp]
+lemma pageDifferential_of_rel (r : ℤ) (a b : ℤ × ℤ)
+    (h : a + (⟨r, 1 - r⟩ : ℤ × ℤ) = b) :
+    pageDifferential K r a b =
+      K.dPageAux r a.1 b.1 (a.1 + a.2) (b.1 + b.2)
+        (by
+          have h1 := congrArg Prod.fst h
+          simpa using h1.symm)
+        (by
+          have h1 := congrArg Prod.fst h
+          have h2 := congrArg Prod.snd h
+          dsimp at h1 h2
+          omega) := by
+  simp only [pageDifferential, dif_pos h]
+
+/-- The `r`-page of a filtered complex as a homological complex in `ModuleCat`.
+Its objects are the bigraded pages and its complex shape has step `(r, 1 - r)`. -/
+def pageComplex (r : ℤ) :
+    HomologicalComplex (ModuleCat.{v} R)
+      (ComplexShape.up' (⟨r, 1 - r⟩ : ℤ × ℤ)) where
+  X a := ModuleCat.of R (K.pageBigraded r a.1 a.2)
+  d a b := ModuleCat.ofHom (pageDifferential K r a b)
+  shape a b h := by
+    change ¬a + (⟨r, 1 - r⟩ : ℤ × ℤ) = b at h
+    apply ModuleCat.hom_ext
+    simp [pageDifferential, h]
+  d_comp_d' a b c hab hbc := by
+    apply ModuleCat.hom_ext
+    simp only [ModuleCat.hom_comp, ModuleCat.hom_ofHom, ModuleCat.hom_zero]
+    rw [pageDifferential_of_rel K r a b hab]
+    rw [pageDifferential_of_rel K r b c hbc]
+    apply K.dPageAux_comp
+
+/-- The object of `pageComplex` at `(p, q)` is the concrete bigraded page
+`Eᵣ^{p,q}`. -/
+@[simp]
+lemma pageComplex_X (r : ℤ) (a : ℤ × ℤ) :
+    (K.pageComplex r).X a = ModuleCat.of R (K.pageBigraded r a.1 a.2) := rfl
+
+/-- On a pair of related bidegrees, the underlying linear map of the
+categorical page differential is `FilteredComplex.dPageAux`. -/
+@[simp]
+lemma pageComplex_d_hom_of_rel (r : ℤ) (a b : ℤ × ℤ)
+    (h : a + (⟨r, 1 - r⟩ : ℤ × ℤ) = b) :
+    ((K.pageComplex r).d a b).hom =
+      K.dPageAux r a.1 b.1 (a.1 + a.2) (b.1 + b.2)
+        (by
+          have h1 := congrArg Prod.fst h
+          simpa using h1.symm)
+        (by
+          have h1 := congrArg Prod.fst h
+          have h2 := congrArg Prod.snd h
+          dsimp at h1 h2
+          omega) := by
+  simp [pageComplex, pageDifferential, h]
+
+/-! ## Functoriality of the categorical pages -/
+
+section Functoriality
+
+variable {K K' K'' : FilteredComplex.{u, v} R}
+
+/-- The morphism of categorical `r`-pages induced by a morphism of filtered
+cochain complexes. -/
+def Hom.pageHom (f : K ⟶ K') (r : ℤ) : K.pageComplex r ⟶ K'.pageComplex r where
+  f a := ModuleCat.ofHom (f.mapPage r a.1 (a.1 + a.2))
+  comm' a b hab := by
+    have hp : b.1 = a.1 + r := by
+      have h := congrArg Prod.fst hab
+      simpa using h.symm
+    have hn : b.1 + b.2 = a.1 + a.2 + 1 := by
+      have h1 := congrArg Prod.fst hab
+      have h2 := congrArg Prod.snd hab
+      dsimp at h1 h2
+      omega
+    apply ModuleCat.hom_ext
+    simp only [ModuleCat.hom_comp]
+    rw [K.pageComplex_d_hom_of_rel r a b hab]
+    rw [K'.pageComplex_d_hom_of_rel r a b hab]
+    exact (f.mapPage_dPageAux r a.1 b.1 (a.1 + a.2) (b.1 + b.2) hp hn).symm
+
+@[simp] lemma Hom.pageHom_f (f : K ⟶ K') (r : ℤ) (a : ℤ × ℤ) :
+    (f.pageHom r).f a = ModuleCat.ofHom (f.mapPage r a.1 (a.1 + a.2)) := rfl
+
+@[simp] lemma Hom.pageHom_id (K : FilteredComplex.{u, v} R) (r : ℤ) :
+    Hom.pageHom (𝟙 K) r = 𝟙 (K.pageComplex r) := by
+  ext a
+  simp
+
+@[simp] lemma Hom.pageHom_comp (f : K ⟶ K') (g : K' ⟶ K'') (r : ℤ) :
+    (f ≫ g).pageHom r = f.pageHom r ≫ g.pageHom r := by
+  ext a
+  simp
+
+/-- The functor sending a filtered complex to its categorical `r`-page. -/
+@[simps]
+def pageComplexFunctor (R : Type u) [Ring R] (r : ℤ) :
+    FilteredComplex.{u, v} R ⥤
+      HomologicalComplex (ModuleCat.{v} R)
+        (ComplexShape.up' (⟨r, 1 - r⟩ : ℤ × ℤ)) where
+  obj K := K.pageComplex r
+  map f := f.pageHom r
+
+end Functoriality
+
+/-- The categorical homology of the `r`-page at a bidegree is isomorphic to the
+corresponding object of the `(r + 1)`-page. -/
+noncomputable def pageHomologyIso (r : ℤ) (b : ℤ × ℤ) :
+    (K.pageComplex r).homology b ≅ (K.pageComplex (r + 1)).X b := by
+  let a : ℤ × ℤ := (b.1 - r, b.2 + r - 1)
+  let c : ℤ × ℤ := (b.1 + r, b.2 + 1 - r)
+  let shape := ComplexShape.up' (⟨r, 1 - r⟩ : ℤ × ℤ)
+  have hab : shape.Rel a b := by
+    change a + (⟨r, 1 - r⟩ : ℤ × ℤ) = b
+    apply Prod.ext
+    · dsimp [a]
+      omega
+    · dsimp [a]
+      omega
+  have hbc : shape.Rel b c := by
+    change b + (⟨r, 1 - r⟩ : ℤ × ℤ) = c
+    apply Prod.ext
+    · rfl
+    · dsimp [c]
+      omega
+  have hpin : a.1 = b.1 - r := by simp [a]
+  have hpout : c.1 = b.1 + r := by simp [c]
+  have hnin : a.1 + a.2 = b.1 + b.2 - 1 := by dsimp [a]; omega
+  have hnout : c.1 + c.2 = b.1 + b.2 + 1 := by dsimp [c]; omega
+  have pageSuccEquivAux
+      (p pin pout n nin nout : ℤ)
+      (hpin' : pin = p - r) (hpout' : pout = p + r)
+      (hnin' : nin = n - 1) (hnout' : nout = n + 1) :
+      K.page (r + 1) p n ≃ₗ[R]
+        (↥(ker (K.dPageAux r p pout n nout hpout' hnout')) ⧸
+          (range (K.dPageAux r pin p nin n
+            (by rw [hpin']; ring) (by rw [hnin']; ring))).comap
+            (ker (K.dPageAux r p pout n nout hpout' hnout')).subtype) := by
+    subst hpin'
+    subst hpout'
+    subst hnin'
+    subst hnout'
+    exact K.pageSuccEquiv r p n
+  let S := (K.pageComplex r).sc' a b c
+  refine (K.pageComplex r).homologyIsoSc' a b c
+      (shape.prev_eq' hab) (shape.next_eq' hbc) ≪≫
+    S.moduleCatHomologyIso ≪≫ ?_
+  refine eqToIso ?_ ≪≫
+    (pageSuccEquivAux b.1 a.1 c.1 (b.1 + b.2) (a.1 + a.2) (c.1 + c.2)
+      hpin hpout hnin hnout).symm.toModuleIso
+  change ModuleCat.of R
+      (LinearMap.ker S.g.hom ⧸ LinearMap.range S.moduleCatToCycles) =
+    ModuleCat.of R
+      (↥(ker (K.dPageAux r b.1 c.1 (b.1 + b.2) (c.1 + c.2) hpout hnout)) ⧸
+        (range (K.dPageAux r a.1 b.1 (a.1 + a.2) (b.1 + b.2)
+          (by rw [hpin]; ring) (by rw [hnin]; ring))).comap
+          (ker (K.dPageAux r b.1 c.1 (b.1 + b.2) (c.1 + c.2) hpout hnout)).subtype)
+  rw [LinearMap.range_codRestrict]
+  change ModuleCat.of R
+      (↥(LinearMap.ker ((K.pageComplex r).d b c).hom) ⧸
+        (LinearMap.range ((K.pageComplex r).d a b).hom).comap
+          (LinearMap.ker ((K.pageComplex r).d b c).hom).subtype) = _
+  rw [K.pageComplex_d_hom_of_rel r a b hab]
+  rw [K.pageComplex_d_hom_of_rel r b c hbc]
+  congr 4
+
+/-- The cohomological spectral sequence associated to a filtered complex, in
+mathlib's categorical `SpectralSequence` API, starting at page `r₀`. -/
+noncomputable def toCohomologicalSpectralSequence (r₀ : ℤ) :
+    CategoryTheory.CohomologicalSpectralSequence (ModuleCat.{v} R) r₀ where
+  page r _ := K.pageComplex r
+  iso r r' b hrr' _ := by
+    subst hrr'
+    exact K.pageHomologyIso r b
+
+end FilteredComplex

--- a/FLT/Slop/SpectralSequence/DoubleComplex.lean
+++ b/FLT/Slop/SpectralSequence/DoubleComplex.lean
@@ -51,6 +51,8 @@ filtrations).  This is the first result of Vakil, *The Rising Sea*, §1.7.
 
 @[expose] public section
 
+namespace Slop
+
 open CategoryTheory CategoryTheory.Limits
 open Submodule LinearMap DirectSum
 
@@ -1053,3 +1055,5 @@ noncomputable def rowPageOneEquiv (p a : ℤ) :
 end FirstPage
 
 end DoubleComplex
+
+end Slop

--- a/FLT/Slop/SpectralSequence/DoubleComplex.lean
+++ b/FLT/Slop/SpectralSequence/DoubleComplex.lean
@@ -6,6 +6,8 @@ Authors: Akhil Mathew
 module
 
 public import FLT.Slop.SpectralSequence.FiveTerm
+public import Mathlib.Algebra.Category.ModuleCat.Colimits
+public import Mathlib.Algebra.Homology.TotalComplex
 public import Mathlib.Algebra.DirectSum.Module
 
 /-!
@@ -22,8 +24,8 @@ filtrations).  This is the first result of Vakil, *The Rising Sea*, §1.7.
 
 ## Main definitions
 
-* `DoubleComplex` : a double complex of modules, with all-pairs differentials
-  (only the consecutive components are meaningful) and anticommuting `dh`, `dv`.
+* `DoubleComplex` : mathlib's `HomologicalComplex₂` of modules, presented with
+  horizontal and signed vertical differentials `dh`, `dv` that anticommute.
 * `DoubleComplex.Tot`, `DoubleComplex.totalD` : the total complex and its total
   differential.
 * `DoubleComplex.colF`, `DoubleComplex.rowF` and `DoubleComplex.colFiltered`,
@@ -37,7 +39,7 @@ filtrations).  This is the first result of Vakil, *The Rising Sea*, §1.7.
 * `DoubleComplex.colPageOneEquiv`, `DoubleComplex.rowPageOneEquiv` :
   `ᴵE₁ ≅ ker(dv)/im(dv)` and `ᴵᴵE₁ ≅ ker(dh)/im(dh)` — the first pages are the
   vertical/horizontal cohomology (FOAG §1.7), built via the reusable
-  `homologyEquivOfSquares`.
+  `FilteredComplex.homologyEquivOfSquares`.
 * `DoubleComplex.colPageEquivGrH`, `DoubleComplex.rowPageEquivGrH` :
   **convergence** — for a first-quadrant double complex both spectral sequences
   converge to the associated graded of `H^n(Tot)`.
@@ -49,40 +51,127 @@ filtrations).  This is the first result of Vakil, *The Rising Sea*, §1.7.
 
 @[expose] public section
 
+open CategoryTheory CategoryTheory.Limits
 open Submodule LinearMap DirectSum
 
-/-- A **double complex** of modules, with all-pairs differentials: only the
-components `dh i (i+1) j j` (horizontal) and `dv i i j (j+1)` (vertical) are
-meaningful; the flexible index slots avoid dependent-type transport when forming
-the total complex.  The differentials anticommute, so the total differential
-squares to zero on the nose. -/
-structure DoubleComplex (R : Type*) [Ring R] where
-  /-- The modules. -/
-  A : ℤ → ℤ → Type*
-  [addCommGroup : ∀ i j, AddCommGroup (A i j)]
-  [module : ∀ i j, Module R (A i j)]
-  /-- The horizontal differential; only `dh i (i+1) j j` is meaningful. -/
-  dh : ∀ i i' j j' : ℤ, A i j →ₗ[R] A i' j'
-  /-- The vertical differential; only `dv i i j (j+1)` is meaningful. -/
-  dv : ∀ i i' j j' : ℤ, A i j →ₗ[R] A i' j'
-  /-- The horizontal differential squares to zero. -/
-  dh_dh : ∀ (i i' i'' j j' j'' : ℤ), i' = i + 1 → i'' = i' + 1 → j' = j → j'' = j →
-    ∀ x : A i j, dh i' i'' j' j'' (dh i i' j j' x) = 0
-  /-- The vertical differential squares to zero. -/
-  dv_dv : ∀ (i j j' j'' : ℤ), j' = j + 1 → j'' = j' + 1 →
-    ∀ x : A i j, dv i i j' j'' (dv i i j j' x) = 0
-  /-- The horizontal and vertical differentials anticommute. -/
-  anticomm : ∀ (i i' j jh jv jt : ℤ), i' = i + 1 → jh = j → jv = j + 1 → jt = j + 1 →
-    ∀ x : A i j, dv i' i' jh jt (dh i i' j jh x) + dh i i' jv jt (dv i i j jv x) = 0
+universe u v
 
-attribute [instance] DoubleComplex.addCommGroup DoubleComplex.module
+/-- A **double cochain complex** of `R`-modules, using mathlib's standard bicomplex API.
+
+The two native differentials commute.  Mathlib's total-complex convention multiplies
+the vertical differential in column `i` by `(-1)^i`, so the resulting horizontal and
+signed vertical differentials anticommute. -/
+abbrev DoubleComplex (R : Type u) [Ring R] :=
+  HomologicalComplex₂ (ModuleCat.{v} R) (ComplexShape.up ℤ) (ComplexShape.up ℤ)
 
 namespace DoubleComplex
 
-variable {R : Type*} [Ring R] (K : DoubleComplex R)
+variable {R : Type u} [Ring R] (K : DoubleComplex.{u, v} R)
+
+/-- The module in bidegree `(i,j)`. -/
+abbrev A (i j : ℤ) : Type v := (K.X i).X j
+
+/-- The horizontal differential, with a second row index for convenient transport.
+It is zero unless the two row indices agree. -/
+noncomputable def dh (i i' j j' : ℤ) : K.A i j →ₗ[R] K.A i' j' :=
+  if h : j = j' then
+    ((K.d i i').f j ≫
+      (HomologicalComplex₂.XXIsoOfEq (ModuleCat R) (ComplexShape.up ℤ)
+        (ComplexShape.up ℤ) K rfl h).hom).hom
+  else 0
+
+/-- The signed vertical differential, with a second column index for convenient
+transport.  The sign `(-1)^i` is exactly mathlib's standard total-complex sign;
+this differential anticommutes with `dh`. -/
+noncomputable def dv (i i' j j' : ℤ) : K.A i j →ₗ[R] K.A i' j' :=
+  if h : i = i' then
+    (i.negOnePow • ((K.X i).d j j' ≫
+      (HomologicalComplex₂.XXIsoOfEq (ModuleCat R) (ComplexShape.up ℤ)
+        (ComplexShape.up ℤ) K h rfl).hom)).hom
+  else 0
+
+@[simp]
+lemma dh_eq (i i' j : ℤ) : K.dh i i' j j = ((K.d i i').f j).hom := by
+  simp [dh]
+
+@[simp]
+lemma dv_eq (i j j' : ℤ) : K.dv i i j j' = (i.negOnePow • (K.X i).d j j').hom := by
+  simp [dv]
+
+/-- The standard total-complex sign does not change the kernel of a vertical
+differential. -/
+lemma ker_dv_eq_native (i j j' : ℤ) :
+    LinearMap.ker (K.dv i i j j') = LinearMap.ker ((K.X i).d j j').hom := by
+  rw [dv_eq]
+  ext x
+  simp only [LinearMap.mem_ker]
+  constructor
+  · intro hx
+    have := congr_arg (fun y ↦ i.negOnePow • y) hx
+    have hs : (↑i.negOnePow : ℤ) * ↑i.negOnePow = 1 := by
+      exact congr_arg Units.val (Int.units_mul_self i.negOnePow)
+    simpa only [Units.smul_def, ModuleCat.hom_zsmul, LinearMap.smul_apply, smul_zero,
+      smul_smul, hs, one_smul] using this
+  · intro hx
+    simp [hx]
+
+/-- The standard total-complex sign does not change the range of a vertical
+differential. -/
+lemma range_dv_eq_native (i j j' : ℤ) :
+    LinearMap.range (K.dv i i j j') = LinearMap.range ((K.X i).d j j').hom := by
+  rw [dv_eq]
+  apply le_antisymm
+  · rintro y ⟨x, rfl⟩
+    exact ⟨i.negOnePow • x, by simp⟩
+  · rintro y ⟨x, rfl⟩
+    exact ⟨i.negOnePow • x, by simp [smul_smul]⟩
+
+/-- The horizontal differential squares to zero. -/
+lemma dh_dh (i i' i'' j j' j'' : ℤ) (hi' : i' = i + 1) (hi'' : i'' = i' + 1)
+    (hj' : j' = j) (hj'' : j'' = j) (x : K.A i j) :
+    K.dh i' i'' j' j'' (K.dh i i' j j' x) = 0 := by
+  subst i' i'' j' j''
+  simp only [dh_eq]
+  have h := ModuleCat.hom_ext_iff.mp (K.d_f_comp_d_f i (i + 1) (i + 1 + 1) j)
+  simpa only [ModuleCat.hom_comp, LinearMap.comp_apply, ModuleCat.hom_zero,
+    LinearMap.zero_apply] using DFunLike.congr_fun h x
+
+/-- The signed vertical differential squares to zero. -/
+lemma dv_dv (i j j' j'' : ℤ) (hj' : j' = j + 1) (hj'' : j'' = j' + 1)
+    (x : K.A i j) : K.dv i i j' j'' (K.dv i i j j' x) = 0 := by
+  subst j' j''
+  simp only [dv_eq]
+  have hcat :
+      (i.negOnePow • (K.X i).d j (j + 1)) ≫
+          (i.negOnePow • (K.X i).d (j + 1) (j + 1 + 1)) = 0 := by
+    rw [Linear.units_smul_comp, Linear.comp_units_smul, smul_smul,
+      Int.units_mul_self, one_smul, (K.X i).d_comp_d]
+  have hx := DFunLike.congr_fun (ModuleCat.hom_ext_iff.mp hcat) x
+  simpa only [ModuleCat.hom_comp, LinearMap.comp_apply, ModuleCat.hom_zero,
+    LinearMap.zero_apply] using hx
+
+/-- The horizontal and signed vertical differentials anticommute. -/
+lemma anticomm (i i' j jh jv jt : ℤ) (hi' : i' = i + 1) (hjh : jh = j)
+    (hjv : jv = j + 1) (hjt : jt = j + 1) (x : K.A i j) :
+    K.dv i' i' jh jt (K.dh i i' j jh x) + K.dh i i' jv jt (K.dv i i j jv x) = 0 := by
+  subst i' jh jv jt
+  simp only [dh_eq, dv_eq]
+  have hcat :
+      (K.d i (i + 1)).f j ≫ ((i + 1).negOnePow • (K.X (i + 1)).d j (j + 1)) +
+          (i.negOnePow • (K.X i).d j (j + 1)) ≫ (K.d i (i + 1)).f (j + 1) = 0 := by
+    rw [Linear.comp_units_smul, Linear.units_smul_comp, Int.negOnePow_succ,
+      Units.neg_smul, K.d_comm, neg_add_cancel]
+  have hx := DFunLike.congr_fun (ModuleCat.hom_ext_iff.mp hcat) x
+  simpa only [ModuleCat.hom_add, LinearMap.add_apply, ModuleCat.hom_comp,
+    LinearMap.comp_apply, ModuleCat.hom_zero, LinearMap.zero_apply] using hx
 
 /-- The total module `Tot^n = ⊕_i A^{i, n-i}`. -/
 abbrev Tot (n : ℤ) := ⨁ i : ℤ, K.A i (n - i)
+
+/-- Mathlib's categorical coproduct total complex.  The explicit direct-sum model
+below is canonically identified with it by `totalIso`. -/
+noncomputable abbrev standardTotal : CochainComplex (ModuleCat.{v} R) ℤ :=
+  HomologicalComplex₂.total K (ComplexShape.up ℤ)
 
 /-- The total differential `dh + dv` (meaningful for `m = n + 1`). -/
 noncomputable def totalD (n m : ℤ) : K.Tot n →ₗ[R] K.Tot m :=
@@ -97,6 +186,32 @@ noncomputable def totalD (n m : ℤ) : K.Tot n →ₗ[R] K.Tot m :=
           (K.dh i (i + 1) (n - i) (m - (i + 1)) x)
         + DirectSum.lof R ℤ (fun i' ↦ K.A i' (m - i')) i (K.dv i i (n - i) (m - i) x) := by
   simp [totalD]
+
+lemma totalD_shape (n m : ℤ) (h : ¬ (ComplexShape.up ℤ).Rel n m) :
+    K.totalD n m = 0 := by
+  apply DirectSum.linearMap_ext
+  intro i
+  ext x
+  rw [LinearMap.comp_apply, totalD_lof]
+  have hnm : m ≠ n + 1 := by simpa only [ComplexShape.up_Rel, eq_comm] using h
+  have hh : K.dh i (i + 1) (n - i) (m - (i + 1)) = 0 := by
+    rw [dh]
+    split_ifs with heq
+    · exfalso
+      apply hnm
+      omega
+    · rfl
+  have hv : K.dv i i (n - i) (m - i) = 0 := by
+    rw [dv, dif_pos rfl]
+    have hs : ¬ (ComplexShape.up ℤ).Rel (n - i) (m - i) := by
+      intro hs
+      apply hnm
+      simp only [ComplexShape.up_Rel] at hs
+      omega
+    rw [(K.X i).shape _ _ hs]
+    simp
+  rw [hh, hv]
+  simp
 
 lemma totalD_totalD (n m t : ℤ) (hm : m = n + 1) (ht : t = m + 1) (x : K.Tot n) :
     K.totalD m t (K.totalD n m x) = 0 := by
@@ -113,6 +228,186 @@ lemma totalD_totalD (n m t : ℤ) (hm : m = n + 1) (ht : t = m + 1) (x : K.Tot n
     rw [map_zero]
   | add x y hx hy =>
     rw [map_add, map_add, hx, hy, add_zero]
+
+/-- A concrete direct-sum total complex using mathlib's standard sign convention. -/
+noncomputable def totalCochainComplex : CochainComplex (ModuleCat.{v} R) ℤ where
+  X n := ModuleCat.of R (K.Tot n)
+  d n m := ModuleCat.ofHom (K.totalD n m)
+  shape n m h := by
+    rw [K.totalD_shape n m h]
+    rfl
+  d_comp_d' n m t hm ht := by
+    apply ModuleCat.hom_ext
+    apply LinearMap.ext
+    intro x
+    exact K.totalD_totalD n m t (by simpa only [ComplexShape.up_Rel] using hm.symm)
+      (by simpa only [ComplexShape.up_Rel] using ht.symm) x
+
+@[simp]
+lemma totalCochainComplex_d_hom (n m : ℤ) :
+    (K.totalCochainComplex.d n m).hom = K.totalD n m := rfl
+
+/-- The canonical map from the concrete direct-sum total in degree `n` to
+mathlib's categorical coproduct total. -/
+noncomputable def totToStandardTotal (n : ℤ) :
+    ModuleCat.of R (K.Tot n) ⟶ (K.standardTotal).X n :=
+  ModuleCat.ofHom <| DirectSum.toModule R ℤ _ fun i ↦
+    (HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) i (n - i) n (by
+      change i + (n - i) = n
+      omega)).hom
+
+/-- The canonical map from mathlib's categorical coproduct total in degree `n`
+to the concrete direct sum. -/
+noncomputable def standardTotalToTot (n : ℤ) :
+    (K.standardTotal).X n ⟶ ModuleCat.of R (K.Tot n) :=
+  HomologicalComplex₂.totalDesc K fun i j h ↦
+    (HomologicalComplex₂.XXIsoOfEq (ModuleCat R) (ComplexShape.up ℤ)
+      (ComplexShape.up ℤ) K rfl (by
+        change i + j = n at h
+        omega)).hom ≫
+      ModuleCat.ofHom (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i)
+
+/-- A concrete direct-sum inclusion followed by `totToStandardTotal` is
+mathlib's corresponding total-complex inclusion. -/
+@[reassoc (attr := simp)]
+lemma lof_totToStandardTotal (n i : ℤ) :
+    ModuleCat.ofHom (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i) ≫
+        K.totToStandardTotal n =
+      HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) i (n - i) n (by
+        change i + (n - i) = n
+        omega) := by
+  apply ModuleCat.hom_ext
+  apply LinearMap.ext
+  intro x
+  change (DirectSum.toModule R ℤ _
+      (fun i ↦ (HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) i (n - i) n (by
+        change i + (n - i) = n
+        omega)).hom))
+      (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i x) =
+    (HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) i (n - i) n (by
+      change i + (n - i) = n
+      omega)).hom x
+  apply DirectSum.toModule_lof
+
+/-- A mathlib total-complex inclusion followed by `standardTotalToTot` is the
+corresponding concrete direct-sum inclusion, up to the canonical index transport. -/
+@[reassoc (attr := simp)]
+lemma ιTotal_standardTotalToTot (n i j : ℤ)
+    (h : ComplexShape.π (ComplexShape.up ℤ) (ComplexShape.up ℤ)
+      (ComplexShape.up ℤ) (i, j) = n) :
+    HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) i j n h ≫
+        K.standardTotalToTot n =
+      (HomologicalComplex₂.XXIsoOfEq (ModuleCat R) (ComplexShape.up ℤ)
+        (ComplexShape.up ℤ) K rfl (by
+          change i + j = n at h
+          omega)).hom ≫
+        ModuleCat.ofHom (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i) := by
+  apply HomologicalComplex₂.ι_totalDesc
+
+/-- The canonical isomorphism between the concrete and categorical total objects
+in a fixed degree. -/
+noncomputable def totalIsoX (n : ℤ) :
+    ModuleCat.of R (K.Tot n) ≅ (K.standardTotal).X n where
+  hom := K.totToStandardTotal n
+  inv := K.standardTotalToTot n
+  hom_inv_id := by
+    apply ModuleCat.hom_ext
+    apply DirectSum.linearMap_ext
+    intro i
+    change (ModuleCat.ofHom (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i) ≫
+      K.totToStandardTotal n ≫ K.standardTotalToTot n).hom =
+        (ModuleCat.ofHom (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i) ≫
+          𝟙 (ModuleCat.of R (K.Tot n))).hom
+    rw [K.lof_totToStandardTotal_assoc, K.ιTotal_standardTotalToTot]
+    simp
+  inv_hom_id := by
+    apply HomologicalComplex₂.total.hom_ext (ComplexShape.up ℤ)
+    intro i j h
+    rw [← Category.assoc, K.ιTotal_standardTotalToTot, Category.assoc,
+      K.lof_totToStandardTotal]
+    simp
+
+/-- The concrete total differential on a direct-sum inclusion, expressed
+categorically. -/
+@[reassoc]
+lemma lof_totalCochainComplex_d (n m i : ℤ) :
+    ModuleCat.ofHom (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i) ≫
+        K.totalCochainComplex.d n m =
+      ModuleCat.ofHom (K.dh i (i + 1) (n - i) (m - (i + 1))) ≫
+          ModuleCat.ofHom (DirectSum.lof R ℤ (fun i' ↦ K.A i' (m - i')) (i + 1)) +
+        ModuleCat.ofHom (K.dv i i (n - i) (m - i)) ≫
+          ModuleCat.ofHom (DirectSum.lof R ℤ (fun i' ↦ K.A i' (m - i')) i) := by
+  apply ModuleCat.hom_ext
+  apply LinearMap.ext
+  intro x
+  exact K.totalD_lof n m i x
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The horizontal contribution to mathlib's total differential agrees with
+the horizontal contribution in the concrete direct-sum model. -/
+lemma d₁_eq_concrete (n m i : ℤ) (hm : m = n + 1) :
+    HomologicalComplex₂.d₁ K (ComplexShape.up ℤ) i (n - i) m =
+      ModuleCat.ofHom (K.dh i (i + 1) (n - i) (m - (i + 1))) ≫
+        HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) (i + 1) (m - (i + 1)) m (by
+          change (i + 1) + (m - (i + 1)) = m
+          omega) := by
+  have hi : (ComplexShape.up ℤ).Rel i (i + 1) := by simp
+  have htarget : ComplexShape.π (ComplexShape.up ℤ) (ComplexShape.up ℤ)
+      (ComplexShape.up ℤ) (i + 1, n - i) = m := by
+    change (i + 1) + (n - i) = m
+    omega
+  rw [HomologicalComplex₂.d₁_eq K (ComplexShape.up ℤ) hi (n - i) m htarget]
+  have hj : n - i = m - (i + 1) := by omega
+  rw [dh, dif_pos hj]
+  change (1 : ℤˣ) • ((K.d i (i + 1)).f (n - i) ≫
+      HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) (i + 1) (n - i) m htarget) = _
+  rw [one_smul]
+  simp only [ModuleCat.ofHom_hom, Category.assoc]
+  rw [HomologicalComplex₂.XXIsoOfEq_hom_ιTotal]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The vertical contribution to mathlib's total differential agrees with the
+signed vertical contribution in the concrete direct-sum model. -/
+lemma d₂_eq_concrete (n m i : ℤ) (hm : m = n + 1) :
+    HomologicalComplex₂.d₂ K (ComplexShape.up ℤ) i (n - i) m =
+      ModuleCat.ofHom (K.dv i i (n - i) (m - i)) ≫
+        HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) i (m - i) m (by
+          change i + (m - i) = m
+          omega) := by
+  have hj : (ComplexShape.up ℤ).Rel (n - i) (m - i) := by
+    simp only [ComplexShape.up_Rel]
+    omega
+  have htarget : ComplexShape.π (ComplexShape.up ℤ) (ComplexShape.up ℤ)
+      (ComplexShape.up ℤ) (i, m - i) = m := by
+    change i + (m - i) = m
+    omega
+  rw [HomologicalComplex₂.d₂_eq K (ComplexShape.up ℤ) i hj m htarget]
+  rw [dv_eq]
+  change i.negOnePow • ((K.X i).d (n - i) (m - i) ≫
+      HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) i (m - i) m htarget) =
+    (i.negOnePow • (K.X i).d (n - i) (m - i)) ≫
+      HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) i (m - i) m _
+  rw [Linear.units_smul_comp]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The concrete direct-sum total complex is canonically isomorphic to mathlib's
+categorical coproduct total complex. -/
+noncomputable def totalIso : K.totalCochainComplex ≅ K.standardTotal :=
+  HomologicalComplex.Hom.isoOfComponents (K.totalIsoX) (fun n m h ↦ by
+    apply ModuleCat.hom_ext
+    apply DirectSum.linearMap_ext
+    intro i
+    change (ModuleCat.ofHom (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i) ≫
+        (K.totalIsoX n).hom ≫ K.standardTotal.d n m).hom =
+      (ModuleCat.ofHom (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i) ≫
+        K.totalCochainComplex.d n m ≫ (K.totalIsoX m).hom).hom
+    apply congr_arg ModuleCat.Hom.hom
+    dsimp only [totalIsoX]
+    rw [K.lof_totToStandardTotal_assoc, HomologicalComplex₂.total_d]
+    simp only [Preadditive.comp_add, HomologicalComplex₂.ι_D₁, HomologicalComplex₂.ι_D₂]
+    rw [← Category.assoc, K.lof_totalCochainComplex_d, Preadditive.add_comp,
+      Category.assoc, K.lof_totToStandardTotal, Category.assoc, K.lof_totToStandardTotal]
+    rw [K.d₁_eq_concrete n m i h.symm, K.d₂_eq_concrete n m i h.symm])
 
 /-- The **column filtration** `F_I^p Tot^n = ⊕_{i ≥ p} A^{i, n-i}`. -/
 def colF (p n : ℤ) : Submodule R (K.Tot n) :=
@@ -161,27 +456,33 @@ lemma totalD_mem_rowF (p n m : ℤ) (hm : m = n + 1) {x : K.Tot n} (hx : x ∈ K
 
 /-- The filtered complex given by the column filtration on the total complex. -/
 noncomputable def colFiltered : FilteredComplex R where
-  X := K.Tot
-  d := K.totalD
-  d_comp_d := fun i j k hj hk x ↦ K.totalD_totalD i j k hj hk x
+  toCochainComplex := K.totalCochainComplex
   F := K.colF
-  F_le := fun p n ↦ by
+  antitone_F := fun n p q hp ↦ by
     refine iSup₂_le fun i hi ↦ ?_
     exact le_iSup₂ (f := fun i' _ ↦
-      LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i (by omega)
-  d_mem_F := fun p i j _ x hx ↦ K.totalD_mem_colF p i j hx
+      LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i
+      (hp.trans hi)
+  map_d_le := fun p i j ↦ by
+    rintro y ⟨x, hx, rfl⟩
+    exact K.totalD_mem_colF p i j hx
 
 /-- The filtered complex given by the row filtration on the total complex. -/
 noncomputable def rowFiltered : FilteredComplex R where
-  X := K.Tot
-  d := K.totalD
-  d_comp_d := fun i j k hj hk x ↦ K.totalD_totalD i j k hj hk x
+  toCochainComplex := K.totalCochainComplex
   F := K.rowF
-  F_le := fun p n ↦ by
+  antitone_F := fun n p q hp ↦ by
     refine iSup₂_le fun i hi ↦ ?_
     exact le_iSup₂ (f := fun i' _ ↦
-      LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i (by omega)
-  d_mem_F := fun p i j hj x hx ↦ K.totalD_mem_rowF p i j hj hx
+      LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i
+      (hp.trans hi)
+  map_d_le := fun p i j ↦ by
+    change (K.rowF p i).map (K.totalD i j) ≤ K.rowF p j
+    by_cases hj : j = i + 1
+    · rintro y ⟨x, hx, rfl⟩
+      exact K.totalD_mem_rowF p i j hj hx
+    · rw [K.totalD_shape i j (by simpa only [ComplexShape.up_Rel, eq_comm] using hj)]
+      simp
 
 /-- The two filtered complexes share the underlying complex, hence they have the
 same cohomology: both spectral sequences abut to `H^n(Tot)`. -/
@@ -347,7 +648,7 @@ end GradedPieces
 
 /-! ### First-quadrant boundedness -/
 
-section FirstQuadrant
+section IsFirstQuadrant
 
 variable (hfq : ∀ i j : ℤ, i < 0 ∨ j < 0 → Subsingleton (K.A i j))
 
@@ -419,37 +720,37 @@ noncomputable def rowPageEquivGrH {r p n : ℤ} (hr1 : n + 1 < p + r) (hr2 : p -
         (K.rowFiltered.FH (p + 1) n).comap (K.rowFiltered.FH p n).subtype) :=
   K.rowFiltered.pageEquivGrHOfBounded (K.rowF_eq_bot hfq hr1) (K.rowF_eq_top hfq hr2)
 
-/-- The column filtration of a first-quadrant double complex is `FirstQuadrant`. -/
-theorem colFiltered_firstQuadrant : K.colFiltered.FirstQuadrant :=
+/-- The column filtration of a first-quadrant double complex is `IsFirstQuadrant`. -/
+theorem colFiltered_isFirstQuadrant : K.colFiltered.IsFirstQuadrant :=
   ⟨fun h ↦ K.colF_eq_bot hfq h, fun h ↦ K.colF_eq_top hfq h⟩
 
-/-- The row filtration of a first-quadrant double complex is `FirstQuadrant`. -/
-theorem rowFiltered_firstQuadrant : K.rowFiltered.FirstQuadrant :=
+/-- The row filtration of a first-quadrant double complex is `IsFirstQuadrant`. -/
+theorem rowFiltered_isFirstQuadrant : K.rowFiltered.IsFirstQuadrant :=
   ⟨fun h ↦ K.rowF_eq_bot hfq h, fun h ↦ K.rowF_eq_top hfq h⟩
 
 /-- **Five-term exact sequence of the first (column) spectral sequence** of a
 first-quadrant double complex:
 `0 → ᴵE_2^{1,0} → H¹(Tot) → ᴵE_2^{0,1} →^{d₂} ᴵE_2^{2,0} → H²(Tot)`. -/
 theorem colFiltered_five_term_exact :
-    Function.Injective (FilteredComplex.f1 (K.colFiltered_firstQuadrant hfq)) ∧
-    Function.Exact (FilteredComplex.f1 (K.colFiltered_firstQuadrant hfq))
-      (FilteredComplex.f2 (K.colFiltered_firstQuadrant hfq)) ∧
-    Function.Exact (FilteredComplex.f2 (K.colFiltered_firstQuadrant hfq)) K.colFiltered.d2 ∧
-    Function.Exact K.colFiltered.d2 (FilteredComplex.f4 (K.colFiltered_firstQuadrant hfq)) :=
-  K.colFiltered.five_term_exact (K.colFiltered_firstQuadrant hfq)
+    Function.Injective (FilteredComplex.f1 (K.colFiltered_isFirstQuadrant hfq)) ∧
+    Function.Exact (FilteredComplex.f1 (K.colFiltered_isFirstQuadrant hfq))
+      (FilteredComplex.f2 (K.colFiltered_isFirstQuadrant hfq)) ∧
+    Function.Exact (FilteredComplex.f2 (K.colFiltered_isFirstQuadrant hfq)) K.colFiltered.d2 ∧
+    Function.Exact K.colFiltered.d2 (FilteredComplex.f4 (K.colFiltered_isFirstQuadrant hfq)) :=
+  K.colFiltered.five_term_exact (K.colFiltered_isFirstQuadrant hfq)
 
 /-- **Five-term exact sequence of the second (row) spectral sequence** of a
 first-quadrant double complex:
 `0 → ᴵᴵE_2^{1,0} → H¹(Tot) → ᴵᴵE_2^{0,1} →^{d₂} ᴵᴵE_2^{2,0} → H²(Tot)`. -/
 theorem rowFiltered_five_term_exact :
-    Function.Injective (FilteredComplex.f1 (K.rowFiltered_firstQuadrant hfq)) ∧
-    Function.Exact (FilteredComplex.f1 (K.rowFiltered_firstQuadrant hfq))
-      (FilteredComplex.f2 (K.rowFiltered_firstQuadrant hfq)) ∧
-    Function.Exact (FilteredComplex.f2 (K.rowFiltered_firstQuadrant hfq)) K.rowFiltered.d2 ∧
-    Function.Exact K.rowFiltered.d2 (FilteredComplex.f4 (K.rowFiltered_firstQuadrant hfq)) :=
-  K.rowFiltered.five_term_exact (K.rowFiltered_firstQuadrant hfq)
+    Function.Injective (FilteredComplex.f1 (K.rowFiltered_isFirstQuadrant hfq)) ∧
+    Function.Exact (FilteredComplex.f1 (K.rowFiltered_isFirstQuadrant hfq))
+      (FilteredComplex.f2 (K.rowFiltered_isFirstQuadrant hfq)) ∧
+    Function.Exact (FilteredComplex.f2 (K.rowFiltered_isFirstQuadrant hfq)) K.rowFiltered.d2 ∧
+    Function.Exact K.rowFiltered.d2 (FilteredComplex.f4 (K.rowFiltered_isFirstQuadrant hfq)) :=
+  K.rowFiltered.five_term_exact (K.rowFiltered_isFirstQuadrant hfq)
 
-end FirstQuadrant
+end IsFirstQuadrant
 
 /-! ### The first page: `E₁` is the vertical/horizontal cohomology
 
@@ -458,8 +759,10 @@ The zeroth page of the column spectral sequence is the double complex itself
 under that identification to the *vertical* differential `dv`.  Consequently the
 first page `ᴵE₁^{p,n}` is the vertical cohomology of the `p`-th column.  Dually,
 the row spectral sequence has `d₀ = dh` (horizontal), so `ᴵᴵE₁` is horizontal
-cohomology.  This is the differential-level half of Vakil, *The Rising Sea*,
-§1.7 (`E₁ = H(gr)` made concrete for a double complex). -/
+cohomology.  Here `dv` includes mathlib's `(-1)^p` total-complex sign; the lemmas
+`ker_dv_eq_native` and `range_dv_eq_native` identify its homology with that of the
+native vertical differential.  This is the differential-level half of Vakil,
+*The Rising Sea*, §1.7 (`E₁ = H(gr)` made concrete for a double complex). -/
 
 section FirstPage
 
@@ -572,7 +875,7 @@ noncomputable def colPageOneEquiv (p a : ℤ) :
     K.colFiltered.page 1 p a ≃ₗ[R]
       (↥(ker (K.dvOut p a)) ⧸ (range (K.dvIn p a)).comap (ker (K.dvOut p a)).subtype) :=
   (K.colFiltered.pageSuccEquiv' 0 p p p a (by ring) (by ring)).trans <|
-    homologyEquivOfSquares
+    FilteredComplex.homologyEquivOfSquares
       (e := K.colPageZeroEquiv p a)
       (fout := K.colFiltered.dPageAux 0 p p a (a + 1) (by ring) rfl)
       (gout := K.dvOut p a)
@@ -729,7 +1032,7 @@ noncomputable def rowPageOneEquiv (p a : ℤ) :
     K.rowFiltered.page 1 p a ≃ₗ[R]
       (↥(ker (K.dhOut p a)) ⧸ (range (K.dhIn p a)).comap (ker (K.dhOut p a)).subtype) :=
   (K.rowFiltered.pageSuccEquiv' 0 p p p a (by ring) (by ring)).trans <|
-    homologyEquivOfSquares
+    FilteredComplex.homologyEquivOfSquares
       (e := K.rowPageZeroEquiv p a)
       (fout := K.rowFiltered.dPageAux 0 p p a (a + 1) (by ring) rfl)
       (gout := K.dhOut p a)

--- a/FLT/Slop/SpectralSequence/DoubleComplex.lean
+++ b/FLT/Slop/SpectralSequence/DoubleComplex.lean
@@ -1,0 +1,752 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.SpectralSequence.FiveTerm
+public import Mathlib.Algebra.DirectSum.Module
+
+/-!
+# The two spectral sequences of a double complex
+
+A double complex `A^{i,j}` (first-quadrant, i.e. trivial for `i < 0` or `j < 0`)
+has a total complex `Tot^n = ⨁_i A^{i, n-i}` carrying two filtrations — by
+columns (`colF`) and by rows (`rowF`) — each of which is bounded *at every
+degree* even though it is globally unbounded.  Feeding these into the graded
+convergence theorem of `FLT.Slop.SpectralSequence.FilteredComplex` produces the
+two classical spectral sequences, both converging to the associated graded of
+the cohomology `H^n(Tot)` of the same total complex (for the respective
+filtrations).  This is the first result of Vakil, *The Rising Sea*, §1.7.
+
+## Main definitions
+
+* `DoubleComplex` : a double complex of modules, with all-pairs differentials
+  (only the consecutive components are meaningful) and anticommuting `dh`, `dv`.
+* `DoubleComplex.Tot`, `DoubleComplex.totalD` : the total complex and its total
+  differential.
+* `DoubleComplex.colF`, `DoubleComplex.rowF` and `DoubleComplex.colFiltered`,
+  `DoubleComplex.rowFiltered` : the column/row filtrations and the two filtered
+  complexes they define on the total complex.
+
+## Main results
+
+* `DoubleComplex.colPageZeroEquiv`, `DoubleComplex.rowPageZeroEquiv` : the
+  zeroth pages of both spectral sequences are the double complex itself.
+* `DoubleComplex.colPageOneEquiv`, `DoubleComplex.rowPageOneEquiv` :
+  `ᴵE₁ ≅ ker(dv)/im(dv)` and `ᴵᴵE₁ ≅ ker(dh)/im(dh)` — the first pages are the
+  vertical/horizontal cohomology (FOAG §1.7), built via the reusable
+  `homologyEquivOfSquares`.
+* `DoubleComplex.colPageEquivGrH`, `DoubleComplex.rowPageEquivGrH` :
+  **convergence** — for a first-quadrant double complex both spectral sequences
+  converge to the associated graded of `H^n(Tot)`.
+* `DoubleComplex.colFiltered_five_term_exact`,
+  `DoubleComplex.rowFiltered_five_term_exact` : the five-term exact sequences
+  `0 → E_2^{1,0} → H¹(Tot) → E_2^{0,1} →^{d₂} E_2^{2,0} → H²(Tot)` of the two
+  spectral sequences.
+-/
+
+@[expose] public section
+
+open Submodule LinearMap DirectSum
+
+/-- A **double complex** of modules, with all-pairs differentials: only the
+components `dh i (i+1) j j` (horizontal) and `dv i i j (j+1)` (vertical) are
+meaningful; the flexible index slots avoid dependent-type transport when forming
+the total complex.  The differentials anticommute, so the total differential
+squares to zero on the nose. -/
+structure DoubleComplex (R : Type*) [Ring R] where
+  /-- The modules. -/
+  A : ℤ → ℤ → Type*
+  [addCommGroup : ∀ i j, AddCommGroup (A i j)]
+  [module : ∀ i j, Module R (A i j)]
+  /-- The horizontal differential; only `dh i (i+1) j j` is meaningful. -/
+  dh : ∀ i i' j j' : ℤ, A i j →ₗ[R] A i' j'
+  /-- The vertical differential; only `dv i i j (j+1)` is meaningful. -/
+  dv : ∀ i i' j j' : ℤ, A i j →ₗ[R] A i' j'
+  /-- The horizontal differential squares to zero. -/
+  dh_dh : ∀ (i i' i'' j j' j'' : ℤ), i' = i + 1 → i'' = i' + 1 → j' = j → j'' = j →
+    ∀ x : A i j, dh i' i'' j' j'' (dh i i' j j' x) = 0
+  /-- The vertical differential squares to zero. -/
+  dv_dv : ∀ (i j j' j'' : ℤ), j' = j + 1 → j'' = j' + 1 →
+    ∀ x : A i j, dv i i j' j'' (dv i i j j' x) = 0
+  /-- The horizontal and vertical differentials anticommute. -/
+  anticomm : ∀ (i i' j jh jv jt : ℤ), i' = i + 1 → jh = j → jv = j + 1 → jt = j + 1 →
+    ∀ x : A i j, dv i' i' jh jt (dh i i' j jh x) + dh i i' jv jt (dv i i j jv x) = 0
+
+attribute [instance] DoubleComplex.addCommGroup DoubleComplex.module
+
+namespace DoubleComplex
+
+variable {R : Type*} [Ring R] (K : DoubleComplex R)
+
+/-- The total module `Tot^n = ⊕_i A^{i, n-i}`. -/
+abbrev Tot (n : ℤ) := ⨁ i : ℤ, K.A i (n - i)
+
+/-- The total differential `dh + dv` (meaningful for `m = n + 1`). -/
+noncomputable def totalD (n m : ℤ) : K.Tot n →ₗ[R] K.Tot m :=
+  DirectSum.toModule R ℤ _ fun i ↦
+    (DirectSum.lof R ℤ (fun i' ↦ K.A i' (m - i')) (i + 1)).comp
+      (K.dh i (i + 1) (n - i) (m - (i + 1)))
+    + (DirectSum.lof R ℤ (fun i' ↦ K.A i' (m - i')) i).comp (K.dv i i (n - i) (m - i))
+
+@[simp] lemma totalD_lof (n m i : ℤ) (x : K.A i (n - i)) :
+    K.totalD n m (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i x)
+      = DirectSum.lof R ℤ (fun i' ↦ K.A i' (m - i')) (i + 1)
+          (K.dh i (i + 1) (n - i) (m - (i + 1)) x)
+        + DirectSum.lof R ℤ (fun i' ↦ K.A i' (m - i')) i (K.dv i i (n - i) (m - i) x) := by
+  simp [totalD]
+
+lemma totalD_totalD (n m t : ℤ) (hm : m = n + 1) (ht : t = m + 1) (x : K.Tot n) :
+    K.totalD m t (K.totalD n m x) = 0 := by
+  induction x using DirectSum.induction_on with
+  | zero => simp
+  | of i a =>
+    rw [← DirectSum.lof_eq_of R, totalD_lof, map_add, totalD_lof, totalD_lof]
+    rw [K.dh_dh i (i + 1) (i + 1 + 1) (n - i) (m - (i + 1)) (t - (i + 1 + 1)) rfl rfl
+      (by omega) (by omega) a]
+    rw [K.dv_dv i (n - i) (m - i) (t - i) (by omega) (by omega) a]
+    rw [map_zero, map_zero, zero_add, add_zero, ← map_add]
+    rw [K.anticomm i (i + 1) (n - i) (m - (i + 1)) (m - i) (t - (i + 1)) rfl (by omega)
+      (by omega) (by omega) a]
+    rw [map_zero]
+  | add x y hx hy =>
+    rw [map_add, map_add, hx, hy, add_zero]
+
+/-- The **column filtration** `F_I^p Tot^n = ⊕_{i ≥ p} A^{i, n-i}`. -/
+def colF (p n : ℤ) : Submodule R (K.Tot n) :=
+  ⨆ (i : ℤ) (_ : p ≤ i), LinearMap.range (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i)
+
+/-- The **row filtration** `F_II^p Tot^n = ⊕_{n-i ≥ p} A^{i, n-i}`. -/
+def rowF (p n : ℤ) : Submodule R (K.Tot n) :=
+  ⨆ (i : ℤ) (_ : p ≤ n - i),
+    LinearMap.range (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i)
+
+lemma totalD_mem_colF (p n m : ℤ) {x : K.Tot n} (hx : x ∈ K.colF p n) :
+    K.totalD n m x ∈ K.colF p m := by
+  have hmap : (K.colF p n).map (K.totalD n m) ≤ K.colF p m := by
+    rw [colF, Submodule.map_iSup]
+    refine iSup_le fun i ↦ ?_
+    rw [Submodule.map_iSup]
+    refine iSup_le fun hi ↦ ?_
+    rintro y ⟨z, ⟨a, rfl⟩, rfl⟩
+    rw [totalD_lof]
+    refine add_mem ?_ ?_
+    · exact le_iSup₂ (f := fun i' _ ↦
+        LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (m - i'')) i'))
+        (i + 1) (by omega) ⟨_, rfl⟩
+    · exact le_iSup₂ (f := fun i' _ ↦
+        LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (m - i'')) i'))
+        i hi ⟨_, rfl⟩
+  exact hmap (Submodule.mem_map_of_mem hx)
+
+lemma totalD_mem_rowF (p n m : ℤ) (hm : m = n + 1) {x : K.Tot n} (hx : x ∈ K.rowF p n) :
+    K.totalD n m x ∈ K.rowF p m := by
+  have hmap : (K.rowF p n).map (K.totalD n m) ≤ K.rowF p m := by
+    rw [rowF, Submodule.map_iSup]
+    refine iSup_le fun i ↦ ?_
+    rw [Submodule.map_iSup]
+    refine iSup_le fun hi ↦ ?_
+    rintro y ⟨z, ⟨a, rfl⟩, rfl⟩
+    rw [totalD_lof]
+    refine add_mem ?_ ?_
+    · exact le_iSup₂ (f := fun i' _ ↦
+        LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (m - i'')) i'))
+        (i + 1) (by omega) ⟨_, rfl⟩
+    · exact le_iSup₂ (f := fun i' _ ↦
+        LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (m - i'')) i'))
+        i (by omega) ⟨_, rfl⟩
+  exact hmap (Submodule.mem_map_of_mem hx)
+
+/-- The filtered complex given by the column filtration on the total complex. -/
+noncomputable def colFiltered : FilteredComplex R where
+  X := K.Tot
+  d := K.totalD
+  d_comp_d := fun i j k hj hk x ↦ K.totalD_totalD i j k hj hk x
+  F := K.colF
+  F_le := fun p n ↦ by
+    refine iSup₂_le fun i hi ↦ ?_
+    exact le_iSup₂ (f := fun i' _ ↦
+      LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i (by omega)
+  d_mem_F := fun p i j _ x hx ↦ K.totalD_mem_colF p i j hx
+
+/-- The filtered complex given by the row filtration on the total complex. -/
+noncomputable def rowFiltered : FilteredComplex R where
+  X := K.Tot
+  d := K.totalD
+  d_comp_d := fun i j k hj hk x ↦ K.totalD_totalD i j k hj hk x
+  F := K.rowF
+  F_le := fun p n ↦ by
+    refine iSup₂_le fun i hi ↦ ?_
+    exact le_iSup₂ (f := fun i' _ ↦
+      LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i (by omega)
+  d_mem_F := fun p i j hj x hx ↦ K.totalD_mem_rowF p i j hj hx
+
+/-- The two filtered complexes share the underlying complex, hence they have the
+same cohomology: both spectral sequences abut to `H^n(Tot)`. -/
+lemma colFiltered_homology_eq_rowFiltered_homology (n : ℤ) :
+    K.colFiltered.homology n = K.rowFiltered.homology n := rfl
+
+/-! ### The zeroth pages: the double complex itself
+
+The associated graded of the column filtration at `(p, n)` is the single entry
+`A^{p, n-p}`, by the direct-sum decomposition; combined with `pageZeroEquiv` this
+identifies the zeroth page of the first spectral sequence with the double complex
+itself, and similarly for the row filtration. -/
+
+section GradedPieces
+
+lemma lof_injective (i n : ℤ) :
+    Function.Injective (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) i) :=
+  Function.LeftInverse.injective
+    (g := DirectSum.component R ℤ (fun i' ↦ K.A i' (n - i')) i)
+    fun b ↦ DirectSum.component.lof_self (R := R) (ι := ℤ)
+      (M := fun i' ↦ K.A i' (n - i')) i b
+
+lemma colF_eq_sup (p n : ℤ) :
+    K.colF p n = LinearMap.range (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) p)
+      ⊔ K.colF (p + 1) n := by
+  apply le_antisymm
+  · refine iSup₂_le fun i hi ↦ ?_
+    rcases eq_or_lt_of_le hi with rfl | h
+    · exact le_sup_left
+    · exact le_trans (le_iSup₂ (f := fun i' _ ↦
+        LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i (by omega))
+        le_sup_right
+  · refine sup_le ?_ ?_
+    · exact le_iSup₂ (f := fun i' _ ↦
+        LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) p le_rfl
+    · refine iSup₂_le fun i hi ↦ ?_
+      exact le_iSup₂ (f := fun i' _ ↦
+        LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i (by omega)
+
+lemma colF_le_ker_component (p n : ℤ) :
+    K.colF (p + 1) n
+      ≤ LinearMap.ker (DirectSum.component R ℤ (fun i' ↦ K.A i' (n - i')) p) := by
+  refine iSup₂_le fun i hi ↦ ?_
+  rintro x ⟨a, rfl⟩
+  rw [LinearMap.mem_ker, DirectSum.component.of]
+  rw [dif_neg (by omega : ¬ i = p)]
+
+lemma comap_colF_eq_bot (p n : ℤ) :
+    Submodule.comap
+        (LinearMap.range (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) p)).subtype
+        (LinearMap.range (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) p))
+      ⊓ Submodule.comap
+          (LinearMap.range (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) p)).subtype
+          (K.colF (p + 1) n) = ⊥ := by
+  refine le_bot_iff.mp fun x hx ↦ ?_
+  obtain ⟨-, hx2⟩ := Submodule.mem_inf.mp hx
+  have hx2' : (x : K.Tot n) ∈ K.colF (p + 1) n := hx2
+  obtain ⟨a, ha⟩ := x.2
+  have hcomp : DirectSum.component R ℤ (fun i' ↦ K.A i' (n - i')) p (x : K.Tot n) = 0 :=
+    K.colF_le_ker_component p n hx2'
+  rw [← ha, DirectSum.component.lof_self] at hcomp
+  rw [Submodule.mem_bot]
+  apply Subtype.ext
+  rw [← ha, hcomp, map_zero]
+  rfl
+
+/-- The associated graded piece of the column filtration is a single entry of the
+double complex: `gr^p_I Tot^n ≅ A^{p, n-p}`. -/
+noncomputable def colGrEquiv (p n : ℤ) :
+    (↥(K.colF p n) ⧸ (K.colF (p + 1) n).comap (K.colF p n).subtype) ≃ₗ[R] K.A p (n - p) :=
+  (Submodule.Quotient.equiv _ _ (LinearEquiv.ofEq _ _ (K.colF_eq_sup p n)) (by
+      ext ξ
+      simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
+      constructor
+      · rintro ⟨η, hη, rfl⟩
+        simpa using hη
+      · intro hξ
+        exact ⟨(LinearEquiv.ofEq _ _ (K.colF_eq_sup p n)).symm ξ, by simpa using hξ,
+          (LinearEquiv.ofEq _ _ (K.colF_eq_sup p n)).apply_symm_apply ξ⟩)).trans
+    (((LinearMap.quotientInfEquivSupQuotient _ _).symm.trans
+      (Submodule.quotEquivOfEqBot _ (K.comap_colF_eq_bot p n))).trans
+      (LinearEquiv.ofInjective _ (K.lof_injective p n)).symm)
+
+/-- **The zeroth page of the first (column-filtered) spectral sequence of a double
+complex is the double complex itself**: `ᴵE_0^{p,n} ≅ A^{p, n-p}`. -/
+noncomputable def colPageZeroEquiv (p n : ℤ) :
+    K.colFiltered.page 0 p n ≃ₗ[R] K.A p (n - p) :=
+  (K.colFiltered.pageZeroEquiv p n).trans (K.colGrEquiv p n)
+
+lemma rowF_eq_sup (p n : ℤ) :
+    K.rowF p n = LinearMap.range (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) (n - p))
+      ⊔ K.rowF (p + 1) n := by
+  apply le_antisymm
+  · refine iSup₂_le fun i hi ↦ ?_
+    by_cases h : p + 1 ≤ n - i
+    · exact le_trans (le_iSup₂ (f := fun i' _ ↦
+        LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i h)
+        le_sup_right
+    · have hip : i = n - p := by omega
+      subst hip
+      exact le_sup_left
+  · refine sup_le ?_ ?_
+    · exact le_iSup₂ (f := fun i' _ ↦
+        LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) (n - p)
+        (by omega)
+    · refine iSup₂_le fun i hi ↦ ?_
+      exact le_iSup₂ (f := fun i' _ ↦
+        LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i (by omega)
+
+lemma rowF_le_ker_component (p n : ℤ) :
+    K.rowF (p + 1) n
+      ≤ LinearMap.ker (DirectSum.component R ℤ (fun i' ↦ K.A i' (n - i')) (n - p)) := by
+  refine iSup₂_le fun i hi ↦ ?_
+  rintro x ⟨a, rfl⟩
+  rw [LinearMap.mem_ker, DirectSum.component.of]
+  rw [dif_neg (by omega : ¬ i = n - p)]
+
+lemma comap_rowF_eq_bot (p n : ℤ) :
+    Submodule.comap
+        (LinearMap.range (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) (n - p))).subtype
+        (LinearMap.range (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) (n - p)))
+      ⊓ Submodule.comap
+          (LinearMap.range (DirectSum.lof R ℤ (fun i' ↦ K.A i' (n - i')) (n - p))).subtype
+          (K.rowF (p + 1) n) = ⊥ := by
+  refine le_bot_iff.mp fun x hx ↦ ?_
+  obtain ⟨-, hx2⟩ := Submodule.mem_inf.mp hx
+  have hx2' : (x : K.Tot n) ∈ K.rowF (p + 1) n := hx2
+  obtain ⟨a, ha⟩ := x.2
+  have hcomp : DirectSum.component R ℤ (fun i' ↦ K.A i' (n - i')) (n - p) (x : K.Tot n) = 0 :=
+    K.rowF_le_ker_component p n hx2'
+  rw [← ha, DirectSum.component.lof_self] at hcomp
+  rw [Submodule.mem_bot]
+  apply Subtype.ext
+  rw [← ha, hcomp, map_zero]
+  rfl
+
+/-- The associated graded piece of the row filtration is a single entry of the
+double complex. -/
+noncomputable def rowGrEquiv (p n : ℤ) :
+    (↥(K.rowF p n) ⧸ (K.rowF (p + 1) n).comap (K.rowF p n).subtype)
+      ≃ₗ[R] K.A (n - p) (n - (n - p)) :=
+  (Submodule.Quotient.equiv _ _ (LinearEquiv.ofEq _ _ (K.rowF_eq_sup p n)) (by
+      ext ξ
+      simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
+      constructor
+      · rintro ⟨η, hη, rfl⟩
+        simpa using hη
+      · intro hξ
+        exact ⟨(LinearEquiv.ofEq _ _ (K.rowF_eq_sup p n)).symm ξ, by simpa using hξ,
+          (LinearEquiv.ofEq _ _ (K.rowF_eq_sup p n)).apply_symm_apply ξ⟩)).trans
+    (((LinearMap.quotientInfEquivSupQuotient _ _).symm.trans
+      (Submodule.quotEquivOfEqBot _ (K.comap_rowF_eq_bot p n))).trans
+      (LinearEquiv.ofInjective _ (K.lof_injective (n - p) n)).symm)
+
+/-- **The zeroth page of the second (row-filtered) spectral sequence of a double
+complex is the double complex itself**: `ᴵᴵE_0^{p,n} ≅ A^{n-p, p}` (the second
+index appears as `n - (n - p)`). -/
+noncomputable def rowPageZeroEquiv (p n : ℤ) :
+    K.rowFiltered.page 0 p n ≃ₗ[R] K.A (n - p) (n - (n - p)) :=
+  (K.rowFiltered.pageZeroEquiv p n).trans (K.rowGrEquiv p n)
+
+end GradedPieces
+
+/-! ### First-quadrant boundedness -/
+
+section FirstQuadrant
+
+variable (hfq : ∀ i j : ℤ, i < 0 ∨ j < 0 → Subsingleton (K.A i j))
+
+include hfq
+
+lemma colF_eq_bot {p n : ℤ} (hp : n < p) : K.colF p n = ⊥ := by
+  refine le_bot_iff.mp (iSup₂_le fun i hi ↦ ?_)
+  rintro y ⟨a, rfl⟩
+  haveI := hfq i (n - i) (Or.inr (by omega))
+  rw [Subsingleton.elim a 0, map_zero]
+  exact zero_mem _
+
+lemma colF_eq_top {p n : ℤ} (hp : p ≤ 0) : K.colF p n = ⊤ := by
+  have key : ∀ x : K.Tot n, x ∈ K.colF p n := by
+    intro x
+    induction x using DirectSum.induction_on with
+    | zero => exact zero_mem _
+    | of i a =>
+      by_cases h : p ≤ i
+      · refine le_iSup₂ (f := fun i' _ ↦
+          LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i h ?_
+        rw [← DirectSum.lof_eq_of R]
+        exact ⟨a, rfl⟩
+      · haveI := hfq i (n - i) (Or.inl (by omega))
+        rw [Subsingleton.elim a 0, map_zero]
+        exact zero_mem _
+    | add x y hx hy => exact add_mem hx hy
+  exact top_le_iff.mp fun x _ ↦ key x
+
+lemma rowF_eq_bot {p n : ℤ} (hp : n < p) : K.rowF p n = ⊥ := by
+  refine le_bot_iff.mp (iSup₂_le fun i hi ↦ ?_)
+  rintro y ⟨a, rfl⟩
+  haveI := hfq i (n - i) (Or.inl (by omega))
+  rw [Subsingleton.elim a 0, map_zero]
+  exact zero_mem _
+
+lemma rowF_eq_top {p n : ℤ} (hp : p ≤ 0) : K.rowF p n = ⊤ := by
+  have key : ∀ x : K.Tot n, x ∈ K.rowF p n := by
+    intro x
+    induction x using DirectSum.induction_on with
+    | zero => exact zero_mem _
+    | of i a =>
+      by_cases h : p ≤ n - i
+      · refine le_iSup₂ (f := fun i' _ ↦
+          LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (n - i'')) i')) i h ?_
+        rw [← DirectSum.lof_eq_of R]
+        exact ⟨a, rfl⟩
+      · haveI := hfq i (n - i) (Or.inr (by omega))
+        rw [Subsingleton.elim a 0, map_zero]
+        exact zero_mem _
+    | add x y hx hy => exact add_mem hx hy
+  exact top_le_iff.mp fun x _ ↦ key x
+
+/-- **The first spectral sequence of a first-quadrant double complex converges**:
+once `r` passes the (spot-dependent) bounds, the page `ᴵE_r^{p,n}` is the
+associated graded, for the column filtration, of `H^n(Tot)`. -/
+noncomputable def colPageEquivGrH {r p n : ℤ} (hr1 : n + 1 < p + r) (hr2 : p - r + 1 ≤ 0) :
+    K.colFiltered.page r p n ≃ₗ[R]
+      (↥(K.colFiltered.FH p n) ⧸
+        (K.colFiltered.FH (p + 1) n).comap (K.colFiltered.FH p n).subtype) :=
+  K.colFiltered.pageEquivGrHOfBounded (K.colF_eq_bot hfq hr1) (K.colF_eq_top hfq hr2)
+
+/-- **The second spectral sequence of a first-quadrant double complex converges**:
+once `r` passes the (spot-dependent) bounds, the page `ᴵᴵE_r^{p,n}` is the
+associated graded, for the row filtration, of the *same* `H^n(Tot)`. -/
+noncomputable def rowPageEquivGrH {r p n : ℤ} (hr1 : n + 1 < p + r) (hr2 : p - r + 1 ≤ 0) :
+    K.rowFiltered.page r p n ≃ₗ[R]
+      (↥(K.rowFiltered.FH p n) ⧸
+        (K.rowFiltered.FH (p + 1) n).comap (K.rowFiltered.FH p n).subtype) :=
+  K.rowFiltered.pageEquivGrHOfBounded (K.rowF_eq_bot hfq hr1) (K.rowF_eq_top hfq hr2)
+
+/-- The column filtration of a first-quadrant double complex is `FirstQuadrant`. -/
+theorem colFiltered_firstQuadrant : K.colFiltered.FirstQuadrant :=
+  ⟨fun h ↦ K.colF_eq_bot hfq h, fun h ↦ K.colF_eq_top hfq h⟩
+
+/-- The row filtration of a first-quadrant double complex is `FirstQuadrant`. -/
+theorem rowFiltered_firstQuadrant : K.rowFiltered.FirstQuadrant :=
+  ⟨fun h ↦ K.rowF_eq_bot hfq h, fun h ↦ K.rowF_eq_top hfq h⟩
+
+/-- **Five-term exact sequence of the first (column) spectral sequence** of a
+first-quadrant double complex:
+`0 → ᴵE_2^{1,0} → H¹(Tot) → ᴵE_2^{0,1} →^{d₂} ᴵE_2^{2,0} → H²(Tot)`. -/
+theorem colFiltered_five_term_exact :
+    Function.Injective (FilteredComplex.f1 (K.colFiltered_firstQuadrant hfq)) ∧
+    Function.Exact (FilteredComplex.f1 (K.colFiltered_firstQuadrant hfq))
+      (FilteredComplex.f2 (K.colFiltered_firstQuadrant hfq)) ∧
+    Function.Exact (FilteredComplex.f2 (K.colFiltered_firstQuadrant hfq)) K.colFiltered.d2 ∧
+    Function.Exact K.colFiltered.d2 (FilteredComplex.f4 (K.colFiltered_firstQuadrant hfq)) :=
+  K.colFiltered.five_term_exact (K.colFiltered_firstQuadrant hfq)
+
+/-- **Five-term exact sequence of the second (row) spectral sequence** of a
+first-quadrant double complex:
+`0 → ᴵᴵE_2^{1,0} → H¹(Tot) → ᴵᴵE_2^{0,1} →^{d₂} ᴵᴵE_2^{2,0} → H²(Tot)`. -/
+theorem rowFiltered_five_term_exact :
+    Function.Injective (FilteredComplex.f1 (K.rowFiltered_firstQuadrant hfq)) ∧
+    Function.Exact (FilteredComplex.f1 (K.rowFiltered_firstQuadrant hfq))
+      (FilteredComplex.f2 (K.rowFiltered_firstQuadrant hfq)) ∧
+    Function.Exact (FilteredComplex.f2 (K.rowFiltered_firstQuadrant hfq)) K.rowFiltered.d2 ∧
+    Function.Exact K.rowFiltered.d2 (FilteredComplex.f4 (K.rowFiltered_firstQuadrant hfq)) :=
+  K.rowFiltered.five_term_exact (K.rowFiltered_firstQuadrant hfq)
+
+end FirstQuadrant
+
+/-! ### The first page: `E₁` is the vertical/horizontal cohomology
+
+The zeroth page of the column spectral sequence is the double complex itself
+(`colPageZeroEquiv`), and — as we now show — its differential `d₀` corresponds
+under that identification to the *vertical* differential `dv`.  Consequently the
+first page `ᴵE₁^{p,n}` is the vertical cohomology of the `p`-th column.  Dually,
+the row spectral sequence has `d₀ = dh` (horizontal), so `ᴵᴵE₁` is horizontal
+cohomology.  This is the differential-level half of Vakil, *The Rising Sea*,
+§1.7 (`E₁ = H(gr)` made concrete for a double complex). -/
+
+section FirstPage
+
+/-- A single entry `lof_i α` with `p ≤ i` lies in the column filtration `colF^p`. -/
+lemma lof_mem_colF {p i : ℤ} (a : ℤ) (h : p ≤ i) (α : K.A i (a - i)) :
+    (DirectSum.lof R ℤ (fun i' ↦ K.A i' (a - i')) i α) ∈ K.colF p a :=
+  (le_iSup₂ (f := fun j (_ : p ≤ j) ↦
+    LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (a - i'')) j)) i h)
+    (LinearMap.mem_range_self _ _)
+
+/-- A single entry `lof_p α` is a `0`-cocycle of the column filtration. -/
+lemma lof_mem_Z_zero (p a : ℤ) (α : K.A p (a - p)) :
+    (DirectSum.lof R ℤ (fun i' ↦ K.A i' (a - i')) p α)
+      ∈ K.colFiltered.Z 0 p a (a + 1) := by
+  rw [K.colFiltered.Z_zero]
+  exact K.lof_mem_colF a le_rfl α
+
+/-- Forward evaluation of the E₀-identification on the class of a single entry:
+`ᴵE₀^{p,a} ≅ A^{p,a-p}` sends `[lof_p α]` to `α`. -/
+lemma colPageZeroEquiv_mk (p a : ℤ) (α : K.A p (a - p))
+    (h : (DirectSum.lof R ℤ (fun i' ↦ K.A i' (a - i')) p α)
+        ∈ K.colFiltered.Z 0 p a (a + 1)) :
+    K.colPageZeroEquiv p a (Submodule.Quotient.mk ⟨_, h⟩) = α := by
+  rw [colPageZeroEquiv, colGrEquiv, FilteredComplex.pageZeroEquiv]
+  rw [LinearEquiv.trans_apply, Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+  erw [LinearEquiv.trans_apply, LinearEquiv.trans_apply, LinearEquiv.trans_apply]
+  erw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+  rw [LinearMap.quotientInfEquivSupQuotient_symm_apply_left _ _ _
+    (LinearMap.mem_range.mpr ⟨α, rfl⟩)]
+  rw [Submodule.quotEquivOfEqBot_apply_mk]
+  apply K.lof_injective p a
+  rw [LinearEquiv.ofInjective_symm_apply]
+  rfl
+
+/-- Inverse form of `colPageZeroEquiv_mk`: the E₀-identification sends `α` back to
+the class of the single entry `lof_p α`. -/
+lemma colPageZeroEquiv_symm_apply (p a : ℤ) (α : K.A p (a - p)) :
+    (K.colPageZeroEquiv p a).symm α
+      = Submodule.Quotient.mk ⟨_, K.lof_mem_Z_zero p a α⟩ :=
+  (LinearEquiv.symm_apply_eq _).2 (K.colPageZeroEquiv_mk p a α _).symm
+
+/-- **The differential `d₀` of the column spectral sequence is the vertical
+differential `dv`.**  Under the identification `ᴵE₀^{p,a} ≅ A^{p,a-p}`
+(`colPageZeroEquiv`), the page-zero differential `d₀ : ᴵE₀^{p,a} → ᴵE₀^{p,a+1}`
+becomes `dv : A^{p,a-p} → A^{p,(a+1)-p}`.  Hence `ᴵE₁^{p,a} = H_dv^{a-p}` of the
+`p`-th column. -/
+theorem colPageZeroEquiv_dPageAux (p a : ℤ) (x : K.colFiltered.page 0 p a) :
+    K.colPageZeroEquiv p (a + 1)
+        (K.colFiltered.dPageAux 0 p p a (a + 1) (by ring) rfl x)
+      = K.dv p p (a - p) ((a + 1) - p) (K.colPageZeroEquiv p a x) := by
+  obtain ⟨α, rfl⟩ : ∃ α, (K.colPageZeroEquiv p a).symm α = x :=
+    ⟨K.colPageZeroEquiv p a x, (K.colPageZeroEquiv p a).symm_apply_apply x⟩
+  rw [LinearEquiv.apply_symm_apply, K.colPageZeroEquiv_symm_apply,
+    K.colFiltered.dPageAux_mk]
+  have hcls : (Submodule.Quotient.mk
+        (K.colFiltered.dZ 0 p p a (a + 1) (by ring) rfl
+          ⟨_, K.lof_mem_Z_zero p a α⟩) : K.colFiltered.page 0 p (a + 1))
+      = Submodule.Quotient.mk
+          ⟨_, K.lof_mem_Z_zero p (a + 1) (K.dv p p (a - p) ((a + 1) - p) α)⟩ := by
+    rw [K.colFiltered.pageπ_eq_iff]
+    have hval : (↑(K.colFiltered.dZ 0 p p a (a + 1) (by ring) rfl
+          ⟨_, K.lof_mem_Z_zero p a α⟩) : K.colFiltered.X (a + 1))
+        = DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) (p + 1)
+            (K.dh p (p + 1) (a - p) ((a + 1) - (p + 1)) α)
+          + DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) p
+            (K.dv p p (a - p) ((a + 1) - p) α) := by
+      rw [FilteredComplex.dZ_coe]
+      exact K.totalD_lof a (a + 1) p α
+    rw [hval, K.colFiltered.B_zero]
+    change _ ∈ K.colF (p + 1) (a + 1)
+    have hb : (↑(⟨DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) p
+              (K.dv p p (a - p) ((a + 1) - p) α),
+            K.lof_mem_Z_zero p (a + 1) (K.dv p p (a - p) ((a + 1) - p) α)⟩ :
+          ↥(K.colFiltered.Z 0 p (a + 1) ((a + 1) + 1))) : K.colFiltered.X (a + 1))
+        = DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) p
+            (K.dv p p (a - p) ((a + 1) - p) α) := rfl
+    rw [hb]
+    have hmem : DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) (p + 1)
+        (K.dh p (p + 1) (a - p) ((a + 1) - (p + 1)) α) ∈ K.colF (p + 1) (a + 1) :=
+      K.lof_mem_colF (a + 1) (by omega) _
+    convert hmem using 1
+    abel
+  rw [hcls, K.colPageZeroEquiv_mk]
+
+/-- Flexible-degree form of `colPageZeroEquiv_dPageAux`: the target degree `m` is
+a free variable (`m = n + 1`).  Used to name both the incoming and outgoing
+page-zero differentials at a spot with clean indices. -/
+theorem colPageZeroEquiv_dPageAux' (p n m : ℤ) (hm : m = n + 1)
+    (x : K.colFiltered.page 0 p n) :
+    K.colPageZeroEquiv p m (K.colFiltered.dPageAux 0 p p n m (by ring) hm x)
+      = K.dv p p (n - p) (m - p) (K.colPageZeroEquiv p n x) := by
+  subst hm
+  exact K.colPageZeroEquiv_dPageAux p n x
+
+/-- The outgoing vertical differential at spot `(p, a)`:
+`dv : A^{p,a-p} → A^{p,(a+1)-p}`. -/
+noncomputable abbrev dvOut (p a : ℤ) : K.A p (a - p) →ₗ[R] K.A p ((a + 1) - p) :=
+  K.dv p p (a - p) ((a + 1) - p)
+
+/-- The incoming vertical differential at spot `(p, a)`:
+`dv : A^{p,(a-1)-p} → A^{p,a-p}`. -/
+noncomputable abbrev dvIn (p a : ℤ) : K.A p ((a - 1) - p) →ₗ[R] K.A p (a - p) :=
+  K.dv p p ((a - 1) - p) (a - p)
+
+/-- **`ᴵE₁` is the vertical cohomology of the double complex** (FOAG §1.7,
+first spectral sequence).  Under the identification `ᴵE₀^{p,•} ≅ A^{p, •-p}`,
+the first page `ᴵE₁^{p,a}` is the homology of the `p`-th column at the vertical
+differential: `ᴵE₁^{p,a} ≅ ker(dv)/im(dv)`. -/
+noncomputable def colPageOneEquiv (p a : ℤ) :
+    K.colFiltered.page 1 p a ≃ₗ[R]
+      (↥(ker (K.dvOut p a)) ⧸ (range (K.dvIn p a)).comap (ker (K.dvOut p a)).subtype) :=
+  (K.colFiltered.pageSuccEquiv' 0 p p p a (by ring) (by ring)).trans <|
+    homologyEquivOfSquares
+      (e := K.colPageZeroEquiv p a)
+      (fout := K.colFiltered.dPageAux 0 p p a (a + 1) (by ring) rfl)
+      (gout := K.dvOut p a)
+      (eout := K.colPageZeroEquiv p (a + 1))
+      (hout := fun x ↦ K.colPageZeroEquiv_dPageAux' p a (a + 1) (by ring) x)
+      (fin_ := K.colFiltered.dPageAux 0 p p (a - 1) a (by ring) (by ring))
+      (gin := K.dvIn p a)
+      (hin := by
+        rw [← LinearMap.range_comp]
+        have hcomp : (K.colPageZeroEquiv p a : K.colFiltered.page 0 p a →ₗ[R] _).comp
+              (K.colFiltered.dPageAux 0 p p (a - 1) a (by ring) (by ring))
+            = (K.dvIn p a).comp
+              (K.colPageZeroEquiv p (a - 1) : K.colFiltered.page 0 p (a - 1) →ₗ[R] _) := by
+          refine LinearMap.ext fun x ↦ ?_
+          simpa using K.colPageZeroEquiv_dPageAux' p (a - 1) a (by ring) x
+        rw [hcomp, LinearMap.range_comp, LinearEquiv.range, Submodule.map_top])
+
+/-! #### Row version: `d₀ = dh`
+
+The dual statement for the second (row-filtered) spectral sequence: under the
+identification `ᴵᴵE₀^{p,a} ≅ A^{a-p, a-(a-p)}` (`rowPageZeroEquiv`), the page-zero
+differential is the *horizontal* differential `dh`.  Hence `ᴵᴵE₁ = H_dh`.  The
+one wrinkle over the column case: the surviving `dh` term from `totalD_lof` sits
+at family index `(a-p)+1`, while `rowPageZeroEquiv (a+1)`'s generator is at
+`(a+1)-p`; these are equal only propositionally, so a `lof`-index transport is
+needed (handled by the flexible-index `rowPageZeroEquiv_mk'`). -/
+
+/-- A single entry `lof_i α` with `p ≤ a - i` lies in the row filtration `rowF^p`. -/
+lemma lof_mem_rowF {p i : ℤ} (a : ℤ) (h : p ≤ a - i) (α : K.A i (a - i)) :
+    (DirectSum.lof R ℤ (fun i' ↦ K.A i' (a - i')) i α) ∈ K.rowF p a :=
+  (le_iSup₂ (f := fun j (_ : p ≤ a - j) ↦
+    LinearMap.range (DirectSum.lof R ℤ (fun i'' ↦ K.A i'' (a - i'')) j)) i h)
+    (LinearMap.mem_range_self _ _)
+
+/-- A single entry `lof_{a-p} β` is a `0`-cocycle of the row filtration. -/
+lemma lof_mem_rowZ_zero (p a : ℤ) (β : K.A (a - p) (a - (a - p))) :
+    (DirectSum.lof R ℤ (fun i' ↦ K.A i' (a - i')) (a - p) β)
+      ∈ K.rowFiltered.Z 0 p a (a + 1) := by
+  rw [K.rowFiltered.Z_zero]
+  exact K.lof_mem_rowF a (by omega) β
+
+/-- Forward evaluation of the row E₀-identification on the class of a single entry:
+`ᴵᴵE₀^{p,a} ≅ A^{a-p, a-(a-p)}` sends `[lof_{a-p} β]` to `β`. -/
+lemma rowPageZeroEquiv_mk (p a : ℤ) (β : K.A (a - p) (a - (a - p)))
+    (h : (DirectSum.lof R ℤ (fun i' ↦ K.A i' (a - i')) (a - p) β)
+        ∈ K.rowFiltered.Z 0 p a (a + 1)) :
+    K.rowPageZeroEquiv p a (Submodule.Quotient.mk ⟨_, h⟩) = β := by
+  rw [rowPageZeroEquiv, rowGrEquiv, FilteredComplex.pageZeroEquiv]
+  rw [LinearEquiv.trans_apply, Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+  erw [LinearEquiv.trans_apply, LinearEquiv.trans_apply, LinearEquiv.trans_apply]
+  erw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+  rw [LinearMap.quotientInfEquivSupQuotient_symm_apply_left _ _ _
+    (LinearMap.mem_range.mpr ⟨β, rfl⟩)]
+  rw [Submodule.quotEquivOfEqBot_apply_mk]
+  apply K.lof_injective (a - p) a
+  rw [LinearEquiv.ofInjective_symm_apply]
+  rfl
+
+/-- Flexible-index form of `rowPageZeroEquiv_mk`: the generator may sit at any
+index `j` propositionally equal to `a - p`, at the cost of a cast on the value. -/
+lemma rowPageZeroEquiv_mk' (p a j : ℤ) (hj : j = a - p) (β : K.A j (a - j))
+    (h : (DirectSum.lof R ℤ (fun i' ↦ K.A i' (a - i')) j β)
+        ∈ K.rowFiltered.Z 0 p a (a + 1)) :
+    K.rowPageZeroEquiv p a (Submodule.Quotient.mk ⟨_, h⟩) = hj ▸ β := by
+  subst hj
+  exact K.rowPageZeroEquiv_mk p a β h
+
+/-- Inverse form of `rowPageZeroEquiv_mk`. -/
+lemma rowPageZeroEquiv_symm_apply (p a : ℤ) (β : K.A (a - p) (a - (a - p))) :
+    (K.rowPageZeroEquiv p a).symm β
+      = Submodule.Quotient.mk ⟨_, K.lof_mem_rowZ_zero p a β⟩ :=
+  (LinearEquiv.symm_apply_eq _).2 (K.rowPageZeroEquiv_mk p a β _).symm
+
+/-- **The differential `d₀` of the row spectral sequence is the horizontal
+differential `dh`.**  Under `rowPageZeroEquiv : ᴵᴵE₀^{p,a} ≅ A^{a-p, a-(a-p)}`,
+the page-zero differential `d₀ : ᴵᴵE₀^{p,a} → ᴵᴵE₀^{p,a+1}` becomes
+`dh : A^{a-p, a-(a-p)} → A^{(a+1)-p, (a+1)-((a+1)-p)}`.  Hence
+`ᴵᴵE₁^{p,a} = H_dh` (horizontal cohomology). -/
+theorem rowPageZeroEquiv_dPageAux (p a : ℤ) (x : K.rowFiltered.page 0 p a) :
+    K.rowPageZeroEquiv p (a + 1)
+        (K.rowFiltered.dPageAux 0 p p a (a + 1) (by ring) rfl x)
+      = K.dh (a - p) ((a + 1) - p) (a - (a - p)) ((a + 1) - ((a + 1) - p))
+          (K.rowPageZeroEquiv p a x) := by
+  obtain ⟨β, rfl⟩ : ∃ β, (K.rowPageZeroEquiv p a).symm β = x :=
+    ⟨K.rowPageZeroEquiv p a x, (K.rowPageZeroEquiv p a).symm_apply_apply x⟩
+  rw [LinearEquiv.apply_symm_apply, K.rowPageZeroEquiv_symm_apply,
+    K.rowFiltered.dPageAux_mk]
+  -- membership of the surviving `dh` term (at index `(a-p)+1`) as a 0-cocycle
+  have hz : (DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) ((a - p) + 1)
+        (K.dh (a - p) ((a - p) + 1) (a - (a - p)) ((a + 1) - ((a - p) + 1)) β))
+      ∈ K.rowFiltered.Z 0 p (a + 1) ((a + 1) + 1) := by
+    rw [K.rowFiltered.Z_zero]
+    exact K.lof_mem_rowF (a + 1) (by omega) _
+  have hcls : (Submodule.Quotient.mk
+        (K.rowFiltered.dZ 0 p p a (a + 1) (by ring) rfl
+          ⟨_, K.lof_mem_rowZ_zero p a β⟩) : K.rowFiltered.page 0 p (a + 1))
+      = Submodule.Quotient.mk ⟨_, hz⟩ := by
+    rw [K.rowFiltered.pageπ_eq_iff]
+    have hval : (↑(K.rowFiltered.dZ 0 p p a (a + 1) (by ring) rfl
+          ⟨_, K.lof_mem_rowZ_zero p a β⟩) : K.rowFiltered.X (a + 1))
+        = DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) ((a - p) + 1)
+            (K.dh (a - p) ((a - p) + 1) (a - (a - p)) ((a + 1) - ((a - p) + 1)) β)
+          + DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) (a - p)
+            (K.dv (a - p) (a - p) (a - (a - p)) ((a + 1) - (a - p)) β) := by
+      rw [FilteredComplex.dZ_coe]
+      exact K.totalD_lof a (a + 1) (a - p) β
+    rw [hval, K.rowFiltered.B_zero]
+    change _ ∈ K.rowF (p + 1) (a + 1)
+    have hb : (↑(⟨DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) ((a - p) + 1)
+              (K.dh (a - p) ((a - p) + 1) (a - (a - p)) ((a + 1) - ((a - p) + 1)) β),
+            hz⟩ : ↥(K.rowFiltered.Z 0 p (a + 1) ((a + 1) + 1))) : K.rowFiltered.X (a + 1))
+        = DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) ((a - p) + 1)
+            (K.dh (a - p) ((a - p) + 1) (a - (a - p)) ((a + 1) - ((a - p) + 1)) β) := rfl
+    rw [hb]
+    have hmem : DirectSum.lof R ℤ (fun i' ↦ K.A i' ((a + 1) - i')) (a - p)
+        (K.dv (a - p) (a - p) (a - (a - p)) ((a + 1) - (a - p)) β) ∈ K.rowF (p + 1) (a + 1) :=
+      K.lof_mem_rowF (a + 1) (by omega) _
+    convert hmem using 1
+    abel
+  rw [hcls, K.rowPageZeroEquiv_mk' p (a + 1) ((a - p) + 1) (by ring) _ hz]
+  -- transport the surviving `dh` index `(a-p)+1` to `(a+1)-p`
+  exact (fun k (e : (a - p) + 1 = k) ↦
+    (by subst e; rfl :
+      (e ▸ K.dh (a - p) ((a - p) + 1) (a - (a - p)) ((a + 1) - ((a - p) + 1)) β
+          : K.A k ((a + 1) - k))
+        = K.dh (a - p) k (a - (a - p)) ((a + 1) - k) β)) ((a + 1) - p) (by ring)
+
+/-- Flexible-degree form of `rowPageZeroEquiv_dPageAux`: the target degree `m` is
+a free variable (`m = n + 1`). -/
+theorem rowPageZeroEquiv_dPageAux' (p n m : ℤ) (hm : m = n + 1)
+    (x : K.rowFiltered.page 0 p n) :
+    K.rowPageZeroEquiv p m (K.rowFiltered.dPageAux 0 p p n m (by ring) hm x)
+      = K.dh (n - p) (m - p) (n - (n - p)) (m - (m - p)) (K.rowPageZeroEquiv p n x) := by
+  subst hm
+  exact K.rowPageZeroEquiv_dPageAux p n x
+
+/-- The outgoing horizontal differential at spot `(p, a)`:
+`dh : A^{a-p, a-(a-p)} → A^{(a+1)-p, (a+1)-((a+1)-p)}`. -/
+noncomputable abbrev dhOut (p a : ℤ) :
+    K.A (a - p) (a - (a - p)) →ₗ[R] K.A ((a + 1) - p) ((a + 1) - ((a + 1) - p)) :=
+  K.dh (a - p) ((a + 1) - p) (a - (a - p)) ((a + 1) - ((a + 1) - p))
+
+/-- The incoming horizontal differential at spot `(p, a)`:
+`dh : A^{(a-1)-p, (a-1)-((a-1)-p)} → A^{a-p, a-(a-p)}`. -/
+noncomputable abbrev dhIn (p a : ℤ) :
+    K.A ((a - 1) - p) ((a - 1) - ((a - 1) - p)) →ₗ[R] K.A (a - p) (a - (a - p)) :=
+  K.dh ((a - 1) - p) (a - p) ((a - 1) - ((a - 1) - p)) (a - (a - p))
+
+/-- **`ᴵᴵE₁` is the horizontal cohomology of the double complex** (FOAG §1.7,
+second spectral sequence).  Under the identification `ᴵᴵE₀^{p,•} ≅ A^{•-p, •-(•-p)}`,
+the first page `ᴵᴵE₁^{p,a}` is the homology of the appropriate row at the
+horizontal differential: `ᴵᴵE₁^{p,a} ≅ ker(dh)/im(dh)`. -/
+noncomputable def rowPageOneEquiv (p a : ℤ) :
+    K.rowFiltered.page 1 p a ≃ₗ[R]
+      (↥(ker (K.dhOut p a)) ⧸ (range (K.dhIn p a)).comap (ker (K.dhOut p a)).subtype) :=
+  (K.rowFiltered.pageSuccEquiv' 0 p p p a (by ring) (by ring)).trans <|
+    homologyEquivOfSquares
+      (e := K.rowPageZeroEquiv p a)
+      (fout := K.rowFiltered.dPageAux 0 p p a (a + 1) (by ring) rfl)
+      (gout := K.dhOut p a)
+      (eout := K.rowPageZeroEquiv p (a + 1))
+      (hout := fun x ↦ K.rowPageZeroEquiv_dPageAux' p a (a + 1) (by ring) x)
+      (fin_ := K.rowFiltered.dPageAux 0 p p (a - 1) a (by ring) (by ring))
+      (gin := K.dhIn p a)
+      (hin := by
+        rw [← LinearMap.range_comp]
+        have hcomp : (K.rowPageZeroEquiv p a : K.rowFiltered.page 0 p a →ₗ[R] _).comp
+              (K.rowFiltered.dPageAux 0 p p (a - 1) a (by ring) (by ring))
+            = (K.dhIn p a).comp
+              (K.rowPageZeroEquiv p (a - 1) : K.rowFiltered.page 0 p (a - 1) →ₗ[R] _) := by
+          refine LinearMap.ext fun x ↦ ?_
+          simpa using K.rowPageZeroEquiv_dPageAux' p (a - 1) a (by ring) x
+        rw [hcomp, LinearMap.range_comp, LinearEquiv.range, Submodule.map_top])
+
+end FirstPage
+
+end DoubleComplex

--- a/FLT/Slop/SpectralSequence/DoubleComplex.lean
+++ b/FLT/Slop/SpectralSequence/DoubleComplex.lean
@@ -344,7 +344,6 @@ lemma lof_totalCochainComplex_d (n m i : ℤ) :
   intro x
   exact K.totalD_lof n m i x
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The horizontal contribution to mathlib's total differential agrees with
 the horizontal contribution in the concrete direct-sum model. -/
 lemma d₁_eq_concrete (n m i : ℤ) (hm : m = n + 1) :
@@ -367,7 +366,6 @@ lemma d₁_eq_concrete (n m i : ℤ) (hm : m = n + 1) :
   simp only [ModuleCat.ofHom_hom, Category.assoc]
   rw [HomologicalComplex₂.XXIsoOfEq_hom_ιTotal]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The vertical contribution to mathlib's total differential agrees with the
 signed vertical contribution in the concrete direct-sum model. -/
 lemma d₂_eq_concrete (n m i : ℤ) (hm : m = n + 1) :
@@ -391,6 +389,8 @@ lemma d₂_eq_concrete (n m i : ℤ) (hm : m = n + 1) :
       HomologicalComplex₂.ιTotal K (ComplexShape.up ℤ) i (m - i) m _
   rw [Linear.units_smul_comp]
 
+-- The `set_option` is required here: without it the `isoOfComponents`
+-- compatibility proof leaves metavariables that the kernel rejects.
 set_option backward.isDefEq.respectTransparency false in
 /-- The concrete direct-sum total complex is canonically isomorphic to mathlib's
 categorical coproduct total complex. -/

--- a/FLT/Slop/SpectralSequence/ExactCoupleBridge.lean
+++ b/FLT/Slop/SpectralSequence/ExactCoupleBridge.lean
@@ -1,0 +1,231 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.SpectralSequence.FilteredModule
+
+/-!
+# The exact couple of a filtered differential module
+
+Given a `FilteredDifferentialModule R M` we build its exact couple (Weibel §5.9.1):
+* `D^p = H(F^p M) = Z_∞^p / d(F^p)` — the homology of the subcomplex `F^p M`;
+* `E^p = E_1^p = Z_1^p / B_1^p` — the first page;
+* `i : D^{p+1} → D^p` induced by the inclusion `F^{p+1} ↪ F^p`;
+* `j : D^p → E^p` induced by `Z_∞^p ↪ Z_1^p`;
+* `k : E^p → D^{p+1}` the connecting map `[x] ↦ [d x]`.
+
+This file establishes the per-degree maps and the three exactness statements
+(`range_iMap_eq_ker_jMap`, `range_jMap_eq_ker_kMap`, `range_kMap_eq_ker_iMap`)
+— the mathematical heart of the exact couple of a filtered differential module.
+Assembling them into a `GradedExactCouple` on `⨁ p, HF p` (see the sibling
+`FLT.Slop.ExactCouple` development) is the natural next step and is not done
+here.
+-/
+
+@[expose] public section
+
+open scoped DirectSum
+open Submodule LinearMap
+
+namespace FilteredDifferentialModule
+
+variable {R : Type*} {M : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+variable (K : FilteredDifferentialModule R M)
+
+/-! ## The homology of the subcomplex `F^p` -/
+
+/-- The boundaries of the subcomplex `F^p`: `d(F^p) = im(d|_{F^p})`. -/
+def dF (p : ℤ) : Submodule R M := (K.F p).map K.d
+
+lemma dF_le_Zinf (p : ℤ) : K.dF p ≤ K.Zinf p := by
+  rintro _ ⟨x, hx, rfl⟩
+  refine Submodule.mem_inf.mpr ⟨K.d_mem_F p x hx, ?_⟩
+  exact LinearMap.mem_ker.mpr (K.d_squared x)
+
+lemma dF_mono {p q : ℤ} (h : p ≤ q) : K.dF q ≤ K.dF p :=
+  Submodule.map_mono (K.F_mono h)
+
+/-- `D^p = H(F^p) = Z_∞^p / d(F^p)`, the homology of the subcomplex `F^p`. -/
+abbrev HF (p : ℤ) := ↥(K.Zinf p) ⧸ (K.dF p).comap (K.Zinf p).subtype
+
+/-- Membership in `d(F^p)` for a `Z_∞^p`-element, unfolded. -/
+lemma mem_dF_comap {p : ℤ} (z : ↥(K.Zinf p)) :
+    z ∈ (K.dF p).comap (K.Zinf p).subtype ↔ ∃ x ∈ K.F p, K.d x = z := by
+  simp only [Submodule.mem_comap, Submodule.coe_subtype, dF, Submodule.mem_map]
+
+/-! ## The map `i : D^{p+1} → D^p` -/
+
+/-- The inclusion `Z_∞^{p+1} → Z_∞^p`. -/
+def ZinfIncl (p : ℤ) : ↥(K.Zinf (p + 1)) →ₗ[R] ↥(K.Zinf p) :=
+  Submodule.inclusion (inf_le_inf_right _ (K.F_le p))
+
+/-- `i : D^{p+1} → D^p`, induced by `F^{p+1} ↪ F^p`. -/
+def iMap (p : ℤ) : K.HF (p + 1) →ₗ[R] K.HF p :=
+  Submodule.mapQ _ _ (K.ZinfIncl p) (by
+    rintro z hz
+    rw [Submodule.mem_comap] at hz ⊢
+    obtain ⟨x, hx, hdx⟩ := (K.mem_dF_comap z).mp hz
+    exact (K.mem_dF_comap _).mpr ⟨x, K.F_le p hx, hdx⟩)
+
+@[simp] lemma iMap_mk (p : ℤ) (z : ↥(K.Zinf (p + 1))) :
+    K.iMap p (Submodule.Quotient.mk z) = Submodule.Quotient.mk (K.ZinfIncl p z) :=
+  Submodule.mapQ_apply _ _ _ z
+
+/-! ## The map `j : D^p → E^p` -/
+
+lemma Zinf_le_Z_one (p : ℤ) : K.Zinf p ≤ K.Z 1 p := by
+  intro z hz
+  obtain ⟨hzF, hzk⟩ := Submodule.mem_inf.mp hz
+  refine K.mem_Z.mpr ⟨hzF, ?_⟩
+  rw [LinearMap.mem_ker.mp hzk]
+  exact zero_mem _
+
+lemma dF_le_B_one (p : ℤ) : K.dF p ≤ K.B 1 p := by
+  rintro _ ⟨x, hx, rfl⟩
+  refine K.mem_B_right ?_ (K.d_mem_F p x hx)
+  rwa [show p - 1 + 1 = p by ring]
+
+/-- The inclusion `Z_∞^p → Z_1^p`. -/
+def ZinfToZone (p : ℤ) : ↥(K.Zinf p) →ₗ[R] ↥(K.Z 1 p) :=
+  Submodule.inclusion (K.Zinf_le_Z_one p)
+
+/-- `j : D^p → E^p = E_1^p`, induced by `Z_∞^p ↪ Z_1^p`. -/
+def jMap (p : ℤ) : K.HF p →ₗ[R] K.page 1 p :=
+  Submodule.mapQ _ _ (K.ZinfToZone p) (by
+    rintro z hz
+    rw [Submodule.mem_comap] at hz ⊢
+    obtain ⟨x, hx, hdx⟩ := (K.mem_dF_comap z).mp hz
+    simp only [Submodule.mem_comap, Submodule.coe_subtype, ZinfToZone,
+      Submodule.coe_inclusion] at *
+    rw [← hdx]
+    exact K.dF_le_B_one p ⟨x, hx, rfl⟩)
+
+@[simp] lemma jMap_mk (p : ℤ) (z : ↥(K.Zinf p)) :
+    K.jMap p (Submodule.Quotient.mk z) = Submodule.Quotient.mk (K.ZinfToZone p z) :=
+  Submodule.mapQ_apply _ _ _ z
+
+/-! ## The map `k : E^p → D^{p+1}` -/
+
+lemma d_mem_Zinf_succ {p : ℤ} {x : M} (hx : x ∈ K.Z 1 p) : K.d x ∈ K.Zinf (p + 1) :=
+  Submodule.mem_inf.mpr ⟨(K.mem_Z.mp hx).2, LinearMap.mem_ker.mpr (K.d_squared x)⟩
+
+/-- The connecting map `Z_1^p → Z_∞^{p+1}`, `x ↦ d x`. -/
+def ZoneToZinf (p : ℤ) : ↥(K.Z 1 p) →ₗ[R] ↥(K.Zinf (p + 1)) :=
+  K.d.restrict fun _ hx ↦ K.d_mem_Zinf_succ hx
+
+@[simp] lemma ZoneToZinf_coe (p : ℤ) (x : ↥(K.Z 1 p)) :
+    (K.ZoneToZinf p x : M) = K.d x := rfl
+
+/-- `k : E^p → D^{p+1}`, the connecting map `[x] ↦ [d x]`. -/
+def kMap (p : ℤ) : K.page 1 p →ₗ[R] K.HF (p + 1) :=
+  Submodule.mapQ _ _ (K.ZoneToZinf p) (by
+    rintro x hx
+    simp only [Submodule.mem_comap, Submodule.coe_subtype] at hx
+    obtain ⟨u, v, hu1, hu2, hv, hdv, hxeq⟩ := K.B_cases hx
+    rw [Submodule.mem_comap]
+    change K.d (x : M) ∈ K.dF (p + 1)
+    rw [hxeq, map_add, K.d_squared v, add_zero]
+    exact Submodule.mem_map_of_mem hu1)
+
+@[simp] lemma kMap_mk (p : ℤ) (x : ↥(K.Z 1 p)) :
+    K.kMap p (Submodule.Quotient.mk x) = Submodule.Quotient.mk (K.ZoneToZinf p x) :=
+  Submodule.mapQ_apply _ _ _ x
+
+@[simp] lemma ZinfIncl_coe (p : ℤ) (z : ↥(K.Zinf (p + 1))) :
+    (K.ZinfIncl p z : M) = z := rfl
+
+@[simp] lemma ZinfToZone_coe (p : ℤ) (z : ↥(K.Zinf p)) :
+    (K.ZinfToZone p z : M) = z := rfl
+
+/-! ## Zero-membership criteria in the quotients -/
+
+lemma HF_mk_eq_zero {p : ℤ} (z : ↥(K.Zinf p)) :
+    (Submodule.Quotient.mk z : K.HF p) = 0 ↔ (z : M) ∈ K.dF p := by
+  rw [Submodule.Quotient.mk_eq_zero, Submodule.mem_comap, Submodule.coe_subtype]
+
+lemma page_one_mk_eq_zero {p : ℤ} (x : ↥(K.Z 1 p)) :
+    (Submodule.Quotient.mk x : K.page 1 p) = 0 ↔ (x : M) ∈ K.B 1 p := by
+  rw [Submodule.Quotient.mk_eq_zero, Submodule.mem_comap, Submodule.coe_subtype]
+
+/-! ## The three exactness conditions -/
+
+/-- Exactness at `D` (`im i = ker j`): `range (iMap p) = ker (jMap p)`. -/
+theorem range_iMap_eq_ker_jMap (p : ℤ) :
+    range (K.iMap p) = ker (K.jMap p) := by
+  apply le_antisymm
+  · rintro _ ⟨w, rfl⟩
+    obtain ⟨z, rfl⟩ := Submodule.Quotient.mk_surjective _ w
+    rw [LinearMap.mem_ker, iMap_mk, jMap_mk, K.page_one_mk_eq_zero]
+    simp only [ZinfToZone_coe, ZinfIncl_coe]
+    -- `z ∈ Zinf (p+1)`, so `z ∈ F(p+1) ∩ d⁻¹ F(p+1) ⊆ B_1^p`
+    refine K.mem_B_left z.2.1 ?_
+    rw [LinearMap.mem_ker.mp z.2.2]; exact zero_mem _
+  · intro w hw
+    obtain ⟨z, rfl⟩ := Submodule.Quotient.mk_surjective _ w
+    rw [LinearMap.mem_ker, jMap_mk, K.page_one_mk_eq_zero] at hw
+    simp only [ZinfToZone_coe] at hw
+    obtain ⟨u, v, hu1, hu2, hv, hdv, hzeq⟩ := K.B_cases hw
+    -- `z = u + d v`, `d z = 0` forces `d u = 0`, so `u ∈ Zinf (p+1)` and `i[u] = [z]`
+    have hvp : v ∈ K.F p := by rwa [show p - 1 + 1 = p by ring] at hv
+    have hdu : K.d u = 0 := by
+      have hz0 : K.d (z : M) = 0 := LinearMap.mem_ker.mp z.2.2
+      rw [hzeq, map_add, K.d_squared v, add_zero] at hz0; exact hz0
+    refine ⟨Submodule.Quotient.mk ⟨u, Submodule.mem_inf.mpr ⟨hu1, LinearMap.mem_ker.mpr hdu⟩⟩, ?_⟩
+    rw [iMap_mk, Submodule.Quotient.eq, K.mem_dF_comap]
+    refine ⟨-v, neg_mem hvp, ?_⟩
+    simp only [map_neg, Submodule.coe_sub, ZinfIncl_coe, hzeq]; abel
+
+/-- Exactness at `E` (`im j = ker k`): `range (jMap p) = ker (kMap p)`. -/
+theorem range_jMap_eq_ker_kMap (p : ℤ) :
+    range (K.jMap p) = ker (K.kMap p) := by
+  apply le_antisymm
+  · rintro _ ⟨w, rfl⟩
+    obtain ⟨z, rfl⟩ := Submodule.Quotient.mk_surjective _ w
+    rw [LinearMap.mem_ker, jMap_mk, kMap_mk, K.HF_mk_eq_zero]
+    simp only [ZoneToZinf_coe, ZinfToZone_coe]
+    -- `k(j[z]) = [d z] = [0]` since `z ∈ ker d`
+    rw [LinearMap.mem_ker.mp z.2.2]; exact zero_mem _
+  · intro w hw
+    obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective _ w
+    rw [LinearMap.mem_ker, kMap_mk, K.HF_mk_eq_zero] at hw
+    simp only [ZoneToZinf_coe] at hw
+    rw [dF, Submodule.mem_map] at hw
+    obtain ⟨u, hu, hux⟩ := hw
+    -- `d x = d u`, `u ∈ F(p+1)`; then `x - u ∈ Zinf p` and `j[x-u] = [x]`
+    have hxu_ker : (x : M) - u ∈ ker K.d := by
+      rw [LinearMap.mem_ker, map_sub, hux, sub_self]
+    have hxu_F : (x : M) - u ∈ K.F p := sub_mem (K.mem_Z.mp x.2).1 (K.F_le p hu)
+    refine ⟨Submodule.Quotient.mk ⟨(x : M) - u, Submodule.mem_inf.mpr ⟨hxu_F, hxu_ker⟩⟩, ?_⟩
+    rw [jMap_mk, Submodule.Quotient.eq, Submodule.mem_comap, Submodule.coe_subtype]
+    simp only [Submodule.coe_sub, ZinfToZone_coe]
+    have hval : ((x : M) - u) - (x : M) = -u := by abel
+    rw [hval]
+    exact neg_mem (K.mem_B_left hu (by rw [hux]; exact (K.mem_Z.mp x.2).2))
+
+/-- Exactness at `D` (`im k = ker i`): `range (kMap p) = ker (iMap p)`. -/
+theorem range_kMap_eq_ker_iMap (p : ℤ) :
+    range (K.kMap p) = ker (K.iMap p) := by
+  apply le_antisymm
+  · rintro _ ⟨w, rfl⟩
+    obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective _ w
+    rw [LinearMap.mem_ker, kMap_mk, iMap_mk, K.HF_mk_eq_zero]
+    simp only [ZinfIncl_coe, ZoneToZinf_coe]
+    -- `i(k[x]) = [d x]`, `d x ∈ d(F^p)`
+    exact ⟨(x : M), (K.mem_Z.mp x.2).1, rfl⟩
+  · intro w hw
+    obtain ⟨z, rfl⟩ := Submodule.Quotient.mk_surjective _ w
+    rw [LinearMap.mem_ker, iMap_mk, K.HF_mk_eq_zero] at hw
+    simp only [ZinfIncl_coe] at hw
+    rw [dF, Submodule.mem_map] at hw
+    obtain ⟨x, hx, hdx⟩ := hw
+    -- `z = d x` for `x ∈ F p`; `d x = z ∈ F(p+1)`, so `x ∈ Z_1^p` and `k[x] = [z]`
+    have hxZ : x ∈ K.Z 1 p := K.mem_Z.mpr ⟨hx, by rw [hdx]; exact z.2.1⟩
+    refine ⟨Submodule.Quotient.mk ⟨x, hxZ⟩, ?_⟩
+    rw [kMap_mk, Submodule.Quotient.eq, K.mem_dF_comap]
+    refine ⟨0, zero_mem _, ?_⟩
+    simp only [map_zero, Submodule.coe_sub, ZoneToZinf_coe, hdx]; abel
+
+end FilteredDifferentialModule

--- a/FLT/Slop/SpectralSequence/ExactCoupleBridge.lean
+++ b/FLT/Slop/SpectralSequence/ExactCoupleBridge.lean
@@ -6,23 +6,23 @@ Authors: Akhil Mathew
 module
 
 public import FLT.Slop.SpectralSequence.FilteredModule
+public import FLT.Slop.ExactCouple.Graded
 
 /-!
 # The exact couple of a filtered differential module
 
 Given a `FilteredDifferentialModule R M` we build its exact couple (Weibel §5.9.1):
-* `D^p = H(F^p M) = Z_∞^p / d(F^p)` — the homology of the subcomplex `F^p M`;
+* `D^p = H(F^p M) = (F^p ∩ ker d) / d(F^p)` — the homology of the subcomplex
+  `F^p M`;
 * `E^p = E_1^p = Z_1^p / B_1^p` — the first page;
 * `i : D^{p+1} → D^p` induced by the inclusion `F^{p+1} ↪ F^p`;
-* `j : D^p → E^p` induced by `Z_∞^p ↪ Z_1^p`;
+* `j : D^p → E^p` induced by `(F^p ∩ ker d) ↪ Z_1^p`;
 * `k : E^p → D^{p+1}` the connecting map `[x] ↦ [d x]`.
 
 This file establishes the per-degree maps and the three exactness statements
 (`range_iMap_eq_ker_jMap`, `range_jMap_eq_ker_kMap`, `range_kMap_eq_ker_iMap`)
-— the mathematical heart of the exact couple of a filtered differential module.
-Assembling them into a `GradedExactCouple` on `⨁ p, HF p` (see the sibling
-`FLT.Slop.ExactCouple` development) is the natural next step and is not done
-here.
+and assembles them into a `GradedExactCouple` on the direct sums
+`⨁ p, HF p` and `⨁ p, page 1 p`.
 -/
 
 @[expose] public section
@@ -32,7 +32,7 @@ open Submodule LinearMap
 
 namespace FilteredDifferentialModule
 
-variable {R : Type*} {M : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+variable {R : Type*} {M : Type*} [Ring R] [AddCommGroup M] [Module R M]
 variable (K : FilteredDifferentialModule R M)
 
 /-! ## The homology of the subcomplex `F^p` -/
@@ -40,7 +40,7 @@ variable (K : FilteredDifferentialModule R M)
 /-- The boundaries of the subcomplex `F^p`: `d(F^p) = im(d|_{F^p})`. -/
 def dF (p : ℤ) : Submodule R M := (K.F p).map K.d
 
-lemma dF_le_Zinf (p : ℤ) : K.dF p ≤ K.Zinf p := by
+lemma dF_le_abutmentZ (p : ℤ) : K.dF p ≤ K.abutmentZ p := by
   rintro _ ⟨x, hx, rfl⟩
   refine Submodule.mem_inf.mpr ⟨K.d_mem_F p x hx, ?_⟩
   exact LinearMap.mem_ker.mpr (K.d_squared x)
@@ -48,35 +48,37 @@ lemma dF_le_Zinf (p : ℤ) : K.dF p ≤ K.Zinf p := by
 lemma dF_mono {p q : ℤ} (h : p ≤ q) : K.dF q ≤ K.dF p :=
   Submodule.map_mono (K.F_mono h)
 
-/-- `D^p = H(F^p) = Z_∞^p / d(F^p)`, the homology of the subcomplex `F^p`. -/
-abbrev HF (p : ℤ) := ↥(K.Zinf p) ⧸ (K.dF p).comap (K.Zinf p).subtype
+/-- `D^p = H(F^p) = (F^p ∩ ker d) / d(F^p)`, the homology of the subcomplex
+`F^p`. Here `abutmentZ p` is the cycle submodule used to present this homology;
+it is not the limit-term numerator `limitZ p`. -/
+abbrev HF (p : ℤ) := ↥(K.abutmentZ p) ⧸ (K.dF p).comap (K.abutmentZ p).subtype
 
-/-- Membership in `d(F^p)` for a `Z_∞^p`-element, unfolded. -/
-lemma mem_dF_comap {p : ℤ} (z : ↥(K.Zinf p)) :
-    z ∈ (K.dF p).comap (K.Zinf p).subtype ↔ ∃ x ∈ K.F p, K.d x = z := by
+/-- Membership in `d(F^p)` for an element of `F^p ∩ ker d`, unfolded. -/
+lemma mem_dF_comap {p : ℤ} (z : ↥(K.abutmentZ p)) :
+    z ∈ (K.dF p).comap (K.abutmentZ p).subtype ↔ ∃ x ∈ K.F p, K.d x = z := by
   simp only [Submodule.mem_comap, Submodule.coe_subtype, dF, Submodule.mem_map]
 
 /-! ## The map `i : D^{p+1} → D^p` -/
 
-/-- The inclusion `Z_∞^{p+1} → Z_∞^p`. -/
-def ZinfIncl (p : ℤ) : ↥(K.Zinf (p + 1)) →ₗ[R] ↥(K.Zinf p) :=
+/-- The inclusion `F^{p+1} ∩ ker d → F^p ∩ ker d`. -/
+def abutmentZIncl (p : ℤ) : ↥(K.abutmentZ (p + 1)) →ₗ[R] ↥(K.abutmentZ p) :=
   Submodule.inclusion (inf_le_inf_right _ (K.F_le p))
 
 /-- `i : D^{p+1} → D^p`, induced by `F^{p+1} ↪ F^p`. -/
 def iMap (p : ℤ) : K.HF (p + 1) →ₗ[R] K.HF p :=
-  Submodule.mapQ _ _ (K.ZinfIncl p) (by
+  Submodule.mapQ _ _ (K.abutmentZIncl p) (by
     rintro z hz
     rw [Submodule.mem_comap] at hz ⊢
     obtain ⟨x, hx, hdx⟩ := (K.mem_dF_comap z).mp hz
     exact (K.mem_dF_comap _).mpr ⟨x, K.F_le p hx, hdx⟩)
 
-@[simp] lemma iMap_mk (p : ℤ) (z : ↥(K.Zinf (p + 1))) :
-    K.iMap p (Submodule.Quotient.mk z) = Submodule.Quotient.mk (K.ZinfIncl p z) :=
+@[simp] lemma iMap_mk (p : ℤ) (z : ↥(K.abutmentZ (p + 1))) :
+    K.iMap p (Submodule.Quotient.mk z) = Submodule.Quotient.mk (K.abutmentZIncl p z) :=
   Submodule.mapQ_apply _ _ _ z
 
 /-! ## The map `j : D^p → E^p` -/
 
-lemma Zinf_le_Z_one (p : ℤ) : K.Zinf p ≤ K.Z 1 p := by
+lemma abutmentZ_le_Z_one (p : ℤ) : K.abutmentZ p ≤ K.Z 1 p := by
   intro z hz
   obtain ⟨hzF, hzk⟩ := Submodule.mem_inf.mp hz
   refine K.mem_Z.mpr ⟨hzF, ?_⟩
@@ -88,40 +90,40 @@ lemma dF_le_B_one (p : ℤ) : K.dF p ≤ K.B 1 p := by
   refine K.mem_B_right ?_ (K.d_mem_F p x hx)
   rwa [show p - 1 + 1 = p by ring]
 
-/-- The inclusion `Z_∞^p → Z_1^p`. -/
-def ZinfToZone (p : ℤ) : ↥(K.Zinf p) →ₗ[R] ↥(K.Z 1 p) :=
-  Submodule.inclusion (K.Zinf_le_Z_one p)
+/-- The inclusion `F^p ∩ ker d → Z_1^p`. -/
+def abutmentZToZOne (p : ℤ) : ↥(K.abutmentZ p) →ₗ[R] ↥(K.Z 1 p) :=
+  Submodule.inclusion (K.abutmentZ_le_Z_one p)
 
-/-- `j : D^p → E^p = E_1^p`, induced by `Z_∞^p ↪ Z_1^p`. -/
+/-- `j : D^p → E^p = E_1^p`, induced by `F^p ∩ ker d ↪ Z_1^p`. -/
 def jMap (p : ℤ) : K.HF p →ₗ[R] K.page 1 p :=
-  Submodule.mapQ _ _ (K.ZinfToZone p) (by
+  Submodule.mapQ _ _ (K.abutmentZToZOne p) (by
     rintro z hz
     rw [Submodule.mem_comap] at hz ⊢
     obtain ⟨x, hx, hdx⟩ := (K.mem_dF_comap z).mp hz
-    simp only [Submodule.mem_comap, Submodule.coe_subtype, ZinfToZone,
+    simp only [Submodule.mem_comap, Submodule.coe_subtype, abutmentZToZOne,
       Submodule.coe_inclusion] at *
     rw [← hdx]
     exact K.dF_le_B_one p ⟨x, hx, rfl⟩)
 
-@[simp] lemma jMap_mk (p : ℤ) (z : ↥(K.Zinf p)) :
-    K.jMap p (Submodule.Quotient.mk z) = Submodule.Quotient.mk (K.ZinfToZone p z) :=
+@[simp] lemma jMap_mk (p : ℤ) (z : ↥(K.abutmentZ p)) :
+    K.jMap p (Submodule.Quotient.mk z) = Submodule.Quotient.mk (K.abutmentZToZOne p z) :=
   Submodule.mapQ_apply _ _ _ z
 
 /-! ## The map `k : E^p → D^{p+1}` -/
 
-lemma d_mem_Zinf_succ {p : ℤ} {x : M} (hx : x ∈ K.Z 1 p) : K.d x ∈ K.Zinf (p + 1) :=
+lemma d_mem_abutmentZ_succ {p : ℤ} {x : M} (hx : x ∈ K.Z 1 p) : K.d x ∈ K.abutmentZ (p + 1) :=
   Submodule.mem_inf.mpr ⟨(K.mem_Z.mp hx).2, LinearMap.mem_ker.mpr (K.d_squared x)⟩
 
-/-- The connecting map `Z_1^p → Z_∞^{p+1}`, `x ↦ d x`. -/
-def ZoneToZinf (p : ℤ) : ↥(K.Z 1 p) →ₗ[R] ↥(K.Zinf (p + 1)) :=
-  K.d.restrict fun _ hx ↦ K.d_mem_Zinf_succ hx
+/-- The connecting map `Z_1^p → F^{p+1} ∩ ker d`, `x ↦ d x`. -/
+def zOneToAbutmentZ (p : ℤ) : ↥(K.Z 1 p) →ₗ[R] ↥(K.abutmentZ (p + 1)) :=
+  K.d.restrict fun _ hx ↦ K.d_mem_abutmentZ_succ hx
 
-@[simp] lemma ZoneToZinf_coe (p : ℤ) (x : ↥(K.Z 1 p)) :
-    (K.ZoneToZinf p x : M) = K.d x := rfl
+@[simp] lemma zOneToAbutmentZ_coe (p : ℤ) (x : ↥(K.Z 1 p)) :
+    (K.zOneToAbutmentZ p x : M) = K.d x := rfl
 
 /-- `k : E^p → D^{p+1}`, the connecting map `[x] ↦ [d x]`. -/
 def kMap (p : ℤ) : K.page 1 p →ₗ[R] K.HF (p + 1) :=
-  Submodule.mapQ _ _ (K.ZoneToZinf p) (by
+  Submodule.mapQ _ _ (K.zOneToAbutmentZ p) (by
     rintro x hx
     simp only [Submodule.mem_comap, Submodule.coe_subtype] at hx
     obtain ⟨u, v, hu1, hu2, hv, hdv, hxeq⟩ := K.B_cases hx
@@ -131,18 +133,27 @@ def kMap (p : ℤ) : K.page 1 p →ₗ[R] K.HF (p + 1) :=
     exact Submodule.mem_map_of_mem hu1)
 
 @[simp] lemma kMap_mk (p : ℤ) (x : ↥(K.Z 1 p)) :
-    K.kMap p (Submodule.Quotient.mk x) = Submodule.Quotient.mk (K.ZoneToZinf p x) :=
+    K.kMap p (Submodule.Quotient.mk x) = Submodule.Quotient.mk (K.zOneToAbutmentZ p x) :=
   Submodule.mapQ_apply _ _ _ x
 
-@[simp] lemma ZinfIncl_coe (p : ℤ) (z : ↥(K.Zinf (p + 1))) :
-    (K.ZinfIncl p z : M) = z := rfl
+/-- On the first page, the differential is the composite `j ∘ k` of the
+exact-couple maps. -/
+lemma jMap_comp_kMap (p : ℤ) :
+    (K.jMap (p + 1)).comp (K.kMap p) = K.dPage 1 p := by
+  apply Submodule.linearMap_qext
+  ext x
+  simp only [LinearMap.comp_apply, Submodule.mkQ_apply, kMap_mk, jMap_mk, dPageAux_mk]
+  congr 1
 
-@[simp] lemma ZinfToZone_coe (p : ℤ) (z : ↥(K.Zinf p)) :
-    (K.ZinfToZone p z : M) = z := rfl
+@[simp] lemma abutmentZIncl_coe (p : ℤ) (z : ↥(K.abutmentZ (p + 1))) :
+    (K.abutmentZIncl p z : M) = z := rfl
+
+@[simp] lemma abutmentZToZOne_coe (p : ℤ) (z : ↥(K.abutmentZ p)) :
+    (K.abutmentZToZOne p z : M) = z := rfl
 
 /-! ## Zero-membership criteria in the quotients -/
 
-lemma HF_mk_eq_zero {p : ℤ} (z : ↥(K.Zinf p)) :
+lemma HF_mk_eq_zero {p : ℤ} (z : ↥(K.abutmentZ p)) :
     (Submodule.Quotient.mk z : K.HF p) = 0 ↔ (z : M) ∈ K.dF p := by
   rw [Submodule.Quotient.mk_eq_zero, Submodule.mem_comap, Submodule.coe_subtype]
 
@@ -159,16 +170,16 @@ theorem range_iMap_eq_ker_jMap (p : ℤ) :
   · rintro _ ⟨w, rfl⟩
     obtain ⟨z, rfl⟩ := Submodule.Quotient.mk_surjective _ w
     rw [LinearMap.mem_ker, iMap_mk, jMap_mk, K.page_one_mk_eq_zero]
-    simp only [ZinfToZone_coe, ZinfIncl_coe]
-    -- `z ∈ Zinf (p+1)`, so `z ∈ F(p+1) ∩ d⁻¹ F(p+1) ⊆ B_1^p`
+    simp only [abutmentZToZOne_coe, abutmentZIncl_coe]
+    -- `z ∈ abutmentZ (p+1)`, so `z ∈ F(p+1) ∩ d⁻¹ F(p+1) ⊆ B_1^p`
     refine K.mem_B_left z.2.1 ?_
     rw [LinearMap.mem_ker.mp z.2.2]; exact zero_mem _
   · intro w hw
     obtain ⟨z, rfl⟩ := Submodule.Quotient.mk_surjective _ w
     rw [LinearMap.mem_ker, jMap_mk, K.page_one_mk_eq_zero] at hw
-    simp only [ZinfToZone_coe] at hw
+    simp only [abutmentZToZOne_coe] at hw
     obtain ⟨u, v, hu1, hu2, hv, hdv, hzeq⟩ := K.B_cases hw
-    -- `z = u + d v`, `d z = 0` forces `d u = 0`, so `u ∈ Zinf (p+1)` and `i[u] = [z]`
+    -- `z = u + d v`, `d z = 0` forces `d u = 0`, so `u ∈ abutmentZ (p+1)` and `i[u] = [z]`
     have hvp : v ∈ K.F p := by rwa [show p - 1 + 1 = p by ring] at hv
     have hdu : K.d u = 0 := by
       have hz0 : K.d (z : M) = 0 := LinearMap.mem_ker.mp z.2.2
@@ -176,7 +187,7 @@ theorem range_iMap_eq_ker_jMap (p : ℤ) :
     refine ⟨Submodule.Quotient.mk ⟨u, Submodule.mem_inf.mpr ⟨hu1, LinearMap.mem_ker.mpr hdu⟩⟩, ?_⟩
     rw [iMap_mk, Submodule.Quotient.eq, K.mem_dF_comap]
     refine ⟨-v, neg_mem hvp, ?_⟩
-    simp only [map_neg, Submodule.coe_sub, ZinfIncl_coe, hzeq]; abel
+    simp only [map_neg, Submodule.coe_sub, abutmentZIncl_coe, hzeq]; abel
 
 /-- Exactness at `E` (`im j = ker k`): `range (jMap p) = ker (kMap p)`. -/
 theorem range_jMap_eq_ker_kMap (p : ℤ) :
@@ -185,22 +196,22 @@ theorem range_jMap_eq_ker_kMap (p : ℤ) :
   · rintro _ ⟨w, rfl⟩
     obtain ⟨z, rfl⟩ := Submodule.Quotient.mk_surjective _ w
     rw [LinearMap.mem_ker, jMap_mk, kMap_mk, K.HF_mk_eq_zero]
-    simp only [ZoneToZinf_coe, ZinfToZone_coe]
+    simp only [zOneToAbutmentZ_coe, abutmentZToZOne_coe]
     -- `k(j[z]) = [d z] = [0]` since `z ∈ ker d`
     rw [LinearMap.mem_ker.mp z.2.2]; exact zero_mem _
   · intro w hw
     obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective _ w
     rw [LinearMap.mem_ker, kMap_mk, K.HF_mk_eq_zero] at hw
-    simp only [ZoneToZinf_coe] at hw
+    simp only [zOneToAbutmentZ_coe] at hw
     rw [dF, Submodule.mem_map] at hw
     obtain ⟨u, hu, hux⟩ := hw
-    -- `d x = d u`, `u ∈ F(p+1)`; then `x - u ∈ Zinf p` and `j[x-u] = [x]`
+    -- `d x = d u`, `u ∈ F(p+1)`; then `x - u ∈ abutmentZ p` and `j[x-u] = [x]`
     have hxu_ker : (x : M) - u ∈ ker K.d := by
       rw [LinearMap.mem_ker, map_sub, hux, sub_self]
     have hxu_F : (x : M) - u ∈ K.F p := sub_mem (K.mem_Z.mp x.2).1 (K.F_le p hu)
     refine ⟨Submodule.Quotient.mk ⟨(x : M) - u, Submodule.mem_inf.mpr ⟨hxu_F, hxu_ker⟩⟩, ?_⟩
     rw [jMap_mk, Submodule.Quotient.eq, Submodule.mem_comap, Submodule.coe_subtype]
-    simp only [Submodule.coe_sub, ZinfToZone_coe]
+    simp only [Submodule.coe_sub, abutmentZToZOne_coe]
     have hval : ((x : M) - u) - (x : M) = -u := by abel
     rw [hval]
     exact neg_mem (K.mem_B_left hu (by rw [hux]; exact (K.mem_Z.mp x.2).2))
@@ -212,13 +223,13 @@ theorem range_kMap_eq_ker_iMap (p : ℤ) :
   · rintro _ ⟨w, rfl⟩
     obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective _ w
     rw [LinearMap.mem_ker, kMap_mk, iMap_mk, K.HF_mk_eq_zero]
-    simp only [ZinfIncl_coe, ZoneToZinf_coe]
+    simp only [abutmentZIncl_coe, zOneToAbutmentZ_coe]
     -- `i(k[x]) = [d x]`, `d x ∈ d(F^p)`
     exact ⟨(x : M), (K.mem_Z.mp x.2).1, rfl⟩
   · intro w hw
     obtain ⟨z, rfl⟩ := Submodule.Quotient.mk_surjective _ w
     rw [LinearMap.mem_ker, iMap_mk, K.HF_mk_eq_zero] at hw
-    simp only [ZinfIncl_coe] at hw
+    simp only [abutmentZIncl_coe] at hw
     rw [dF, Submodule.mem_map] at hw
     obtain ⟨x, hx, hdx⟩ := hw
     -- `z = d x` for `x ∈ F p`; `d x = z ∈ F(p+1)`, so `x ∈ Z_1^p` and `k[x] = [z]`
@@ -226,6 +237,250 @@ theorem range_kMap_eq_ker_iMap (p : ℤ) :
     refine ⟨Submodule.Quotient.mk ⟨x, hxZ⟩, ?_⟩
     rw [kMap_mk, Submodule.Quotient.eq, K.mem_dF_comap]
     refine ⟨0, zero_mem _, ?_⟩
-    simp only [map_zero, Submodule.coe_sub, ZoneToZinf_coe, hdx]; abel
+    simp only [map_zero, Submodule.coe_sub, zOneToAbutmentZ_coe, hdx]; abel
+
+/-! ## Assembly into an exact couple -/
+
+universe u v w x
+
+private lemma exact_lmap
+    {S : Type u} [Ring S] {ι : Type v}
+    {A : ι → Type w} {B : ι → Type x} {C : ι → Type*}
+    [∀ i, AddCommGroup (A i)] [∀ i, Module S (A i)]
+    [∀ i, AddCommGroup (B i)] [∀ i, Module S (B i)]
+    [∀ i, AddCommGroup (C i)] [∀ i, Module S (C i)]
+    (f : ∀ i, A i →ₗ[S] B i) (g : ∀ i, B i →ₗ[S] C i)
+    (h : ∀ i, Function.Exact (f i) (g i)) :
+    Function.Exact (DirectSum.lmap f) (DirectSum.lmap g) := by
+  rw [LinearMap.exact_iff, DirectSum.ker_lmap, DirectSum.range_lmap]
+  ext b
+  simp only [Submodule.mem_comap, Submodule.mem_pi, Set.mem_univ, forall_const]
+  exact forall_congr' fun i => (LinearMap.exact_iff.mp (h i)).symm ▸ Iff.rfl
+
+/-- The filtration predecessor equivalence used to identify
+`⨁ p, H(F^p)` with `⨁ p, H(F^{p+1})`. -/
+def filtrationPredEquiv : ℤ ≃ ℤ where
+  toFun p := p - 1
+  invFun p := p + 1
+  left_inv p := by simp
+  right_inv p := by simp
+
+@[simp] lemma filtrationPredEquiv_symm_apply (p : ℤ) :
+    filtrationPredEquiv.symm p = p + 1 := rfl
+
+/-- The direct sum `D = ⨁ p, H(F^p)`. -/
+abbrev totalHF := ⨁ p : ℤ, K.HF p
+
+/-- The direct sum `E = ⨁ p, E₁^p`. -/
+abbrev totalPageOne := ⨁ p : ℤ, K.page 1 p
+
+/-- The shifted direct sum `⨁ p, H(F^{p+1})`. -/
+abbrev shiftedHF := ⨁ p : ℤ, K.HF (p + 1)
+
+/-- Reindex `⨁ p, H(F^p)` as `⨁ p, H(F^{p+1})`. -/
+noncomputable def shiftHF : K.totalHF ≃ₗ[R] K.shiftedHF :=
+  DirectSum.lequivCongrLeft R filtrationPredEquiv
+
+@[simp] lemma shiftHF_lof_succ (p : ℤ) (z : K.HF (p + 1)) :
+    K.shiftHF (DirectSum.lof R ℤ (fun q => K.HF q) (p + 1) z) =
+      DirectSum.lof R ℤ (fun q => K.HF (q + 1)) p z := by
+  change (DirectSum.lequivCongrLeft R filtrationPredEquiv)
+    (DirectSum.lof R ℤ (fun q => K.HF q) (p + 1) z) =
+      DirectSum.lof R ℤ (fun q => K.HF (q + 1)) p z
+  ext q
+  rw [DirectSum.lequivCongrLeft_apply]
+  simp only [filtrationPredEquiv_symm_apply]
+  by_cases h : p = q
+  · subst q
+    trans z
+    · exact DirectSum.lof_apply (M := fun q => K.HF q) R (p + 1) z
+    · exact (DirectSum.lof_apply (M := fun q => K.HF (q + 1)) R p z).symm
+  · have h' : p + 1 ≠ q + 1 := by omega
+    change DirectSum.component R ℤ (fun q => K.HF q) (q + 1)
+        (DirectSum.lof R ℤ (fun q => K.HF q) (p + 1) z) =
+      DirectSum.component R ℤ (fun q => K.HF (q + 1)) q
+        (DirectSum.lof R ℤ (fun q => K.HF (q + 1)) p z)
+    rw [DirectSum.component.of, DirectSum.component.of, dif_neg h', dif_neg h]
+
+@[simp] lemma shiftHF_symm_lof (p : ℤ) (z : K.HF (p + 1)) :
+    K.shiftHF.symm (DirectSum.lof R ℤ (fun q => K.HF (q + 1)) p z) =
+      DirectSum.lof R ℤ (fun q => K.HF q) (p + 1) z :=
+  K.shiftHF.symm_apply_eq.mpr (K.shiftHF_lof_succ p z).symm
+
+/-- The direct sum of the inclusion maps `iMap`. -/
+noncomputable def totalI : K.totalHF →ₗ[R] K.totalHF :=
+  (DirectSum.lmap fun p => K.iMap p).comp K.shiftHF.toLinearMap
+
+/-- The direct sum of the quotient maps `jMap`. -/
+noncomputable def totalJ : K.totalHF →ₗ[R] K.totalPageOne :=
+  DirectSum.lmap fun p => K.jMap p
+
+/-- The direct sum of the connecting maps `kMap`. -/
+noncomputable def totalK : K.totalPageOne →ₗ[R] K.totalHF :=
+  K.shiftHF.symm.toLinearMap.comp (DirectSum.lmap fun p => K.kMap p)
+
+@[simp] lemma totalI_lof_succ (p : ℤ) (z : K.HF (p + 1)) :
+    K.totalI (DirectSum.lof R ℤ (fun q => K.HF q) (p + 1) z) =
+      DirectSum.lof R ℤ (fun q => K.HF q) p (K.iMap p z) := by
+  simp [totalI]
+
+@[simp] lemma totalJ_lof (p : ℤ) (z : K.HF p) :
+    K.totalJ (DirectSum.lof R ℤ (fun q => K.HF q) p z) =
+      DirectSum.lof R ℤ (fun q => K.page 1 q) p (K.jMap p z) := by
+  simp [totalJ]
+
+@[simp] lemma totalK_lof (p : ℤ) (z : K.page 1 p) :
+    K.totalK (DirectSum.lof R ℤ (fun q => K.page 1 q) p z) =
+      DirectSum.lof R ℤ (fun q => K.HF q) (p + 1) (K.kMap p z) := by
+  simp [totalK]
+
+lemma exact_totalI_totalJ : Function.Exact K.totalI K.totalJ := by
+  apply LinearEquiv.precomp_exact_iff_exact.mpr
+  apply exact_lmap
+  intro p
+  rw [LinearMap.exact_iff]
+  exact (K.range_iMap_eq_ker_jMap p).symm
+
+lemma exact_totalJ_totalK : Function.Exact K.totalJ K.totalK := by
+  apply LinearEquiv.postcomp_exact_iff_exact.mpr
+  apply exact_lmap
+  intro p
+  rw [LinearMap.exact_iff]
+  exact (K.range_jMap_eq_ker_kMap p).symm
+
+lemma exact_totalK_totalI : Function.Exact K.totalK K.totalI := by
+  apply (LinearEquiv.conj_symm_exact_iff_exact
+    (DirectSum.lmap fun p => K.kMap p)
+    (DirectSum.lmap fun p => K.iMap p) K.shiftHF).mpr
+  apply exact_lmap
+  intro p
+  rw [LinearMap.exact_iff]
+  exact (K.range_kMap_eq_ker_iMap p).symm
+
+/-- The exact couple of a filtered differential module, assembled on direct sums
+over the filtration degree. -/
+@[reducible] noncomputable def exactCouple : ExactCouple R where
+  D := K.totalHF
+  E := K.totalPageOne
+  i := K.totalI
+  j := K.totalJ
+  k := K.totalK
+  exact_ij := K.exact_totalI_totalJ
+  exact_jk := K.exact_totalJ_totalK
+  exact_ki := K.exact_totalK_totalI
+
+/-! ## The internal gradings -/
+
+/-- The canonical degree-`p` submodule of a direct sum. -/
+def _root_.DirectSum.canonicalGrading {ι : Type*} [DecidableEq ι] {A : ι → Type*}
+    [∀ p, AddCommGroup (A p)] [∀ p, Module R (A p)] (p : ι) :
+    Submodule R (⨁ q, A q) :=
+  LinearMap.range (DirectSum.lof R ι A p)
+
+/-- The inclusion of one summand, corestricted to its canonical graded submodule. -/
+def _root_.DirectSum.canonicalGradingComponent
+    {ι : Type*} [DecidableEq ι] {A : ι → Type*}
+    [∀ p, AddCommGroup (A p)] [∀ p, Module R (A p)] (p : ι) :
+    A p →ₗ[R] DirectSum.canonicalGrading (R := R) (A := A) p :=
+  (DirectSum.lof R ι A p).codRestrict _ fun z => ⟨z, rfl⟩
+
+/-- Decompose a direct sum into its canonical graded submodules. -/
+noncomputable def _root_.DirectSum.canonicalGradingDecompose
+    {ι : Type*} [DecidableEq ι] {A : ι → Type*}
+    [∀ p, AddCommGroup (A p)] [∀ p, Module R (A p)] :
+    (⨁ q, A q) →ₗ[R] ⨁ p, DirectSum.canonicalGrading (R := R) (A := A) p :=
+  DirectSum.lmap fun p => DirectSum.canonicalGradingComponent (R := R) (A := A) p
+
+/-- The canonical internal decomposition of a direct sum by its summands. -/
+@[implicit_reducible] noncomputable def _root_.DirectSum.canonicalGradingDecomposition
+    {ι : Type*} [DecidableEq ι] {A : ι → Type*}
+    [∀ p, AddCommGroup (A p)] [∀ p, Module R (A p)] :
+    DirectSum.Decomposition (DirectSum.canonicalGrading (R := R) (A := A)) :=
+  DirectSum.Decomposition.ofLinearMap _
+      (DirectSum.canonicalGradingDecompose (R := R) (A := A)) (by
+    apply DirectSum.linearMap_ext
+    intro p
+    apply LinearMap.ext
+    intro z
+    simp only [LinearMap.comp_apply, DirectSum.canonicalGradingDecompose,
+      DirectSum.lmap_lof, DirectSum.coeLinearMap_lof,
+      DirectSum.canonicalGradingComponent, LinearMap.id_apply]
+    rfl) (by
+    apply DirectSum.linearMap_ext
+    intro p
+    apply LinearMap.ext
+    intro z
+    simp only [LinearMap.comp_apply, DirectSum.coeLinearMap_lof, LinearMap.id_apply]
+    obtain ⟨y, hy⟩ := z.property
+    rw [← hy]
+    simp only [DirectSum.canonicalGradingDecompose, DirectSum.lmap_lof]
+    congr 2
+    apply Subtype.ext
+    exact hy)
+
+theorem _root_.DirectSum.isInternal_canonicalGrading
+    {ι : Type*} [DecidableEq ι] {A : ι → Type*}
+    [∀ p, AddCommGroup (A p)] [∀ p, Module R (A p)] :
+    DirectSum.IsInternal (DirectSum.canonicalGrading (R := R) (A := A)) := by
+  letI := DirectSum.canonicalGradingDecomposition (R := R) (A := A)
+  exact DirectSum.Decomposition.isInternal _
+
+/-- The filtration-degree grading of `⨁ p, H(F^p)`. -/
+def totalHFGrading (p : ℤ) : Submodule R K.totalHF :=
+  DirectSum.canonicalGrading (R := R) (A := fun q => K.HF q) p
+
+/-- The filtration-degree grading of `⨁ p, E₁^p`. -/
+def totalPageOneGrading (p : ℤ) : Submodule R K.totalPageOne :=
+  DirectSum.canonicalGrading (R := R) (A := fun q => K.page 1 q) p
+
+lemma totalHFGrading_isInternal : DirectSum.IsInternal K.totalHFGrading :=
+  DirectSum.isInternal_canonicalGrading (R := R) (A := fun q => K.HF q)
+
+lemma totalPageOneGrading_isInternal : DirectSum.IsInternal K.totalPageOneGrading :=
+  DirectSum.isInternal_canonicalGrading (R := R) (A := fun q => K.page 1 q)
+
+/-- The graded exact couple associated to a filtered differential module.
+The maps `i`, `j`, and `k` have filtration degrees `-1`, `0`, and `1`. -/
+noncomputable def gradedExactCouple : GradedExactCouple R ℤ where
+  toExactCouple := K.exactCouple
+  di := -1
+  dj := 0
+  dk := 1
+  gradD := K.totalHFGrading
+  gradE := K.totalPageOneGrading
+  internalD := K.totalHFGrading_isInternal
+  internalE := K.totalPageOneGrading_isInternal
+  homog_i := by
+    intro p
+    rw [show p = (p - 1) + 1 by omega]
+    change (DirectSum.canonicalGrading (R := R) (A := fun q => K.HF q) ((p - 1) + 1)).map
+        K.totalI ≤
+      DirectSum.canonicalGrading (R := R) (A := fun q => K.HF q) (((p - 1) + 1) + (-1))
+    rintro _ ⟨z, ⟨y, rfl⟩, rfl⟩
+    change K.totalI (DirectSum.lof R ℤ (fun q => K.HF q) ((p - 1) + 1) y) ∈
+      DirectSum.canonicalGrading (R := R) (A := fun q => K.HF q) (((p - 1) + 1) + (-1))
+    rw [K.totalI_lof_succ]
+    rw [show (p - 1) + 1 + (-1) = p - 1 by omega]
+    exact ⟨_, rfl⟩
+  homog_j := by
+    intro p
+    change (DirectSum.canonicalGrading (R := R) (A := fun q => K.HF q) p).map K.totalJ ≤
+      DirectSum.canonicalGrading (R := R) (A := fun q => K.page 1 q) (p + 0)
+    rintro _ ⟨z, ⟨y, rfl⟩, rfl⟩
+    change K.totalJ (DirectSum.lof R ℤ (fun q => K.HF q) p y) ∈
+      DirectSum.canonicalGrading (R := R) (A := fun q => K.page 1 q) (p + 0)
+    rw [K.totalJ_lof]
+    simpa using (show
+      DirectSum.lof R ℤ (fun q => K.page 1 q) p (K.jMap p y) ∈
+        DirectSum.canonicalGrading (R := R) (A := fun q => K.page 1 q) p from ⟨_, rfl⟩)
+  homog_k := by
+    intro p
+    change (DirectSum.canonicalGrading (R := R) (A := fun q => K.page 1 q) p).map K.totalK ≤
+      DirectSum.canonicalGrading (R := R) (A := fun q => K.HF q) (p + 1)
+    rintro _ ⟨z, ⟨y, rfl⟩, rfl⟩
+    change K.totalK (DirectSum.lof R ℤ (fun q => K.page 1 q) p y) ∈
+      DirectSum.canonicalGrading (R := R) (A := fun q => K.HF q) (p + 1)
+    rw [K.totalK_lof]
+    exact ⟨_, rfl⟩
 
 end FilteredDifferentialModule

--- a/FLT/Slop/SpectralSequence/ExactCoupleBridge.lean
+++ b/FLT/Slop/SpectralSequence/ExactCoupleBridge.lean
@@ -27,7 +27,11 @@ and assembles them into a `GradedExactCouple` on the direct sums
 
 @[expose] public section
 
-open scoped DirectSum
+namespace Slop
+
+-- `_root_` is needed: this file's imports already populate the `Slop.DirectSum`
+-- namespace, which would otherwise shadow mathlib's `DirectSum` here.
+open scoped _root_.DirectSum
 open Submodule LinearMap
 
 namespace FilteredDifferentialModule
@@ -372,27 +376,27 @@ over the filtration degree. -/
 /-! ## The internal gradings -/
 
 /-- The canonical degree-`p` submodule of a direct sum. -/
-def _root_.DirectSum.canonicalGrading {ι : Type*} [DecidableEq ι] {A : ι → Type*}
+def _root_.Slop.DirectSum.canonicalGrading {ι : Type*} [DecidableEq ι] {A : ι → Type*}
     [∀ p, AddCommGroup (A p)] [∀ p, Module R (A p)] (p : ι) :
     Submodule R (⨁ q, A q) :=
   LinearMap.range (DirectSum.lof R ι A p)
 
 /-- The inclusion of one summand, corestricted to its canonical graded submodule. -/
-def _root_.DirectSum.canonicalGradingComponent
+def _root_.Slop.DirectSum.canonicalGradingComponent
     {ι : Type*} [DecidableEq ι] {A : ι → Type*}
     [∀ p, AddCommGroup (A p)] [∀ p, Module R (A p)] (p : ι) :
     A p →ₗ[R] DirectSum.canonicalGrading (R := R) (A := A) p :=
   (DirectSum.lof R ι A p).codRestrict _ fun z => ⟨z, rfl⟩
 
 /-- Decompose a direct sum into its canonical graded submodules. -/
-noncomputable def _root_.DirectSum.canonicalGradingDecompose
+noncomputable def _root_.Slop.DirectSum.canonicalGradingDecompose
     {ι : Type*} [DecidableEq ι] {A : ι → Type*}
     [∀ p, AddCommGroup (A p)] [∀ p, Module R (A p)] :
     (⨁ q, A q) →ₗ[R] ⨁ p, DirectSum.canonicalGrading (R := R) (A := A) p :=
   DirectSum.lmap fun p => DirectSum.canonicalGradingComponent (R := R) (A := A) p
 
 /-- The canonical internal decomposition of a direct sum by its summands. -/
-@[implicit_reducible] noncomputable def _root_.DirectSum.canonicalGradingDecomposition
+@[implicit_reducible] noncomputable def _root_.Slop.DirectSum.canonicalGradingDecomposition
     {ι : Type*} [DecidableEq ι] {A : ι → Type*}
     [∀ p, AddCommGroup (A p)] [∀ p, Module R (A p)] :
     DirectSum.Decomposition (DirectSum.canonicalGrading (R := R) (A := A)) :=
@@ -418,7 +422,7 @@ noncomputable def _root_.DirectSum.canonicalGradingDecompose
     apply Subtype.ext
     exact hy)
 
-theorem _root_.DirectSum.isInternal_canonicalGrading
+theorem _root_.Slop.DirectSum.isInternal_canonicalGrading
     {ι : Type*} [DecidableEq ι] {A : ι → Type*}
     [∀ p, AddCommGroup (A p)] [∀ p, Module R (A p)] :
     DirectSum.IsInternal (DirectSum.canonicalGrading (R := R) (A := A)) := by
@@ -484,3 +488,5 @@ noncomputable def gradedExactCouple : GradedExactCouple R ℤ where
     exact ⟨_, rfl⟩
 
 end FilteredDifferentialModule
+
+end Slop

--- a/FLT/Slop/SpectralSequence/FilteredComplex.lean
+++ b/FLT/Slop/SpectralSequence/FilteredComplex.lean
@@ -60,6 +60,8 @@ ambient module never changes.
 
 @[expose] public section
 
+namespace Slop
+
 open CategoryTheory Submodule LinearMap
 
 namespace FilteredComplex
@@ -1113,3 +1115,5 @@ theorem Hom.mapPage_dPageAux (f : K ⟶ K') (r p q n m : ℤ)
 end Functoriality
 
 end FilteredComplex
+
+end Slop

--- a/FLT/Slop/SpectralSequence/FilteredComplex.lean
+++ b/FLT/Slop/SpectralSequence/FilteredComplex.lean
@@ -847,8 +847,7 @@ lemma toFH_surjective (p n : ℤ) : Function.Surjective (K.toFH p n) := by
 
 /-- The associated graded piece `gr^p H^n = F^p H^n / F^{p+1} H^n` of the cohomology.
 This is the object the spectral sequence abuts to: the convergence theorems below
-identify `E_r^{p,n}` with `K.grH p n`.  (Mirrors `GradedAbelian.grH` on the abelian
-side.) -/
+identify `E_r^{p,n}` with `K.grH p n`. -/
 abbrev grH (p n : ℤ) : Type _ :=
   ↥(K.FH p n) ⧸ (K.FH (p + 1) n).comap (K.FH p n).subtype
 

--- a/FLT/Slop/SpectralSequence/FilteredComplex.lean
+++ b/FLT/Slop/SpectralSequence/FilteredComplex.lean
@@ -1,0 +1,726 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import Mathlib.LinearAlgebra.Isomorphisms
+public import Mathlib.Tactic.Abel
+public import Mathlib.Tactic.Ring
+
+/-!
+# The graded spectral sequence of a filtered cochain complex
+
+`FLT.Slop.SpectralSequence.FilteredModule` constructs the spectral sequence of a filtered
+differential *module*, which is the total, ungraded object.  This file refines the
+construction for a filtered cochain **complex** `(X n, d, F)`: the pages are now
+graded, `E_r^{p, n}` sitting at filtration degree `p` and total degree `n`
+(classically one writes `E_r^{p,q}` with `q = n - p`; see `pageBigraded`), and the
+differential has bidegree `(r, 1)` in `(p, n)` — that is, `(r, 1-r)` in `(p, q)`.
+
+The grading is what makes convergence usable in practice: for a first-quadrant-type
+complex the filtration is bounded *at each degree `n`* but unbounded globally, so
+the ungraded convergence theorems do not apply, while the graded ones
+(`pageEquivGrHOfBounded` below) do — with bounds depending on the spot `(p, n)`.
+This is exactly what the spectral sequences of a double complex require.
+
+## Design
+
+A complex is stored with an "all-pairs" differential `d : ∀ i j, X i →ₗ[R] X j`
+(only the consecutive components are ever used; `d² = 0` and filtration
+compatibility are hypotheses about consecutive indices, stated with flexible
+index equalities discharged by `omega`/`ring`).  This avoids all dependent-type
+transport along equalities like `(n - 1) + 1 = n`: the cocycles and boundaries
+
+* `Z r p n m = F^p_n ⊓ (d n m)⁻¹(F^{p+r}_m)`   (intended `m = n + 1`),
+* `B r p l n m = (F^{p+1}_n ⊓ (d n m)⁻¹(F^{p+r}_m)) + d l n (F^{p-r+1}_l ⊓ (d l n)⁻¹(F^p_n))`
+  (intended `l = n - 1`, `m = n + 1`)
+
+are `Submodule R (X n)`-valued functions of the auxiliary indices `l, m`, so
+mismatches like `(n+1) - 1` vs `n` are repaired by rewriting the index — the
+ambient module never changes.
+
+## Main results
+
+* `page r p n` (`= E_r^{p,n}`), `dPageAux` and `dPageAux_comp` (`d_r² = 0`);
+* `pageSuccEquiv` : `E_{r+1}^{p,n} ≅ ker(d_r)/im(d_r)` — the main theorem;
+* `pageEquivGrHOfBounded` : **graded convergence** — if `F^{p+r}_{n+1} = ⊥` and
+  `F^{p-r+1}_{n-1} = ⊤` (one spot at a time!), then `E_r^{p,n} ≅ gr^p H^n`, the
+  associated graded of the cohomology of the complex at degree `n`.
+-/
+
+@[expose] public section
+
+open Submodule LinearMap
+
+section HomologyEquiv
+
+variable {R M M' Nout Nout' Nin Nin' : Type*} [Ring R]
+  [AddCommGroup M] [Module R M] [AddCommGroup M'] [Module R M']
+  [AddCommGroup Nout] [Module R Nout] [AddCommGroup Nout'] [Module R Nout']
+  [AddCommGroup Nin] [Module R Nin] [AddCommGroup Nin'] [Module R Nin']
+
+/-- **Transport of a homology object along a linear isomorphism.**  Suppose
+`e : M ≃ M'` fits into a commuting square with the outgoing differentials —
+`eout (fout x) = gout (e x)` for an iso `eout`— and carries `range fin` onto
+`range gin`.  Then the two homologies `ker fout / im fin` and `ker gout / im gin`
+are isomorphic.  This packages a differential-level identification (a commuting
+square) into a homology-level one. -/
+noncomputable def homologyEquivOfSquares
+    (e : M ≃ₗ[R] M')
+    (fout : M →ₗ[R] Nout) (gout : M' →ₗ[R] Nout')
+    (eout : Nout ≃ₗ[R] Nout')
+    (hout : ∀ x, eout (fout x) = gout (e x))
+    (fin_ : Nin →ₗ[R] M) (gin : Nin' →ₗ[R] M')
+    (hin : (range fin_).map (e : M →ₗ[R] M') = range gin) :
+    (↥(ker fout) ⧸ (range fin_).comap (ker fout).subtype) ≃ₗ[R]
+      (↥(ker gout) ⧸ (range gin).comap (ker gout).subtype) := by
+  have hker : (ker fout).map (e : M →ₗ[R] M') = ker gout := by
+    ext y
+    simp only [Submodule.mem_map, LinearMap.mem_ker]
+    constructor
+    · rintro ⟨x, hx, rfl⟩
+      have h := hout x
+      rw [hx, map_zero] at h
+      exact h.symm
+    · intro hy
+      refine ⟨e.symm y, ?_, e.apply_symm_apply y⟩
+      apply eout.injective
+      rw [hout, e.apply_symm_apply, hy, map_zero]
+  refine Submodule.Quotient.equiv _ _
+    ((e.submoduleMap (ker fout)).trans (LinearEquiv.ofEq _ _ hker)) ?_
+  have hEcoe : ∀ z : ↥(ker fout),
+      (((e.submoduleMap (ker fout)).trans (LinearEquiv.ofEq _ _ hker) z :
+          ↥(ker gout)) : M') = e (z : M) := by
+    intro z
+    rw [LinearEquiv.trans_apply, LinearEquiv.coe_ofEq_apply, LinearEquiv.submoduleMap_apply]
+  ext w
+  obtain ⟨y, hyk⟩ := w
+  simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype,
+    LinearEquiv.coe_coe]
+  constructor
+  · rintro ⟨z, hz1, hz2⟩
+    have hz3 : e (z : M) = y := by rw [← hEcoe z, hz2]
+    rw [← hz3, ← hin]
+    exact ⟨(z : M), hz1, rfl⟩
+  · intro hy
+    rw [← hin] at hy
+    obtain ⟨x, hxr, hxy⟩ := hy
+    rw [LinearEquiv.coe_coe] at hxy
+    have hxk : x ∈ ker fout := by
+      rw [LinearMap.mem_ker]
+      apply eout.injective
+      rw [map_zero, hout, hxy]
+      exact LinearMap.mem_ker.mp hyk
+    refine ⟨⟨x, hxk⟩, hxr, ?_⟩
+    apply Subtype.ext
+    rw [hEcoe]
+    exact hxy
+
+end HomologyEquiv
+
+/-- A **filtered cochain complex** of modules: a `ℤ`-indexed family with an
+all-pairs differential (only consecutive components matter), squaring to zero,
+and a decreasing filtration compatible with the differential. -/
+structure FilteredComplex (R : Type*) [Ring R] where
+  /-- The modules of the complex. -/
+  X : ℤ → Type*
+  [addCommGroup : ∀ n, AddCommGroup (X n)]
+  [module : ∀ n, Module R (X n)]
+  /-- The differential; only the components `d n (n+1)` are meaningful. -/
+  d : ∀ i j : ℤ, X i →ₗ[R] X j
+  /-- The differential squares to zero (on consecutive components). -/
+  d_comp_d : ∀ (i j k : ℤ), j = i + 1 → k = j + 1 → ∀ x : X i, d j k (d i j x) = 0
+  /-- The filtration. -/
+  F : ℤ → ∀ n : ℤ, Submodule R (X n)
+  /-- The filtration is decreasing. -/
+  F_le : ∀ (p n : ℤ), F (p + 1) n ≤ F p n
+  /-- The differential preserves the filtration. -/
+  d_mem_F : ∀ (p i j : ℤ), j = i + 1 → ∀ x ∈ F p i, d i j x ∈ F p j
+
+attribute [instance] FilteredComplex.addCommGroup FilteredComplex.module
+
+namespace FilteredComplex
+
+variable {R : Type*} [Ring R] (K : FilteredComplex R)
+
+lemma F_mono {p q : ℤ} (h : p ≤ q) (n : ℤ) : K.F q n ≤ K.F p n := by
+  obtain ⟨k, rfl⟩ := Int.le.dest h
+  clear h
+  induction k with
+  | zero => simp
+  | succ m ih =>
+    refine le_trans ?_ ih
+    have e : (p + (m + 1 : ℕ) : ℤ) = (p + m) + 1 := by push_cast; ring
+    rw [e]
+    exact K.F_le (p + m) n
+
+/-! ## Cocycles, boundaries, and the graded pages -/
+
+/-- The graded cocycles `Z_r^{p,n} = F^p_n ∩ d⁻¹(F^{p+r}_{n+1})`; the auxiliary
+index `m` is intended to be `n + 1`. -/
+def Z (r p n m : ℤ) : Submodule R (K.X n) :=
+  K.F p n ⊓ (K.F (p + r) m).comap (K.d n m)
+
+lemma mem_Z {r p n m : ℤ} {x : K.X n} :
+    x ∈ K.Z r p n m ↔ x ∈ K.F p n ∧ K.d n m x ∈ K.F (p + r) m := by
+  simp only [Z, Submodule.mem_inf, Submodule.mem_comap]
+
+/-- The graded boundaries
+`B_r^{p,n} = (F^{p+1}_n ∩ d⁻¹F^{p+r}_{n+1}) + d(F^{p-r+1}_{n-1} ∩ d⁻¹F^p_n)`;
+the auxiliary indices `l, m` are intended to be `n - 1, n + 1`. -/
+def B (r p l n m : ℤ) : Submodule R (K.X n) :=
+  (K.F (p + 1) n ⊓ (K.F (p + r) m).comap (K.d n m)) ⊔
+    ((K.F (p - r + 1) l ⊓ (K.F p n).comap (K.d l n)).map (K.d l n))
+
+lemma mem_B_left {r p l n m : ℤ} {u : K.X n} (h1 : u ∈ K.F (p + 1) n)
+    (h2 : K.d n m u ∈ K.F (p + r) m) : u ∈ K.B r p l n m :=
+  Submodule.mem_sup_left (Submodule.mem_inf.mpr ⟨h1, Submodule.mem_comap.mpr h2⟩)
+
+lemma mem_B_right {r p l n m : ℤ} {v : K.X l} (hv : v ∈ K.F (p - r + 1) l)
+    (hdv : K.d l n v ∈ K.F p n) : K.d l n v ∈ K.B r p l n m :=
+  Submodule.mem_sup_right (Submodule.mem_map_of_mem
+    (Submodule.mem_inf.mpr ⟨hv, Submodule.mem_comap.mpr hdv⟩))
+
+lemma B_cases {r p l n m : ℤ} {x : K.X n} (hx : x ∈ K.B r p l n m) :
+    ∃ (u : K.X n) (v : K.X l), u ∈ K.F (p + 1) n ∧ K.d n m u ∈ K.F (p + r) m ∧
+      v ∈ K.F (p - r + 1) l ∧ K.d l n v ∈ K.F p n ∧ x = u + K.d l n v := by
+  obtain ⟨u, hu, w, hw, rfl⟩ := Submodule.mem_sup.mp hx
+  obtain ⟨hu1, hu2⟩ := Submodule.mem_inf.mp hu
+  obtain ⟨v, hv, rfl⟩ := Submodule.mem_map.mp hw
+  obtain ⟨hv1, hv2⟩ := Submodule.mem_inf.mp hv
+  exact ⟨u, v, hu1, Submodule.mem_comap.mp hu2, hv1, Submodule.mem_comap.mp hv2, rfl⟩
+
+lemma B_le_Z {r p l n m : ℤ} (hl : n = l + 1) (hm : m = n + 1) :
+    K.B r p l n m ≤ K.Z r p n m := by
+  intro x hx
+  obtain ⟨u, v, hu1, hu2, hv, hdv, rfl⟩ := K.B_cases hx
+  refine add_mem (K.mem_Z.mpr ⟨K.F_le p n hu1, hu2⟩) (K.mem_Z.mpr ⟨hdv, ?_⟩)
+  rw [K.d_comp_d l n m hl hm v]
+  exact zero_mem _
+
+lemma Z_succ_le (r p n m : ℤ) : K.Z (r + 1) p n m ≤ K.Z r p n m := by
+  intro x hx
+  obtain ⟨h1, h2⟩ := K.mem_Z.mp hx
+  exact K.mem_Z.mpr ⟨h1, K.F_le (p + r) m (by rwa [show p + r + 1 = p + (r + 1) by ring])⟩
+
+/-- The graded page `E_r^{p,n} = Z_r^{p,n} / B_r^{p,n}`. -/
+abbrev page (r p n : ℤ) :=
+  ↥(K.Z r p n (n + 1)) ⧸ (K.B r p (n - 1) n (n + 1)).comap (K.Z r p n (n + 1)).subtype
+
+/-- The classical bigraded page `E_r^{p,q}` with `q` the complementary degree:
+`E_r^{p,q} = E_r^{p, p+q}`. -/
+abbrev pageBigraded (r p q : ℤ) := K.page r p (p + q)
+
+/-! ## The differentials -/
+
+lemma d_mem_Z {r p n : ℤ} {x : K.X n} (hx : x ∈ K.Z r p n (n + 1)) :
+    K.d n (n + 1) x ∈ K.Z r (p + r) (n + 1) (n + 1 + 1) := by
+  obtain ⟨h1, h2⟩ := K.mem_Z.mp hx
+  refine K.mem_Z.mpr ⟨h2, ?_⟩
+  rw [K.d_comp_d n (n + 1) (n + 1 + 1) rfl rfl x]
+  exact zero_mem _
+
+lemma d_mem_B {r p n : ℤ} {x : K.X n} (hx : x ∈ K.B r p (n - 1) n (n + 1)) :
+    K.d n (n + 1) x ∈ K.B r (p + r) n (n + 1) (n + 1 + 1) := by
+  obtain ⟨u, v, hu1, hu2, hv, hdv, rfl⟩ := K.B_cases hx
+  rw [map_add]
+  refine add_mem ?_ ?_
+  · refine K.mem_B_right ?_ hu2
+    rwa [show p + r - r + 1 = p + 1 by ring]
+  · rw [K.d_comp_d (n - 1) n (n + 1) (by ring) rfl v]
+    exact zero_mem _
+
+/-- The differential restricted to the cocycles, with flexible indices
+(`q = p + r`, `m = n + 1`). -/
+def dZ (r p q n m : ℤ) (hq : q = p + r) (hm : m = n + 1) :
+    ↥(K.Z r p n (n + 1)) →ₗ[R] ↥(K.Z r q m (m + 1)) :=
+  (K.d n m).restrict fun x hx ↦ by subst hq hm; exact K.d_mem_Z hx
+
+@[simp] lemma dZ_coe (r p q n m : ℤ) (hq : q = p + r) (hm : m = n + 1)
+    (x : ↥(K.Z r p n (n + 1))) :
+    (K.dZ r p q n m hq hm x : K.X m) = K.d n m x := rfl
+
+/-- The differential `d_r : E_r^{p,n} ⟶ E_r^{p+r, n+1}`, with flexible indices. -/
+def dPageAux (r p q n m : ℤ) (hq : q = p + r) (hm : m = n + 1) :
+    K.page r p n →ₗ[R] K.page r q m :=
+  Submodule.mapQ _ _ (K.dZ r p q n m hq hm) (by
+    intro x hx
+    simp only [Submodule.mem_comap, Submodule.coe_subtype, dZ_coe] at hx ⊢
+    subst hq hm
+    have h := K.d_mem_B hx
+    rw [show n + 1 - 1 = n by ring]
+    exact h)
+
+@[simp] lemma dPageAux_mk (r p q n m : ℤ) (hq : q = p + r) (hm : m = n + 1)
+    (x : ↥(K.Z r p n (n + 1))) :
+    K.dPageAux r p q n m hq hm (Submodule.Quotient.mk x)
+      = Submodule.Quotient.mk (K.dZ r p q n m hq hm x) :=
+  Submodule.mapQ_apply _ _ _ x
+
+lemma dZ_comp_dZ (r p q s n m t : ℤ) (hq : q = p + r) (hs : s = q + r)
+    (hm : m = n + 1) (ht : t = m + 1) :
+    (K.dZ r q s m t hs ht).comp (K.dZ r p q n m hq hm) = 0 := by
+  ext x
+  simp only [LinearMap.comp_apply, dZ_coe, LinearMap.zero_apply, ZeroMemClass.coe_zero]
+  subst hm ht
+  exact K.d_comp_d n (n + 1) (n + 1 + 1) rfl rfl x
+
+/-- The composite of two consecutive graded page differentials vanishes. -/
+theorem dPageAux_comp (r p q s n m t : ℤ) (hq : q = p + r) (hs : s = q + r)
+    (hm : m = n + 1) (ht : t = m + 1) :
+    (K.dPageAux r q s m t hs ht).comp (K.dPageAux r p q n m hq hm) = 0 := by
+  apply Submodule.linearMap_qext
+  ext ζ
+  have h0 : K.dZ r q s m t hs ht (K.dZ r p q n m hq hm ζ) = 0 := by
+    have := K.dZ_comp_dZ r p q s n m t hq hs hm ht
+    exact congrFun (congrArg (fun f ↦ f.toFun) this) ζ
+  simp [h0]
+
+/-- Two elements of the cocycles agree in the page iff their difference lies in
+the boundaries. -/
+lemma pageπ_eq_iff {r p n : ℤ} (a b : ↥(K.Z r p n (n + 1))) :
+    (Submodule.Quotient.mk a : K.page r p n) = Submodule.Quotient.mk b ↔
+      ((a : K.X n) - b) ∈ K.B r p (n - 1) n (n + 1) := by
+  rw [Submodule.Quotient.eq]
+  simp [Submodule.mem_comap]
+
+/-! ## The main theorem: each page is the homology of the previous one -/
+
+section MainTheorem
+
+variable (r p n : ℤ)
+
+/-- The differential `d_r : E_r^{p,n} ⟶ E_r^{p+r, n+1}`. -/
+abbrev dPage : K.page r p n →ₗ[R] K.page r (p + r) (n + 1) :=
+  K.dPageAux r p (p + r) n (n + 1) rfl rfl
+
+/-- The differential `d_r : E_r^{p-r, n-1} ⟶ E_r^{p,n}` arriving at `(p, n)`. -/
+abbrev dPageFrom : K.page r (p - r) (n - 1) →ₗ[R] K.page r p n :=
+  K.dPageAux r (p - r) p (n - 1) n (by ring) (by ring)
+
+/-- The natural map `Z_{r+1}^{p,n} ⟶ ker(d_r)`. -/
+def toKer : ↥(K.Z (r + 1) p n (n + 1)) →ₗ[R] ↥(ker (K.dPage r p n)) :=
+  LinearMap.codRestrict _
+    (((K.B r p (n - 1) n (n + 1)).comap (K.Z r p n (n + 1)).subtype).mkQ.comp
+      (Submodule.inclusion (K.Z_succ_le r p n (n + 1))))
+    fun z ↦ by
+      rw [LinearMap.mem_ker, LinearMap.comp_apply, Submodule.mkQ_apply, K.dPageAux_mk,
+        Submodule.Quotient.mk_eq_zero]
+      simp only [Submodule.mem_comap, Submodule.coe_subtype, dZ_coe, Submodule.coe_inclusion]
+      rw [show n + 1 - 1 = n by ring]
+      have hz := K.mem_Z.mp z.2
+      refine K.mem_B_left ?_ ?_
+      · rw [show p + r + 1 = p + (r + 1) by ring]
+        exact hz.2
+      · rw [K.d_comp_d n (n + 1) (n + 1 + 1) rfl rfl]
+        exact zero_mem _
+
+@[simp] lemma toKer_coe (z : ↥(K.Z (r + 1) p n (n + 1))) :
+    (K.toKer r p n z : K.page r p n) =
+      Submodule.Quotient.mk (Submodule.inclusion (K.Z_succ_le r p n (n + 1)) z) := rfl
+
+lemma toKer_surjective : Function.Surjective (K.toKer r p n) := by
+  rintro ⟨c, hc⟩
+  obtain ⟨⟨z, hzZ⟩, rfl⟩ := Submodule.Quotient.mk_surjective _ c
+  rw [LinearMap.mem_ker, K.dPageAux_mk, Submodule.Quotient.mk_eq_zero] at hc
+  simp only [Submodule.mem_comap, Submodule.coe_subtype, dZ_coe] at hc
+  rw [show n + 1 - 1 = n by ring] at hc
+  obtain ⟨u, v, hu1, hu2, hv, hdv, hsum⟩ := K.B_cases hc
+  rw [show p + r - r + 1 = p + 1 by ring] at hv
+  have hzF : z ∈ K.F p n := (K.mem_Z.mp hzZ).1
+  have hz' : z - v ∈ K.Z (r + 1) p n (n + 1) := by
+    refine K.mem_Z.mpr ⟨sub_mem hzF (K.F_le p n hv), ?_⟩
+    have hdz' : K.d n (n + 1) (z - v) = u := by
+      rw [map_sub, hsum]
+      abel
+    rw [hdz', show p + (r + 1) = p + r + 1 by ring]
+    exact hu1
+  refine ⟨⟨z - v, hz'⟩, ?_⟩
+  apply Subtype.ext
+  rw [toKer_coe, Submodule.Quotient.eq]
+  simp only [Submodule.mem_comap, Submodule.coe_subtype, AddSubgroupClass.coe_sub,
+    Submodule.coe_inclusion]
+  have heq : z - v - z = -v := by abel
+  rw [heq]
+  exact neg_mem (K.mem_B_left hv hdv)
+
+/-- The composite `Z_{r+1}^{p,n} ⟶ ker(d_r) ⟶ ker(d_r)/im(d_r)`. -/
+def toHomology : ↥(K.Z (r + 1) p n (n + 1)) →ₗ[R]
+    ↥(ker (K.dPage r p n)) ⧸
+      (range (K.dPageFrom r p n)).comap (ker (K.dPage r p n)).subtype :=
+  ((range (K.dPageFrom r p n)).comap (ker (K.dPage r p n)).subtype).mkQ.comp (K.toKer r p n)
+
+lemma toHomology_surjective : Function.Surjective (K.toHomology r p n) := by
+  have h := (Submodule.mkQ_surjective
+    ((range (K.dPageFrom r p n)).comap (ker (K.dPage r p n)).subtype)).comp
+      (K.toKer_surjective r p n)
+  simpa [toHomology, LinearMap.coe_comp] using h
+
+/-- Membership in the image of `d_r` arriving at `(p, n)`, concretely. -/
+lemma mk_mem_range_dPageFrom_iff (z : ↥(K.Z r p n (n + 1))) :
+    Submodule.Quotient.mk z ∈ range (K.dPageFrom r p n) ↔
+      ∃ y : K.X (n - 1), y ∈ K.Z r (p - r) (n - 1) n ∧
+        K.d (n - 1) n y - ↑z ∈ K.B r p (n - 1) n (n + 1) := by
+  constructor
+  · rintro ⟨η, hη⟩
+    obtain ⟨y, rfl⟩ := Submodule.Quotient.mk_surjective _ η
+    obtain ⟨y, hy2⟩ := y
+    refine ⟨y, ?_, ?_⟩
+    · have h := hy2
+      rwa [show n - 1 + 1 = n by ring] at h
+    · rw [K.dPageAux_mk, Submodule.Quotient.eq] at hη
+      simpa only [Submodule.mem_comap, Submodule.coe_subtype, AddSubgroupClass.coe_sub,
+        dZ_coe] using hη
+  · rintro ⟨y, hyZ, hy⟩
+    have hyZ' : y ∈ K.Z r (p - r) (n - 1) (n - 1 + 1) := by
+      rw [show n - 1 + 1 = n by ring]
+      exact hyZ
+    refine ⟨Submodule.Quotient.mk ⟨y, hyZ'⟩, ?_⟩
+    rw [K.dPageAux_mk, Submodule.Quotient.eq]
+    simpa only [Submodule.mem_comap, Submodule.coe_subtype, AddSubgroupClass.coe_sub,
+      dZ_coe] using hy
+
+/-- An element of `B_{r+1}^{p,n}` is a `d_r`-boundary on the `r`-th page. -/
+lemma exists_of_mem_B_succ {z : K.X n} (hzB : z ∈ K.B (r + 1) p (n - 1) n (n + 1)) :
+    ∃ y : K.X (n - 1), y ∈ K.Z r (p - r) (n - 1) n ∧
+      K.d (n - 1) n y - z ∈ K.B r p (n - 1) n (n + 1) := by
+  obtain ⟨u, v, hu1, hu2, hv, hdv, hsum⟩ := K.B_cases hzB
+  rw [show p - (r + 1) + 1 = p - r by ring] at hv
+  refine ⟨v, K.mem_Z.mpr ⟨hv, by rw [show p - r + r = p by ring]; exact hdv⟩, ?_⟩
+  have heq : K.d (n - 1) n v - z = -u := by
+    rw [hsum]
+    abel
+  rw [heq]
+  refine neg_mem (K.mem_B_left hu1 (K.F_le (p + r) (n + 1) ?_))
+  rwa [show p + r + 1 = p + (r + 1) by ring]
+
+/-- An `(r+1)`-cocycle which is a `d_r`-boundary lies in `B_{r+1}^{p,n}`. -/
+lemma mem_B_succ_of {z : K.X n} (hz : z ∈ K.Z (r + 1) p n (n + 1))
+    (h : ∃ y : K.X (n - 1), y ∈ K.Z r (p - r) (n - 1) n ∧
+      K.d (n - 1) n y - z ∈ K.B r p (n - 1) n (n + 1)) :
+    z ∈ K.B (r + 1) p (n - 1) n (n + 1) := by
+  obtain ⟨y, hyZ, hy⟩ := h
+  obtain ⟨hy1, hy2⟩ := K.mem_Z.mp hyZ
+  rw [show p - r + r = p by ring] at hy2
+  obtain ⟨u, t, hu1, hu2, ht, hdt, hsum⟩ := K.B_cases hy
+  have hy' : y - t ∈ K.F (p - r) (n - 1) := sub_mem hy1 (K.F_le (p - r) (n - 1) ht)
+  have hdy' : K.d (n - 1) n (y - t) ∈ K.F p n := by
+    rw [map_sub]
+    exact sub_mem hy2 hdt
+  have hu_eq : K.d (n - 1) n (y - t) - z = u := by
+    calc K.d (n - 1) n (y - t) - z
+        = K.d (n - 1) n y - K.d (n - 1) n t - z := by rw [map_sub]
+      _ = K.d (n - 1) n y - z - K.d (n - 1) n t := by abel
+      _ = u := by rw [hsum]; abel
+  have hz_eq : z = K.d (n - 1) n (y - t) - u := by
+    rw [← hu_eq]
+    abel
+  have hdu : K.d n (n + 1) u ∈ K.F (p + (r + 1)) (n + 1) := by
+    have hdu_eq : K.d n (n + 1) u = -K.d n (n + 1) z := by
+      rw [← hu_eq, map_sub, K.d_comp_d (n - 1) n (n + 1) (by ring) rfl (y - t), zero_sub]
+    rw [hdu_eq]
+    exact neg_mem (K.mem_Z.mp hz).2
+  rw [hz_eq]
+  refine sub_mem ?_ (K.mem_B_left hu1 hdu)
+  refine K.mem_B_right ?_ hdy'
+  rwa [show p - (r + 1) + 1 = p - r by ring]
+
+lemma ker_toHomology :
+    ker (K.toHomology r p n)
+      = (K.B (r + 1) p (n - 1) n (n + 1)).comap (K.Z (r + 1) p n (n + 1)).subtype := by
+  ext ζ
+  obtain ⟨z, hz⟩ := ζ
+  simp only [LinearMap.mem_ker, toHomology, LinearMap.comp_apply, Submodule.mkQ_apply,
+    Submodule.Quotient.mk_eq_zero, Submodule.mem_comap, Submodule.coe_subtype, toKer_coe]
+  rw [K.mk_mem_range_dPageFrom_iff]
+  simp only [Submodule.coe_inclusion]
+  exact ⟨fun h ↦ K.mem_B_succ_of r p n hz h, fun h ↦ K.exists_of_mem_B_succ r p n h⟩
+
+/-- **The graded main theorem**: `E_{r+1}^{p,n} ≅ ker(d_r^{p,n})/im(d_r^{p-r,n-1})`. -/
+noncomputable def pageSuccEquiv :
+    K.page (r + 1) p n ≃ₗ[R]
+      (↥(ker (K.dPage r p n)) ⧸
+        (range (K.dPageFrom r p n)).comap (ker (K.dPage r p n)).subtype) :=
+  (Submodule.quotEquivOfEq _ _ (K.ker_toHomology r p n).symm).trans
+    ((K.toHomology r p n).quotKerEquivOfSurjective (K.toHomology_surjective r p n))
+
+/-- **Flexible-index form of the main theorem.**  Identical to `pageSuccEquiv`
+but with the source/target filtration degrees of the differentials supplied as
+free variables `p' = p + r`, `p'' = p - r`.  This lets downstream identifications
+(e.g. `r = 0`, where `p + 0` is *not* definitionally `p`) name the differentials
+with clean indices `dPageAux _ p p _ _` rather than `dPageAux _ p (p + 0) _ _`.
+Proved by `subst` (the two differ only by proof-irrelevant index equalities). -/
+noncomputable def pageSuccEquiv' (r p p' p'' n : ℤ) (hp' : p' = p + r) (hp'' : p'' = p - r) :
+    K.page (r + 1) p n ≃ₗ[R]
+      (↥(ker (K.dPageAux r p p' n (n + 1) hp' rfl)) ⧸
+        (range (K.dPageAux r p'' p (n - 1) n (by rw [hp'']; ring) (by ring))).comap
+          (ker (K.dPageAux r p p' n (n + 1) hp' rfl)).subtype) := by
+  subst hp' hp''
+  exact K.pageSuccEquiv r p n
+
+end MainTheorem
+
+/-! ## Graded convergence
+
+The convergence theory of `Basic.lean`, refined by degree: the boundedness
+hypotheses are now *per spot* — `F^{p+r}_{n+1} = ⊥` and `F^{p-r+1}_{n-1} = ⊤` —
+which is what first-quadrant-type double complexes satisfy even though their
+total filtration is globally unbounded. -/
+
+section Convergence
+
+/-- The infinite cocycles `Z_∞^{p,n} = F^p_n ⊓ ker d`. -/
+def Zinf (p n : ℤ) : Submodule R (K.X n) := K.F p n ⊓ ker (K.d n (n + 1))
+
+/-- The infinite boundaries `B_∞^{p,n} = (F^{p+1}_n ⊓ ker d) + d(d⁻¹ F^p_n)`;
+`l` is intended to be `n - 1`. -/
+def Binf (p l n : ℤ) : Submodule R (K.X n) :=
+  (K.F (p + 1) n ⊓ ker (K.d n (n + 1))) ⊔ ((K.F p n).comap (K.d l n)).map (K.d l n)
+
+lemma mem_Binf_left {p l n : ℤ} {u : K.X n} (h1 : u ∈ K.F (p + 1) n)
+    (h2 : K.d n (n + 1) u = 0) : u ∈ K.Binf p l n :=
+  Submodule.mem_sup_left (Submodule.mem_inf.mpr ⟨h1, LinearMap.mem_ker.mpr h2⟩)
+
+lemma mem_Binf_right {p l n : ℤ} {w : K.X l} (hdw : K.d l n w ∈ K.F p n) :
+    K.d l n w ∈ K.Binf p l n :=
+  Submodule.mem_sup_right (Submodule.mem_map_of_mem (Submodule.mem_comap.mpr hdw))
+
+lemma Binf_cases {p l n : ℤ} {x : K.X n} (hx : x ∈ K.Binf p l n) :
+    ∃ (u : K.X n) (w : K.X l), u ∈ K.F (p + 1) n ∧ K.d n (n + 1) u = 0 ∧
+      K.d l n w ∈ K.F p n ∧ x = u + K.d l n w := by
+  obtain ⟨u, hu, y, hy, rfl⟩ := Submodule.mem_sup.mp hx
+  obtain ⟨hu1, hu2⟩ := Submodule.mem_inf.mp hu
+  obtain ⟨w, hw, rfl⟩ := Submodule.mem_map.mp hy
+  exact ⟨u, w, hu1, LinearMap.mem_ker.mp hu2, Submodule.mem_comap.mp hw, rfl⟩
+
+lemma Binf_le_Zinf {p l n : ℤ} (hl : n = l + 1) : K.Binf p l n ≤ K.Zinf p n := by
+  intro x hx
+  obtain ⟨u, w, hu1, hu2, hdw, rfl⟩ := K.Binf_cases hx
+  refine add_mem (Submodule.mem_inf.mpr ⟨K.F_le p n hu1, LinearMap.mem_ker.mpr hu2⟩) ?_
+  refine Submodule.mem_inf.mpr ⟨hdw, LinearMap.mem_ker.mpr ?_⟩
+  exact K.d_comp_d l n (n + 1) hl rfl w
+
+/-- The limit page `E_∞^{p,n}`. -/
+abbrev pageInf (p n : ℤ) :=
+  ↥(K.Zinf p n) ⧸ (K.Binf p (n - 1) n).comap (K.Zinf p n).subtype
+
+lemma Z_eq_Zinf {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥) :
+    K.Z r p n (n + 1) = K.Zinf p n := by
+  unfold Z Zinf
+  rw [hbot, Submodule.comap_bot]
+
+lemma B_eq_Binf {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥)
+    (htop : K.F (p - r + 1) (n - 1) = ⊤) :
+    K.B r p (n - 1) n (n + 1) = K.Binf p (n - 1) n := by
+  unfold B Binf
+  rw [hbot, htop, Submodule.comap_bot, top_inf_eq]
+
+/-- **Graded stabilization**: once `F^{p+r}_{n+1} = ⊥` and `F^{p-r+1}_{n-1} = ⊤`,
+the `r`-th page at `(p, n)` is the limit page. -/
+noncomputable def pageEquivPageInf {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥)
+    (htop : K.F (p - r + 1) (n - 1) = ⊤) :
+    K.page r p n ≃ₗ[R] K.pageInf p n :=
+  Submodule.Quotient.equiv _ _ (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)) (by
+    have hB := K.B_eq_Binf hbot htop
+    ext ξ
+    simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
+    constructor
+    · rintro ⟨η, hη, rfl⟩
+      rw [← hB]
+      simpa using hη
+    · intro hξ
+      refine ⟨(LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).symm ξ, ?_,
+        (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).apply_symm_apply ξ⟩
+      rw [hB]
+      simpa using hξ)
+
+/-- Beyond the bound of the filtration, the graded differential leaving `(p, n)`
+vanishes. -/
+theorem dPage_eq_zero {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥) :
+    K.dPage r p n = 0 := by
+  apply Submodule.linearMap_qext
+  ext ζ
+  have h0 : K.dZ r p (p + r) n (n + 1) rfl rfl ζ = 0 := by
+    apply Subtype.ext
+    have h := (K.mem_Z.mp ζ.2).2
+    rw [hbot] at h
+    simpa using h
+  simp [h0]
+
+/-- Beyond the bound of the filtration, the graded differential arriving at `(p, n)`
+vanishes. -/
+theorem dPageFrom_eq_zero {r p n : ℤ} (htop : K.F (p - r + 1) (n - 1) = ⊤) :
+    K.dPageFrom r p n = 0 := by
+  apply Submodule.linearMap_qext
+  ext ζ
+  obtain ⟨zv, hzv⟩ := ζ
+  simp only [LinearMap.comp_apply, Submodule.mkQ_apply, K.dPageAux_mk, LinearMap.zero_comp,
+    LinearMap.zero_apply, Submodule.Quotient.mk_eq_zero, Submodule.mem_comap,
+    Submodule.coe_subtype, dZ_coe]
+  have h2 : K.d (n - 1) n zv ∈ K.F p n := by
+    have h := (K.mem_Z.mp hzv).2
+    rw [show n - 1 + 1 = n by ring] at h
+    rwa [show p - r + r = p by ring] at h
+  refine K.mem_B_right ?_ h2
+  rw [htop]
+  exact Submodule.mem_top
+
+/-! ### The limit page is the associated graded of the cohomology -/
+
+/-- The cohomology of the complex at degree `n`, `H^n = ker(d^n)/im(d^{n-1})`. -/
+abbrev homology (n : ℤ) :=
+  ↥(ker (K.d n (n + 1))) ⧸ (range (K.d (n - 1) n)).comap (ker (K.d n (n + 1))).subtype
+
+/-- The filtration induced on the cohomology: `F^p H^n = im(F^p_n ⊓ ker d → H^n)`. -/
+def FH (p n : ℤ) : Submodule R (K.homology n) :=
+  ((K.Zinf p n).comap (ker (K.d n (n + 1))).subtype).map
+    ((range (K.d (n - 1) n)).comap (ker (K.d n (n + 1))).subtype).mkQ
+
+lemma mem_FH_iff {p n : ℤ} {h : K.homology n} :
+    h ∈ K.FH p n ↔ ∃ z : ↥(ker (K.d n (n + 1))), (z : K.X n) ∈ K.F p n ∧
+      Submodule.Quotient.mk z = h := by
+  constructor
+  · intro hh
+    obtain ⟨ζ, hζ, rfl⟩ := Submodule.mem_map.mp hh
+    have h1 := Submodule.mem_comap.mp hζ
+    exact ⟨ζ, (Submodule.mem_inf.mp h1).1, rfl⟩
+  · rintro ⟨z, hz, rfl⟩
+    exact Submodule.mem_map.mpr
+      ⟨z, Submodule.mem_comap.mpr (Submodule.mem_inf.mpr ⟨hz, z.2⟩), rfl⟩
+
+lemma Zinf_le_ker (p n : ℤ) : K.Zinf p n ≤ ker (K.d n (n + 1)) := inf_le_right
+
+/-- The natural map `Z_∞^{p,n} ⟶ F^p H^n`. -/
+def toFH (p n : ℤ) : ↥(K.Zinf p n) →ₗ[R] ↥(K.FH p n) :=
+  LinearMap.codRestrict _
+    (((range (K.d (n - 1) n)).comap (ker (K.d n (n + 1))).subtype).mkQ.comp
+      (Submodule.inclusion (K.Zinf_le_ker p n)))
+    fun x ↦ Submodule.mem_map_of_mem (Submodule.mem_comap.mpr x.2)
+
+@[simp] lemma toFH_coe (p n : ℤ) (x : ↥(K.Zinf p n)) :
+    (K.toFH p n x : K.homology n) =
+      Submodule.Quotient.mk (Submodule.inclusion (K.Zinf_le_ker p n) x) := rfl
+
+lemma toFH_surjective (p n : ℤ) : Function.Surjective (K.toFH p n) := by
+  rintro ⟨h, hmem⟩
+  obtain ⟨ζ, hζ, rfl⟩ := Submodule.mem_map.mp hmem
+  refine ⟨⟨↑ζ, Submodule.mem_comap.mp hζ⟩, ?_⟩
+  apply Subtype.ext
+  rw [toFH_coe]
+  exact congrArg _ (Subtype.ext rfl)
+
+/-- The associated graded piece `gr^p H^n = F^p H^n / F^{p+1} H^n` of the cohomology.
+This is the object the spectral sequence abuts to: the convergence theorems below
+identify `E_r^{p,n}` with `K.grH p n`.  (Mirrors `GradedAbelian.grH` on the abelian
+side.) -/
+abbrev grH (p n : ℤ) : Type _ :=
+  ↥(K.FH p n) ⧸ (K.FH (p + 1) n).comap (K.FH p n).subtype
+
+/-- The composite `Z_∞^{p,n} ⟶ F^p H^n ⟶ gr^p H^n`. -/
+def toGrH (p n : ℤ) : ↥(K.Zinf p n) →ₗ[R] K.grH p n :=
+  ((K.FH (p + 1) n).comap (K.FH p n).subtype).mkQ.comp (K.toFH p n)
+
+lemma toGrH_surjective (p n : ℤ) : Function.Surjective (K.toGrH p n) := by
+  have h := (Submodule.mkQ_surjective
+    ((K.FH (p + 1) n).comap (K.FH p n).subtype)).comp (K.toFH_surjective p n)
+  simpa [toGrH, LinearMap.coe_comp] using h
+
+lemma ker_toGrH (p n : ℤ) :
+    ker (K.toGrH p n) = (K.Binf p (n - 1) n).comap (K.Zinf p n).subtype := by
+  ext ξ
+  obtain ⟨x, hx⟩ := ξ
+  have hxF : x ∈ K.F p n := (Submodule.mem_inf.mp hx).1
+  simp only [LinearMap.mem_ker, toGrH, LinearMap.comp_apply, Submodule.mkQ_apply,
+    Submodule.Quotient.mk_eq_zero, Submodule.mem_comap, Submodule.coe_subtype, toFH_coe]
+  rw [K.mem_FH_iff]
+  constructor
+  · rintro ⟨z, hzF, hzeq⟩
+    rw [Submodule.Quotient.eq] at hzeq
+    have hd : (z : K.X n) - x ∈ range (K.d (n - 1) n) := by
+      simpa using hzeq
+    obtain ⟨m, hm⟩ := hd
+    have h1 : (z : K.X n) ∈ K.Binf p (n - 1) n :=
+      K.mem_Binf_left hzF (LinearMap.mem_ker.mp z.2)
+    have h2 : -((z : K.X n) - x) ∈ K.Binf p (n - 1) n := by
+      refine neg_mem ?_
+      rw [← hm]
+      refine K.mem_Binf_right ?_
+      rw [hm]
+      exact sub_mem (K.F_le p n hzF) hxF
+    have h3 := add_mem h1 h2
+    have heq : (z : K.X n) + -((z : K.X n) - x) = x := by abel
+    rwa [heq] at h3
+  · intro hxB
+    obtain ⟨u, w, hu1, hu2, hdw, hsum⟩ := K.Binf_cases hxB
+    refine ⟨⟨u, LinearMap.mem_ker.mpr hu2⟩, hu1, ?_⟩
+    rw [Submodule.Quotient.eq]
+    simp only [Submodule.mem_comap, Submodule.coe_subtype, AddSubgroupClass.coe_sub,
+      Submodule.coe_inclusion]
+    have heq : u - x = -(K.d (n - 1) n w) := by
+      rw [hsum]
+      abel
+    rw [heq]
+    exact neg_mem ⟨w, rfl⟩
+
+/-- **Identification of the graded limit page**: `E_∞^{p,n} ≅ gr^p H^n`. -/
+noncomputable def pageInfEquivGrH (p n : ℤ) :
+    K.pageInf p n ≃ₗ[R] K.grH p n :=
+  (Submodule.quotEquivOfEq _ _ (K.ker_toGrH p n).symm).trans
+    ((K.toGrH p n).quotKerEquivOfSurjective (K.toGrH_surjective p n))
+
+/-- **Graded convergence** (the statement consumed by the double-complex spectral
+sequences): if `F^{p+r}_{n+1} = ⊥` and `F^{p-r+1}_{n-1} = ⊤` — bounds required only
+at the spot `(p, n)` — then `E_r^{p,n} ≅ gr^p H^n`. -/
+noncomputable def pageEquivGrHOfBounded {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥)
+    (htop : K.F (p - r + 1) (n - 1) = ⊤) :
+    K.page r p n ≃ₗ[R] K.grH p n :=
+  (K.pageEquivPageInf hbot htop).trans (K.pageInfEquivGrH p n)
+
+end Convergence
+
+/-! ## The zeroth page is the associated graded -/
+
+section PageZero
+
+lemma Z_zero (p n : ℤ) : K.Z 0 p n (n + 1) = K.F p n := by
+  refine le_antisymm inf_le_left fun x hx ↦ ?_
+  refine K.mem_Z.mpr ⟨hx, ?_⟩
+  rw [show p + (0 : ℤ) = p by ring]
+  exact K.d_mem_F p n (n + 1) rfl x hx
+
+lemma B_zero (p n : ℤ) : K.B 0 p (n - 1) n (n + 1) = K.F (p + 1) n := by
+  apply le_antisymm
+  · refine sup_le inf_le_left ?_
+    intro x hx
+    obtain ⟨v, hv, rfl⟩ := Submodule.mem_map.mp hx
+    obtain ⟨hv1, _⟩ := Submodule.mem_inf.mp hv
+    rw [show p - 0 + 1 = p + 1 by ring] at hv1
+    exact K.d_mem_F (p + 1) (n - 1) n (by ring) v hv1
+  · intro x hx
+    refine K.mem_B_left hx ?_
+    rw [show p + (0 : ℤ) = p by ring]
+    exact K.d_mem_F p n (n + 1) rfl x (K.F_le p n hx)
+
+/-- **The zeroth page is the associated graded of the filtration**:
+`E_0^{p,n} ≅ F^p_n / F^{p+1}_n`.  (Consequently `E_1 = H(gr)` by the main
+theorem `pageSuccEquiv` at `r = 0`.) -/
+noncomputable def pageZeroEquiv (p n : ℤ) :
+    K.page 0 p n ≃ₗ[R] (↥(K.F p n) ⧸ (K.F (p + 1) n).comap (K.F p n).subtype) :=
+  Submodule.Quotient.equiv _ _ (LinearEquiv.ofEq _ _ (K.Z_zero p n)) (by
+    ext ξ
+    simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
+    constructor
+    · rintro ⟨η, hη, rfl⟩
+      rw [← K.B_zero p n]
+      simpa using hη
+    · intro hξ
+      refine ⟨(LinearEquiv.ofEq _ _ (K.Z_zero p n)).symm ξ, ?_,
+        (LinearEquiv.ofEq _ _ (K.Z_zero p n)).apply_symm_apply ξ⟩
+      rw [K.B_zero p n]
+      simpa using hξ)
+
+end PageZero
+
+end FilteredComplex

--- a/FLT/Slop/SpectralSequence/FilteredComplex.lean
+++ b/FLT/Slop/SpectralSequence/FilteredComplex.lean
@@ -6,8 +6,13 @@ Authors: Akhil Mathew
 module
 
 public import Mathlib.LinearAlgebra.Isomorphisms
-public import Mathlib.Tactic.Abel
-public import Mathlib.Tactic.Ring
+public import Mathlib.Algebra.Category.ModuleCat.Basic
+public import Mathlib.Algebra.Homology.HomologicalComplex
+public import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
+public import Mathlib.Algebra.Homology.ShortComplex.ModuleCat
+import Mathlib.CategoryTheory.EqToHom
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.Ring
 
 /-!
 # The graded spectral sequence of a filtered cochain complex
@@ -27,11 +32,12 @@ This is exactly what the spectral sequences of a double complex require.
 
 ## Design
 
-A complex is stored with an "all-pairs" differential `d : ∀ i j, X i →ₗ[R] X j`
-(only the consecutive components are ever used; `d² = 0` and filtration
-compatibility are hypotheses about consecutive indices, stated with flexible
-index equalities discharged by `omega`/`ring`).  This avoids all dependent-type
-transport along equalities like `(n - 1) + 1 = n`: the cocycles and boundaries
+The underlying complex is a standard
+`CochainComplex (ModuleCat R) ℤ`.  We use its all-pairs differential API, whose
+shape axiom makes every nonconsecutive component zero and whose square-zero
+axiom supplies all differential identities.  Flexible auxiliary indices keep
+the submodule calculations independent of transports such as
+`(n - 1) + 1 = n`: the cocycles and boundaries
 
 * `Z r p n m = F^p_n ⊓ (d n m)⁻¹(F^{p+r}_m)`   (intended `m = n + 1`),
 * `B r p l n m = (F^{p+1}_n ⊓ (d n m)⁻¹(F^{p+r}_m)) + d l n (F^{p-r+1}_l ⊓ (d l n)⁻¹(F^p_n))`
@@ -47,12 +53,16 @@ ambient module never changes.
 * `pageSuccEquiv` : `E_{r+1}^{p,n} ≅ ker(d_r)/im(d_r)` — the main theorem;
 * `pageEquivGrHOfBounded` : **graded convergence** — if `F^{p+r}_{n+1} = ⊥` and
   `F^{p-r+1}_{n-1} = ⊤` (one spot at a time!), then `E_r^{p,n} ≅ gr^p H^n`, the
-  associated graded of the cohomology of the complex at degree `n`.
+  associated graded of the cohomology of the complex at degree `n`;
+* `pageInfEquivGrH` : under the same local bounds, the actual limit term
+  `E_∞^{p,n}` is also isomorphic to `gr^p H^n`.
 -/
 
 @[expose] public section
 
-open Submodule LinearMap
+open CategoryTheory Submodule LinearMap
+
+namespace FilteredComplex
 
 section HomologyEquiv
 
@@ -120,41 +130,53 @@ noncomputable def homologyEquivOfSquares
 
 end HomologyEquiv
 
-/-- A **filtered cochain complex** of modules: a `ℤ`-indexed family with an
-all-pairs differential (only consecutive components matter), squaring to zero,
-and a decreasing filtration compatible with the differential. -/
-structure FilteredComplex (R : Type*) [Ring R] where
-  /-- The modules of the complex. -/
-  X : ℤ → Type*
-  [addCommGroup : ∀ n, AddCommGroup (X n)]
-  [module : ∀ n, Module R (X n)]
-  /-- The differential; only the components `d n (n+1)` are meaningful. -/
-  d : ∀ i j : ℤ, X i →ₗ[R] X j
-  /-- The differential squares to zero (on consecutive components). -/
-  d_comp_d : ∀ (i j k : ℤ), j = i + 1 → k = j + 1 → ∀ x : X i, d j k (d i j x) = 0
-  /-- The filtration. -/
-  F : ℤ → ∀ n : ℤ, Submodule R (X n)
-  /-- The filtration is decreasing. -/
-  F_le : ∀ (p n : ℤ), F (p + 1) n ≤ F p n
-  /-- The differential preserves the filtration. -/
-  d_mem_F : ∀ (p i j : ℤ), j = i + 1 → ∀ x ∈ F p i, d i j x ∈ F p j
+end FilteredComplex
 
-attribute [instance] FilteredComplex.addCommGroup FilteredComplex.module
+universe u v
+
+/-- A **filtered cochain complex** of modules: a standard mathlib cochain complex
+with a decreasing filtration by subcomplexes. -/
+structure FilteredComplex (R : Type u) [Ring R] where
+  /-- The underlying cochain complex. -/
+  toCochainComplex : CochainComplex (ModuleCat.{v} R) ℤ
+  /-- The filtration. -/
+  F : ℤ → ∀ n : ℤ, Submodule R (toCochainComplex.X n)
+  /-- The filtration is decreasing. -/
+  antitone_F : ∀ n, Antitone fun p ↦ F p n
+  /-- The differential preserves the filtration. -/
+  map_d_le : ∀ (p i j : ℤ), (F p i).map (toCochainComplex.d i j).hom ≤ F p j
 
 namespace FilteredComplex
 
-variable {R : Type*} [Ring R] (K : FilteredComplex R)
+variable {R : Type u} [Ring R] (K : FilteredComplex.{u, v} R)
+
+/-- The module in cohomological degree `n`. -/
+abbrev X (n : ℤ) : Type _ := K.toCochainComplex.X n
+
+/-- The underlying linear map of the differential from degree `i` to degree `j`.
+It is zero unless `j = i + 1`, by the shape axiom of the cochain complex. -/
+abbrev d (i j : ℤ) : K.X i →ₗ[R] K.X j := (K.toCochainComplex.d i j).hom
+
+/-- Any two differential components compose to zero; the shape axiom makes this
+automatic when either component is nonconsecutive. -/
+@[simp] lemma d_comp_d (i j k : ℤ) (x : K.X i) :
+    K.d j k (K.d i j x) = 0 := by
+  have h := DFunLike.congr_fun
+    (ModuleCat.hom_ext_iff.mp (K.toCochainComplex.d_comp_d i j k)) x
+  simpa only [ModuleCat.hom_comp, LinearMap.comp_apply, ModuleCat.hom_zero,
+    LinearMap.zero_apply] using h
+
+/-- The successor step of the decreasing filtration. -/
+lemma F_le (p n : ℤ) : K.F (p + 1) n ≤ K.F p n :=
+  K.antitone_F n (by omega)
+
+/-- Every differential component carries each filtration step into itself. -/
+lemma d_mem_F (p i j : ℤ) (x : K.X i) (hx : x ∈ K.F p i) :
+    K.d i j x ∈ K.F p j :=
+  K.map_d_le p i j (Submodule.mem_map_of_mem hx)
 
 lemma F_mono {p q : ℤ} (h : p ≤ q) (n : ℤ) : K.F q n ≤ K.F p n := by
-  obtain ⟨k, rfl⟩ := Int.le.dest h
-  clear h
-  induction k with
-  | zero => simp
-  | succ m ih =>
-    refine le_trans ?_ ih
-    have e : (p + (m + 1 : ℕ) : ℤ) = (p + m) + 1 := by push_cast; ring
-    rw [e]
-    exact K.F_le (p + m) n
+  exact K.antitone_F n h
 
 /-! ## Cocycles, boundaries, and the graded pages -/
 
@@ -192,12 +214,11 @@ lemma B_cases {r p l n m : ℤ} {x : K.X n} (hx : x ∈ K.B r p l n m) :
   obtain ⟨hv1, hv2⟩ := Submodule.mem_inf.mp hv
   exact ⟨u, v, hu1, Submodule.mem_comap.mp hu2, hv1, Submodule.mem_comap.mp hv2, rfl⟩
 
-lemma B_le_Z {r p l n m : ℤ} (hl : n = l + 1) (hm : m = n + 1) :
-    K.B r p l n m ≤ K.Z r p n m := by
+lemma B_le_Z {r p l n m : ℤ} : K.B r p l n m ≤ K.Z r p n m := by
   intro x hx
   obtain ⟨u, v, hu1, hu2, hv, hdv, rfl⟩ := K.B_cases hx
   refine add_mem (K.mem_Z.mpr ⟨K.F_le p n hu1, hu2⟩) (K.mem_Z.mpr ⟨hdv, ?_⟩)
-  rw [K.d_comp_d l n m hl hm v]
+  rw [K.d_comp_d l n m v]
   exact zero_mem _
 
 lemma Z_succ_le (r p n m : ℤ) : K.Z (r + 1) p n m ≤ K.Z r p n m := by
@@ -219,7 +240,7 @@ lemma d_mem_Z {r p n : ℤ} {x : K.X n} (hx : x ∈ K.Z r p n (n + 1)) :
     K.d n (n + 1) x ∈ K.Z r (p + r) (n + 1) (n + 1 + 1) := by
   obtain ⟨h1, h2⟩ := K.mem_Z.mp hx
   refine K.mem_Z.mpr ⟨h2, ?_⟩
-  rw [K.d_comp_d n (n + 1) (n + 1 + 1) rfl rfl x]
+  rw [K.d_comp_d n (n + 1) (n + 1 + 1) x]
   exact zero_mem _
 
 lemma d_mem_B {r p n : ℤ} {x : K.X n} (hx : x ∈ K.B r p (n - 1) n (n + 1)) :
@@ -229,7 +250,7 @@ lemma d_mem_B {r p n : ℤ} {x : K.X n} (hx : x ∈ K.B r p (n - 1) n (n + 1)) :
   refine add_mem ?_ ?_
   · refine K.mem_B_right ?_ hu2
     rwa [show p + r - r + 1 = p + 1 by ring]
-  · rw [K.d_comp_d (n - 1) n (n + 1) (by ring) rfl v]
+  · rw [K.d_comp_d (n - 1) n (n + 1) v]
     exact zero_mem _
 
 /-- The differential restricted to the cocycles, with flexible indices
@@ -265,7 +286,7 @@ lemma dZ_comp_dZ (r p q s n m t : ℤ) (hq : q = p + r) (hs : s = q + r)
   ext x
   simp only [LinearMap.comp_apply, dZ_coe, LinearMap.zero_apply, ZeroMemClass.coe_zero]
   subst hm ht
-  exact K.d_comp_d n (n + 1) (n + 1 + 1) rfl rfl x
+  exact K.d_comp_d n (n + 1) (n + 1 + 1) x
 
 /-- The composite of two consecutive graded page differentials vanishes. -/
 theorem dPageAux_comp (r p q s n m t : ℤ) (hq : q = p + r) (hs : s = q + r)
@@ -314,7 +335,7 @@ def toKer : ↥(K.Z (r + 1) p n (n + 1)) →ₗ[R] ↥(ker (K.dPage r p n)) :=
       refine K.mem_B_left ?_ ?_
       · rw [show p + r + 1 = p + (r + 1) by ring]
         exact hz.2
-      · rw [K.d_comp_d n (n + 1) (n + 1 + 1) rfl rfl]
+      · rw [K.d_comp_d n (n + 1) (n + 1 + 1)]
         exact zero_mem _
 
 @[simp] lemma toKer_coe (z : ↥(K.Z (r + 1) p n (n + 1))) :
@@ -419,7 +440,7 @@ lemma mem_B_succ_of {z : K.X n} (hz : z ∈ K.Z (r + 1) p n (n + 1))
     abel
   have hdu : K.d n (n + 1) u ∈ K.F (p + (r + 1)) (n + 1) := by
     have hdu_eq : K.d n (n + 1) u = -K.d n (n + 1) z := by
-      rw [← hu_eq, map_sub, K.d_comp_d (n - 1) n (n + 1) (by ring) rfl (y - t), zero_sub]
+      rw [← hu_eq, map_sub, K.d_comp_d (n - 1) n (n + 1) (y - t), zero_sub]
     rw [hdu_eq]
     exact neg_mem (K.mem_Z.mp hz).2
   rw [hz_eq]
@@ -464,30 +485,37 @@ end MainTheorem
 
 /-! ## Graded convergence
 
-The convergence theory of `Basic.lean`, refined by degree: the boundedness
+The convergence theory of `FilteredModule.lean`, refined by degree: the boundedness
 hypotheses are now *per spot* — `F^{p+r}_{n+1} = ⊥` and `F^{p-r+1}_{n-1} = ⊤` —
 which is what first-quadrant-type double complexes satisfy even though their
-total filtration is globally unbounded. -/
+total filtration is globally unbounded.
+
+The limit term is formed in `E₀`: its numerator is the intersection of
+`Z_r^{p,n} + F^{p+1}_n`, and its denominator is the union of
+`B_r^{p,n} + F^{p+1}_n`.  The sums with `F^{p+1}_n` are necessary because the
+raw ambient `Z_r` and `B_r` are not nested across arbitrary pages. -/
 
 section Convergence
 
-/-- The infinite cocycles `Z_∞^{p,n} = F^p_n ⊓ ker d`. -/
-def Zinf (p n : ℤ) : Submodule R (K.X n) := K.F p n ⊓ ker (K.d n (n + 1))
+/-- The cycle submodule used to present the associated-graded cohomology target,
+`F^p_n ⊓ ker d`.  This is not the limit-cycle submodule without convergence
+hypotheses. -/
+def abutmentZ (p n : ℤ) : Submodule R (K.X n) := K.F p n ⊓ ker (K.d n (n + 1))
 
-/-- The infinite boundaries `B_∞^{p,n} = (F^{p+1}_n ⊓ ker d) + d(d⁻¹ F^p_n)`;
-`l` is intended to be `n - 1`. -/
-def Binf (p l n : ℤ) : Submodule R (K.X n) :=
+/-- The boundary submodule used to present the associated-graded cohomology target,
+`(F^{p+1}_n ⊓ ker d) + d(d⁻¹ F^p_n)`; `l` is intended to be `n - 1`. -/
+def abutmentB (p l n : ℤ) : Submodule R (K.X n) :=
   (K.F (p + 1) n ⊓ ker (K.d n (n + 1))) ⊔ ((K.F p n).comap (K.d l n)).map (K.d l n)
 
-lemma mem_Binf_left {p l n : ℤ} {u : K.X n} (h1 : u ∈ K.F (p + 1) n)
-    (h2 : K.d n (n + 1) u = 0) : u ∈ K.Binf p l n :=
+lemma mem_abutmentB_left {p l n : ℤ} {u : K.X n} (h1 : u ∈ K.F (p + 1) n)
+    (h2 : K.d n (n + 1) u = 0) : u ∈ K.abutmentB p l n :=
   Submodule.mem_sup_left (Submodule.mem_inf.mpr ⟨h1, LinearMap.mem_ker.mpr h2⟩)
 
-lemma mem_Binf_right {p l n : ℤ} {w : K.X l} (hdw : K.d l n w ∈ K.F p n) :
-    K.d l n w ∈ K.Binf p l n :=
+lemma mem_abutmentB_right {p l n : ℤ} {w : K.X l} (hdw : K.d l n w ∈ K.F p n) :
+    K.d l n w ∈ K.abutmentB p l n :=
   Submodule.mem_sup_right (Submodule.mem_map_of_mem (Submodule.mem_comap.mpr hdw))
 
-lemma Binf_cases {p l n : ℤ} {x : K.X n} (hx : x ∈ K.Binf p l n) :
+lemma abutmentB_cases {p l n : ℤ} {x : K.X n} (hx : x ∈ K.abutmentB p l n) :
     ∃ (u : K.X n) (w : K.X l), u ∈ K.F (p + 1) n ∧ K.d n (n + 1) u = 0 ∧
       K.d l n w ∈ K.F p n ∧ x = u + K.d l n w := by
   obtain ⟨u, hu, y, hy, rfl⟩ := Submodule.mem_sup.mp hx
@@ -495,35 +523,205 @@ lemma Binf_cases {p l n : ℤ} {x : K.X n} (hx : x ∈ K.Binf p l n) :
   obtain ⟨w, hw, rfl⟩ := Submodule.mem_map.mp hy
   exact ⟨u, w, hu1, LinearMap.mem_ker.mp hu2, Submodule.mem_comap.mp hw, rfl⟩
 
-lemma Binf_le_Zinf {p l n : ℤ} (hl : n = l + 1) : K.Binf p l n ≤ K.Zinf p n := by
+lemma abutmentB_le_abutmentZ {p l n : ℤ} : K.abutmentB p l n ≤ K.abutmentZ p n := by
   intro x hx
-  obtain ⟨u, w, hu1, hu2, hdw, rfl⟩ := K.Binf_cases hx
+  obtain ⟨u, w, hu1, hu2, hdw, rfl⟩ := K.abutmentB_cases hx
   refine add_mem (Submodule.mem_inf.mpr ⟨K.F_le p n hu1, LinearMap.mem_ker.mpr hu2⟩) ?_
   refine Submodule.mem_inf.mpr ⟨hdw, LinearMap.mem_ker.mpr ?_⟩
-  exact K.d_comp_d l n (n + 1) hl rfl w
+  exact K.d_comp_d l n (n + 1) w
 
-/-- The limit page `E_∞^{p,n}`. -/
+/-- The associated-graded cohomology target, presented inside `X n`. -/
+abbrev associatedGradedHomology (p n : ℤ) :=
+  ↥(K.abutmentZ p n) ⧸ (K.abutmentB p (n - 1) n).comap (K.abutmentZ p n).subtype
+
+/-- The numerator of the limit term, represented before quotienting by
+`F^{p+1}_n`: `⋂_{r ≥ 0} (Z_r^{p,n} + F^{p+1}_n)`. -/
+def limitZ (p n : ℤ) : Submodule R (K.X n) :=
+  ⨅ r : ℕ, K.Z (r : ℤ) p n (n + 1) ⊔ K.F (p + 1) n
+
+/-- The denominator of the limit term, represented before quotienting by
+`F^{p+1}_n`: `⋃_{r ≥ 0} (B_r^{p,n} + F^{p+1}_n)`. -/
+def limitB (p n : ℤ) : Submodule R (K.X n) :=
+  ⨆ r : ℕ, K.B (r : ℤ) p (n - 1) n (n + 1) ⊔ K.F (p + 1) n
+
+lemma Z_mono {r s p n : ℤ} (h : r ≤ s) :
+    K.Z s p n (n + 1) ≤ K.Z r p n (n + 1) := by
+  intro x hx
+  obtain ⟨hxF, hdx⟩ := K.mem_Z.mp hx
+  exact K.mem_Z.mpr ⟨hxF, K.F_mono (by omega) (n + 1) hdx⟩
+
+lemma normalizedZ_antitone (p n : ℤ) :
+    Antitone fun r : ℕ ↦ K.Z (r : ℤ) p n (n + 1) ⊔ K.F (p + 1) n := by
+  intro r s h
+  exact sup_le_sup (K.Z_mono (by exact_mod_cast h)) le_rfl
+
+lemma normalizedB_monotone (p n : ℤ) :
+    Monotone fun r : ℕ ↦
+      K.B (r : ℤ) p (n - 1) n (n + 1) ⊔ K.F (p + 1) n := by
+  intro r s h
+  refine sup_le ?_ le_sup_right
+  intro x hx
+  obtain ⟨u, v, hu1, -, hv, hdv, rfl⟩ := K.B_cases hx
+  refine add_mem (Submodule.mem_sup_right hu1) (Submodule.mem_sup_left ?_)
+  exact K.mem_B_right (K.F_mono (by omega) (n - 1) hv) hdv
+
+lemma B_sup_F_le_Z_sup_F (r s p n : ℤ) :
+    K.B r p (n - 1) n (n + 1) ⊔ K.F (p + 1) n ≤
+      K.Z s p n (n + 1) ⊔ K.F (p + 1) n := by
+  refine sup_le ?_ le_sup_right
+  intro x hx
+  obtain ⟨u, v, hu1, -, -, hdv, rfl⟩ := K.B_cases hx
+  refine add_mem (Submodule.mem_sup_right hu1) (Submodule.mem_sup_left ?_)
+  refine K.mem_Z.mpr ⟨hdv, ?_⟩
+  rw [K.d_comp_d (n - 1) n (n + 1) v]
+  exact zero_mem _
+
+lemma limitB_le_limitZ (p n : ℤ) : K.limitB p n ≤ K.limitZ p n := by
+  refine iSup_le fun r ↦ le_iInf fun s ↦ ?_
+  exact K.B_sup_F_le_Z_sup_F (r : ℤ) (s : ℤ) p n
+
+lemma limitZ_le_F (p n : ℤ) : K.limitZ p n ≤ K.F p n := by
+  refine le_trans
+    (iInf_le (fun r : ℕ ↦ K.Z (r : ℤ) p n (n + 1) ⊔ K.F (p + 1) n) 0) ?_
+  exact sup_le inf_le_left (K.F_le p n)
+
+lemma F_le_limitB (p n : ℤ) : K.F (p + 1) n ≤ K.limitB p n :=
+  le_trans le_sup_right
+    (le_iSup (fun r : ℕ ↦
+      K.B (r : ℤ) p (n - 1) n (n + 1) ⊔ K.F (p + 1) n) 0)
+
+/-- The limit term `E_∞^{p,n}`.  It need not be equal to any finite page
+without a stabilization hypothesis. -/
 abbrev pageInf (p n : ℤ) :=
-  ↥(K.Zinf p n) ⧸ (K.Binf p (n - 1) n).comap (K.Zinf p n).subtype
+  ↥(K.limitZ p n) ⧸ (K.limitB p n).comap (K.limitZ p n).subtype
 
-lemma Z_eq_Zinf {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥) :
-    K.Z r p n (n + 1) = K.Zinf p n := by
-  unfold Z Zinf
+lemma Z_eq_abutmentZ {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥) :
+    K.Z r p n (n + 1) = K.abutmentZ p n := by
+  unfold Z abutmentZ
   rw [hbot, Submodule.comap_bot]
 
-lemma B_eq_Binf {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥)
+lemma B_eq_abutmentB {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥)
     (htop : K.F (p - r + 1) (n - 1) = ⊤) :
-    K.B r p (n - 1) n (n + 1) = K.Binf p (n - 1) n := by
-  unfold B Binf
+    K.B r p (n - 1) n (n + 1) = K.abutmentB p (n - 1) n := by
+  unfold B abutmentB
   rw [hbot, htop, Submodule.comap_bot, top_inf_eq]
 
-/-- **Graded stabilization**: once `F^{p+r}_{n+1} = ⊥` and `F^{p-r+1}_{n-1} = ⊤`,
-the `r`-th page at `(p, n)` is the limit page. -/
-noncomputable def pageEquivPageInf {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥)
+/-- Once the cocycles have stabilized at `(p,n)`, the numerator of the limit
+term is the cycle numerator of the associated-graded target, together with the
+copy of `F^{p+1}_n` used to represent submodules of `E₀^{p,n}`. -/
+lemma limitZ_eq_abutmentZ_sup_F {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥) :
+    K.limitZ p n = K.abutmentZ p n ⊔ K.F (p + 1) n := by
+  let N := r.toNat
+  have hrN : r ≤ (N : ℤ) := Int.self_le_toNat r
+  have hbotN : K.F (p + (N : ℤ)) (n + 1) = ⊥ :=
+    le_bot_iff.mp (hbot ▸ K.F_mono (by omega) (n + 1))
+  apply le_antisymm
+  · refine le_trans
+      (iInf_le (fun s : ℕ ↦ K.Z (s : ℤ) p n (n + 1) ⊔ K.F (p + 1) n) N) ?_
+    rw [K.Z_eq_abutmentZ hbotN]
+  · refine le_iInf fun s ↦ sup_le ?_ le_sup_right
+    intro x hx
+    exact Submodule.mem_sup_left (K.mem_Z.mpr ⟨hx.1, by
+      rw [LinearMap.mem_ker.mp hx.2]
+      exact zero_mem _⟩)
+
+/-- Once both sides have stabilized at `(p,n)`, the denominator of the limit
+term is the boundary denominator of the associated-graded target, together
+with the copy of `F^{p+1}_n` used to represent submodules of `E₀^{p,n}`. -/
+lemma limitB_eq_abutmentB_sup_F {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥)
     (htop : K.F (p - r + 1) (n - 1) = ⊤) :
-    K.page r p n ≃ₗ[R] K.pageInf p n :=
-  Submodule.Quotient.equiv _ _ (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)) (by
-    have hB := K.B_eq_Binf hbot htop
+    K.limitB p n = K.abutmentB p (n - 1) n ⊔ K.F (p + 1) n := by
+  let N := r.toNat
+  have hrN : r ≤ (N : ℤ) := Int.self_le_toNat r
+  have hbotN : K.F (p + (N : ℤ)) (n + 1) = ⊥ :=
+    le_bot_iff.mp (hbot ▸ K.F_mono (by omega) (n + 1))
+  have htopN : K.F (p - (N : ℤ) + 1) (n - 1) = ⊤ :=
+    top_le_iff.mp (htop ▸ K.F_mono (by omega) (n - 1))
+  apply le_antisymm
+  · refine iSup_le fun s ↦ sup_le ?_ le_sup_right
+    intro x hx
+    obtain ⟨u, w, hu1, -, -, hdw, rfl⟩ := K.B_cases hx
+    refine add_mem (Submodule.mem_sup_right hu1) (Submodule.mem_sup_left ?_)
+    exact K.mem_abutmentB_right hdw
+  · refine le_trans ?_
+      (le_iSup (fun s : ℕ ↦
+        K.B (s : ℤ) p (n - 1) n (n + 1) ⊔ K.F (p + 1) n) N)
+    rw [K.B_eq_abutmentB hbotN htopN]
+
+/-- Intersecting the associated-graded cycle numerator with the normalized
+boundary denominator recovers the unnormalized boundary denominator. -/
+lemma abutmentZ_inf_abutmentB_sup_F_eq_abutmentB (p n : ℤ) :
+    K.abutmentZ p n ⊓ (K.abutmentB p (n - 1) n ⊔ K.F (p + 1) n) =
+      K.abutmentB p (n - 1) n := by
+  have hBZ : K.abutmentB p (n - 1) n ≤ K.abutmentZ p n := K.abutmentB_le_abutmentZ
+  apply le_antisymm
+  · rintro x ⟨hxZ, hx⟩
+    obtain ⟨b, hb, f, hf, rfl⟩ := Submodule.mem_sup.mp hx
+    refine add_mem hb ?_
+    have hfker : K.d n (n + 1) f = 0 := by
+      have hbker : K.d n (n + 1) b = 0 := LinearMap.mem_ker.mp (hBZ hb).2
+      have hxker : K.d n (n + 1) (b + f) = 0 := LinearMap.mem_ker.mp hxZ.2
+      simpa [map_add, hbker] using hxker
+    exact K.mem_abutmentB_left hf hfker
+  · exact le_inf hBZ le_sup_left
+
+/-- The associated-graded cohomology target in its normalized presentation
+inside `E₀^{p,n}`: adjoining `F^{p+1}_n` to both numerator and denominator
+does not change the quotient. -/
+noncomputable def associatedGradedHomologyEquivNormalized (p n : ℤ) :
+    K.associatedGradedHomology p n ≃ₗ[R]
+      (↥(K.abutmentZ p n ⊔ K.F (p + 1) n) ⧸
+        ((K.abutmentB p (n - 1) n ⊔ K.F (p + 1) n).comap
+          (K.abutmentZ p n ⊔ K.F (p + 1) n).subtype)) := by
+  let e := LinearMap.quotientInfEquivSupQuotient (K.abutmentZ p n)
+    (K.abutmentB p (n - 1) n ⊔ K.F (p + 1) n)
+  have hdom :
+      (K.abutmentB p (n - 1) n).comap (K.abutmentZ p n).subtype =
+        (K.abutmentZ p n).comap (K.abutmentZ p n).subtype ⊓
+          (K.abutmentB p (n - 1) n ⊔ K.F (p + 1) n).comap (K.abutmentZ p n).subtype := by
+    ext x
+    change (x : K.X n) ∈ K.abutmentB p (n - 1) n ↔
+      (x : K.X n) ∈ K.abutmentZ p n ∧
+        (x : K.X n) ∈ K.abutmentB p (n - 1) n ⊔ K.F (p + 1) n
+    rw [← Submodule.mem_inf, K.abutmentZ_inf_abutmentB_sup_F_eq_abutmentB]
+  have hnum : K.abutmentZ p n ⊔ (K.abutmentB p (n - 1) n ⊔ K.F (p + 1) n) =
+      K.abutmentZ p n ⊔ K.F (p + 1) n := by
+    rw [← sup_assoc, sup_eq_left.mpr K.abutmentB_le_abutmentZ]
+  rw [hnum] at e
+  exact (Submodule.quotEquivOfEq _ _ hdom).trans e
+
+/-- Under two-sided local bounds at `(p,n)`, the actual limit term is
+canonically isomorphic to the associated-graded cohomology target. -/
+noncomputable def pageInfEquivAssociatedGradedHomology {r p n : ℤ}
+    (hbot : K.F (p + r) (n + 1) = ⊥)
+    (htop : K.F (p - r + 1) (n - 1) = ⊤) :
+    K.pageInf p n ≃ₗ[R] K.associatedGradedHomology p n := by
+  let e₁ : K.pageInf p n ≃ₗ[R]
+      (↥(K.abutmentZ p n ⊔ K.F (p + 1) n) ⧸
+        ((K.abutmentB p (n - 1) n ⊔ K.F (p + 1) n).comap
+          (K.abutmentZ p n ⊔ K.F (p + 1) n).subtype)) :=
+    Submodule.Quotient.equiv _ _
+      (LinearEquiv.ofEq _ _ (K.limitZ_eq_abutmentZ_sup_F hbot)) (by
+        have hB := K.limitB_eq_abutmentB_sup_F hbot htop
+        ext x
+        simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
+        constructor
+        · rintro ⟨y, hy, rfl⟩
+          simpa [hB] using hy
+        · intro hx
+          refine ⟨(LinearEquiv.ofEq _ _ (K.limitZ_eq_abutmentZ_sup_F hbot)).symm x, ?_,
+            (LinearEquiv.ofEq _ _ (K.limitZ_eq_abutmentZ_sup_F hbot)).apply_symm_apply x⟩
+          simpa [hB] using hx)
+  exact e₁.trans (K.associatedGradedHomologyEquivNormalized p n).symm
+
+/-- Once `F^{p+r}_{n+1} = ⊥` and `F^{p-r+1}_{n-1} = ⊤`, the `r`-th page
+at `(p,n)` is the associated-graded cohomology target. -/
+noncomputable def pageEquivAssociatedGradedHomology {r p n : ℤ}
+    (hbot : K.F (p + r) (n + 1) = ⊥)
+    (htop : K.F (p - r + 1) (n - 1) = ⊤) :
+    K.page r p n ≃ₗ[R] K.associatedGradedHomology p n :=
+  Submodule.Quotient.equiv _ _ (LinearEquiv.ofEq _ _ (K.Z_eq_abutmentZ hbot)) (by
+    have hB := K.B_eq_abutmentB hbot htop
     ext ξ
     simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
     constructor
@@ -531,10 +729,19 @@ noncomputable def pageEquivPageInf {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = �
       rw [← hB]
       simpa using hη
     · intro hξ
-      refine ⟨(LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).symm ξ, ?_,
-        (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).apply_symm_apply ξ⟩
+      refine ⟨(LinearEquiv.ofEq _ _ (K.Z_eq_abutmentZ hbot)).symm ξ, ?_,
+        (LinearEquiv.ofEq _ _ (K.Z_eq_abutmentZ hbot)).apply_symm_apply ξ⟩
       rw [hB]
       simpa using hξ)
+
+/-- Under two-sided local bounds at `(p,n)`, the finite `r`-th page has
+stabilized to the limit term. -/
+noncomputable def pageEquivPageInf {r p n : ℤ}
+    (hbot : K.F (p + r) (n + 1) = ⊥)
+    (htop : K.F (p - r + 1) (n - 1) = ⊤) :
+    K.page r p n ≃ₗ[R] K.pageInf p n :=
+  (K.pageEquivAssociatedGradedHomology hbot htop).trans
+    (K.pageInfEquivAssociatedGradedHomology hbot htop).symm
 
 /-- Beyond the bound of the filtration, the graded differential leaving `(p, n)`
 vanishes. -/
@@ -567,15 +774,42 @@ theorem dPageFrom_eq_zero {r p n : ℤ} (htop : K.F (p - r + 1) (n - 1) = ⊤) :
   rw [htop]
   exact Submodule.mem_top
 
-/-! ### The limit page is the associated graded of the cohomology -/
+/-! ### The associated-graded cohomology target -/
 
 /-- The cohomology of the complex at degree `n`, `H^n = ker(d^n)/im(d^{n-1})`. -/
 abbrev homology (n : ℤ) :=
   ↥(ker (K.d n (n + 1))) ⧸ (range (K.d (n - 1) n)).comap (ker (K.d n (n + 1))).subtype
 
+/-- The canonical isomorphism from mathlib's categorical cohomology object to
+the explicit quotient `ker(d n (n + 1)) / range(d (n - 1) n)`. -/
+noncomputable def categoricalHomologyIso (n : ℤ) :
+    K.toCochainComplex.homology n ≅ ModuleCat.of R (K.homology n) := by
+  let a := n - 1
+  let b := n
+  let c := n + 1
+  let shape := ComplexShape.up ℤ
+  have hab : shape.Rel a b := by
+    change n - 1 + 1 = n
+    omega
+  have hbc : shape.Rel b c := by
+    change n + 1 = n + 1
+    rfl
+  let S := K.toCochainComplex.sc' a b c
+  refine K.toCochainComplex.homologyIsoSc' a b c
+      (shape.prev_eq' hab) (shape.next_eq' hbc) ≪≫
+    S.moduleCatHomologyIso ≪≫ ?_
+  refine eqToIso ?_
+  change ModuleCat.of R
+      (LinearMap.ker S.g.hom ⧸ LinearMap.range S.moduleCatToCycles) =
+    ModuleCat.of R
+      (↥(ker (K.d n (n + 1))) ⧸
+        (range (K.d (n - 1) n)).comap (ker (K.d n (n + 1))).subtype)
+  rw [LinearMap.range_codRestrict]
+  rfl
+
 /-- The filtration induced on the cohomology: `F^p H^n = im(F^p_n ⊓ ker d → H^n)`. -/
 def FH (p n : ℤ) : Submodule R (K.homology n) :=
-  ((K.Zinf p n).comap (ker (K.d n (n + 1))).subtype).map
+  ((K.abutmentZ p n).comap (ker (K.d n (n + 1))).subtype).map
     ((range (K.d (n - 1) n)).comap (ker (K.d n (n + 1))).subtype).mkQ
 
 lemma mem_FH_iff {p n : ℤ} {h : K.homology n} :
@@ -590,18 +824,18 @@ lemma mem_FH_iff {p n : ℤ} {h : K.homology n} :
     exact Submodule.mem_map.mpr
       ⟨z, Submodule.mem_comap.mpr (Submodule.mem_inf.mpr ⟨hz, z.2⟩), rfl⟩
 
-lemma Zinf_le_ker (p n : ℤ) : K.Zinf p n ≤ ker (K.d n (n + 1)) := inf_le_right
+lemma abutmentZ_le_ker (p n : ℤ) : K.abutmentZ p n ≤ ker (K.d n (n + 1)) := inf_le_right
 
-/-- The natural map `Z_∞^{p,n} ⟶ F^p H^n`. -/
-def toFH (p n : ℤ) : ↥(K.Zinf p n) →ₗ[R] ↥(K.FH p n) :=
+/-- The natural map from filtered cocycles `F^p_n ∩ ker d` to `F^p H^n`. -/
+def toFH (p n : ℤ) : ↥(K.abutmentZ p n) →ₗ[R] ↥(K.FH p n) :=
   LinearMap.codRestrict _
     (((range (K.d (n - 1) n)).comap (ker (K.d n (n + 1))).subtype).mkQ.comp
-      (Submodule.inclusion (K.Zinf_le_ker p n)))
+      (Submodule.inclusion (K.abutmentZ_le_ker p n)))
     fun x ↦ Submodule.mem_map_of_mem (Submodule.mem_comap.mpr x.2)
 
-@[simp] lemma toFH_coe (p n : ℤ) (x : ↥(K.Zinf p n)) :
+@[simp] lemma toFH_coe (p n : ℤ) (x : ↥(K.abutmentZ p n)) :
     (K.toFH p n x : K.homology n) =
-      Submodule.Quotient.mk (Submodule.inclusion (K.Zinf_le_ker p n) x) := rfl
+      Submodule.Quotient.mk (Submodule.inclusion (K.abutmentZ_le_ker p n) x) := rfl
 
 lemma toFH_surjective (p n : ℤ) : Function.Surjective (K.toFH p n) := by
   rintro ⟨h, hmem⟩
@@ -618,8 +852,8 @@ side.) -/
 abbrev grH (p n : ℤ) : Type _ :=
   ↥(K.FH p n) ⧸ (K.FH (p + 1) n).comap (K.FH p n).subtype
 
-/-- The composite `Z_∞^{p,n} ⟶ F^p H^n ⟶ gr^p H^n`. -/
-def toGrH (p n : ℤ) : ↥(K.Zinf p n) →ₗ[R] K.grH p n :=
+/-- The composite from filtered cocycles to `F^p H^n ⟶ gr^p H^n`. -/
+def toGrH (p n : ℤ) : ↥(K.abutmentZ p n) →ₗ[R] K.grH p n :=
   ((K.FH (p + 1) n).comap (K.FH p n).subtype).mkQ.comp (K.toFH p n)
 
 lemma toGrH_surjective (p n : ℤ) : Function.Surjective (K.toGrH p n) := by
@@ -628,7 +862,7 @@ lemma toGrH_surjective (p n : ℤ) : Function.Surjective (K.toGrH p n) := by
   simpa [toGrH, LinearMap.coe_comp] using h
 
 lemma ker_toGrH (p n : ℤ) :
-    ker (K.toGrH p n) = (K.Binf p (n - 1) n).comap (K.Zinf p n).subtype := by
+    ker (K.toGrH p n) = (K.abutmentB p (n - 1) n).comap (K.abutmentZ p n).subtype := by
   ext ξ
   obtain ⟨x, hx⟩ := ξ
   have hxF : x ∈ K.F p n := (Submodule.mem_inf.mp hx).1
@@ -641,19 +875,19 @@ lemma ker_toGrH (p n : ℤ) :
     have hd : (z : K.X n) - x ∈ range (K.d (n - 1) n) := by
       simpa using hzeq
     obtain ⟨m, hm⟩ := hd
-    have h1 : (z : K.X n) ∈ K.Binf p (n - 1) n :=
-      K.mem_Binf_left hzF (LinearMap.mem_ker.mp z.2)
-    have h2 : -((z : K.X n) - x) ∈ K.Binf p (n - 1) n := by
+    have h1 : (z : K.X n) ∈ K.abutmentB p (n - 1) n :=
+      K.mem_abutmentB_left hzF (LinearMap.mem_ker.mp z.2)
+    have h2 : -((z : K.X n) - x) ∈ K.abutmentB p (n - 1) n := by
       refine neg_mem ?_
       rw [← hm]
-      refine K.mem_Binf_right ?_
+      refine K.mem_abutmentB_right ?_
       rw [hm]
       exact sub_mem (K.F_le p n hzF) hxF
     have h3 := add_mem h1 h2
     have heq : (z : K.X n) + -((z : K.X n) - x) = x := by abel
     rwa [heq] at h3
   · intro hxB
-    obtain ⟨u, w, hu1, hu2, hdw, hsum⟩ := K.Binf_cases hxB
+    obtain ⟨u, w, hu1, hu2, hdw, hsum⟩ := K.abutmentB_cases hxB
     refine ⟨⟨u, LinearMap.mem_ker.mpr hu2⟩, hu1, ?_⟩
     rw [Submodule.Quotient.eq]
     simp only [Submodule.mem_comap, Submodule.coe_subtype, AddSubgroupClass.coe_sub,
@@ -664,11 +898,21 @@ lemma ker_toGrH (p n : ℤ) :
     rw [heq]
     exact neg_mem ⟨w, rfl⟩
 
-/-- **Identification of the graded limit page**: `E_∞^{p,n} ≅ gr^p H^n`. -/
-noncomputable def pageInfEquivGrH (p n : ℤ) :
-    K.pageInf p n ≃ₗ[R] K.grH p n :=
+/-- Identification of the associated-graded target with `gr^p H^n`.  This does
+not identify the limit term `pageInf` without convergence hypotheses. -/
+noncomputable def associatedGradedHomologyEquivGrH (p n : ℤ) :
+    K.associatedGradedHomology p n ≃ₗ[R] K.grH p n :=
   (Submodule.quotEquivOfEq _ _ (K.ker_toGrH p n).symm).trans
     ((K.toGrH p n).quotKerEquivOfSurjective (K.toGrH_surjective p n))
+
+/-- Under two-sided local bounds at `(p,n)`, the limit term is the associated
+graded of the induced filtration on cohomology. -/
+noncomputable def pageInfEquivGrH {r p n : ℤ}
+    (hbot : K.F (p + r) (n + 1) = ⊥)
+    (htop : K.F (p - r + 1) (n - 1) = ⊤) :
+    K.pageInf p n ≃ₗ[R] K.grH p n :=
+  (K.pageInfEquivAssociatedGradedHomology hbot htop).trans
+    (K.associatedGradedHomologyEquivGrH p n)
 
 /-- **Graded convergence** (the statement consumed by the double-complex spectral
 sequences): if `F^{p+r}_{n+1} = ⊥` and `F^{p-r+1}_{n-1} = ⊤` — bounds required only
@@ -676,7 +920,8 @@ at the spot `(p, n)` — then `E_r^{p,n} ≅ gr^p H^n`. -/
 noncomputable def pageEquivGrHOfBounded {r p n : ℤ} (hbot : K.F (p + r) (n + 1) = ⊥)
     (htop : K.F (p - r + 1) (n - 1) = ⊤) :
     K.page r p n ≃ₗ[R] K.grH p n :=
-  (K.pageEquivPageInf hbot htop).trans (K.pageInfEquivGrH p n)
+  (K.pageEquivAssociatedGradedHomology hbot htop).trans
+    (K.associatedGradedHomologyEquivGrH p n)
 
 end Convergence
 
@@ -688,7 +933,7 @@ lemma Z_zero (p n : ℤ) : K.Z 0 p n (n + 1) = K.F p n := by
   refine le_antisymm inf_le_left fun x hx ↦ ?_
   refine K.mem_Z.mpr ⟨hx, ?_⟩
   rw [show p + (0 : ℤ) = p by ring]
-  exact K.d_mem_F p n (n + 1) rfl x hx
+  exact K.d_mem_F p n (n + 1) x hx
 
 lemma B_zero (p n : ℤ) : K.B 0 p (n - 1) n (n + 1) = K.F (p + 1) n := by
   apply le_antisymm
@@ -697,11 +942,11 @@ lemma B_zero (p n : ℤ) : K.B 0 p (n - 1) n (n + 1) = K.F (p + 1) n := by
     obtain ⟨v, hv, rfl⟩ := Submodule.mem_map.mp hx
     obtain ⟨hv1, _⟩ := Submodule.mem_inf.mp hv
     rw [show p - 0 + 1 = p + 1 by ring] at hv1
-    exact K.d_mem_F (p + 1) (n - 1) n (by ring) v hv1
+    exact K.d_mem_F (p + 1) (n - 1) n v hv1
   · intro x hx
     refine K.mem_B_left hx ?_
     rw [show p + (0 : ℤ) = p by ring]
-    exact K.d_mem_F p n (n + 1) rfl x (K.F_le p n hx)
+    exact K.d_mem_F p n (n + 1) x (K.F_le p n hx)
 
 /-- **The zeroth page is the associated graded of the filtration**:
 `E_0^{p,n} ≅ F^p_n / F^{p+1}_n`.  (Consequently `E_1 = H(gr)` by the main
@@ -722,5 +967,150 @@ noncomputable def pageZeroEquiv (p n : ℤ) :
       simpa using hξ)
 
 end PageZero
+
+/-! ## Functoriality
+
+A morphism of filtered complexes is a cochain map which preserves every step of
+the filtration.  Such a morphism induces maps on cocycles, boundaries, and all
+pages, compatible with the page differentials. -/
+
+section Functoriality
+
+open CategoryTheory
+
+variable {K K' K'' : FilteredComplex.{u, v} R}
+
+/-- A morphism of filtered cochain complexes: a cochain map which preserves the
+filtration. -/
+@[ext]
+structure Hom (K K' : FilteredComplex.{u, v} R) where
+  /-- The underlying morphism of cochain complexes. -/
+  toHom : K.toCochainComplex ⟶ K'.toCochainComplex
+  /-- Each component of the cochain map preserves the filtration. -/
+  map_F : ∀ (p n : ℤ), (K.F p n).map (toHom.f n).hom ≤ K'.F p n
+
+namespace Hom
+
+/-- The identity morphism of a filtered complex. -/
+def id (K : FilteredComplex.{u, v} R) : Hom K K where
+  toHom := 𝟙 K.toCochainComplex
+  map_F p n := by simp
+
+/-- The composite of two morphisms of filtered complexes. -/
+def comp (f : Hom K K') (g : Hom K' K'') : Hom K K'' where
+  toHom := f.toHom ≫ g.toHom
+  map_F p n := by
+    rw [HomologicalComplex.comp_f, ModuleCat.hom_comp, Submodule.map_comp]
+    exact le_trans (Submodule.map_mono (f.map_F p n)) (g.map_F p n)
+
+end Hom
+
+instance : Category (FilteredComplex.{u, v} R) where
+  Hom := Hom
+  id := Hom.id
+  comp := Hom.comp
+
+@[simp] lemma id_toHom (K : FilteredComplex.{u, v} R) :
+    (Hom.toHom (𝟙 K : K ⟶ K)) = 𝟙 K.toCochainComplex := rfl
+
+@[simp] lemma comp_toHom (f : K ⟶ K') (g : K' ⟶ K'') :
+    (f ≫ g).toHom = f.toHom ≫ g.toHom := rfl
+
+/-- Two filtered cochain maps are equal if their underlying cochain maps are
+equal. -/
+@[ext]
+lemma Hom.hom_ext (f g : K ⟶ K') (h : f.toHom = g.toHom) : f = g := by
+  cases f
+  cases g
+  cases h
+  rfl
+
+/-- The component of a filtered cochain map commutes with every differential. -/
+lemma Hom.comm_d (f : K ⟶ K') (i j : ℤ) (x : K.X i) :
+    K'.d i j ((f.toHom.f i).hom x) = (f.toHom.f j).hom (K.d i j x) := by
+  have h := DFunLike.congr_fun
+    (ModuleCat.hom_ext_iff.mp (f.toHom.comm i j)) x
+  simpa only [ModuleCat.hom_comp, LinearMap.comp_apply] using h
+
+/-- A filtered cochain map carries each filtration step into the corresponding
+filtration step. -/
+lemma Hom.map_mem_F (f : K ⟶ K') (p n : ℤ) {x : K.X n} (hx : x ∈ K.F p n) :
+    (f.toHom.f n).hom x ∈ K'.F p n :=
+  f.map_F p n (Submodule.mem_map_of_mem hx)
+
+lemma Hom.map_Z (f : K ⟶ K') {r p n m : ℤ} {x : K.X n}
+    (hx : x ∈ K.Z r p n m) : (f.toHom.f n).hom x ∈ K'.Z r p n m := by
+  obtain ⟨hxF, hdx⟩ := K.mem_Z.mp hx
+  refine K'.mem_Z.mpr ⟨f.map_mem_F p n hxF, ?_⟩
+  rw [f.comm_d]
+  exact f.map_mem_F (p + r) m hdx
+
+lemma Hom.map_B (f : K ⟶ K') {r p l n m : ℤ} {x : K.X n}
+    (hx : x ∈ K.B r p l n m) : (f.toHom.f n).hom x ∈ K'.B r p l n m := by
+  obtain ⟨a, b, haF, hda, hbF, hdb, rfl⟩ := K.B_cases hx
+  rw [map_add, ← f.comm_d l n b]
+  refine add_mem (K'.mem_B_left (f.map_mem_F (p + 1) n haF) ?_) ?_
+  · rw [f.comm_d]
+    exact f.map_mem_F (p + r) m hda
+  · refine K'.mem_B_right (f.map_mem_F (p - r + 1) l hbF) ?_
+    rw [f.comm_d]
+    exact f.map_mem_F p n hdb
+
+/-- The map on boundary submodules induced by a filtered cochain map. -/
+def Hom.mapB (f : K ⟶ K') (r p l n m : ℤ) :
+    ↥(K.B r p l n m) →ₗ[R] ↥(K'.B r p l n m) :=
+  (f.toHom.f n).hom.restrict fun _ hx ↦ f.map_B hx
+
+@[simp] lemma Hom.mapB_coe (f : K ⟶ K') (r p l n m : ℤ)
+    (x : ↥(K.B r p l n m)) :
+    (f.mapB r p l n m x : K'.X n) = (f.toHom.f n).hom x := rfl
+
+/-- The map on cocycles induced by a filtered cochain map. -/
+def Hom.mapZ (f : K ⟶ K') (r p n m : ℤ) :
+    ↥(K.Z r p n m) →ₗ[R] ↥(K'.Z r p n m) :=
+  (f.toHom.f n).hom.restrict fun _ hx ↦ f.map_Z hx
+
+@[simp] lemma Hom.mapZ_coe (f : K ⟶ K') (r p n m : ℤ) (x : ↥(K.Z r p n m)) :
+    (f.mapZ r p n m x : K'.X n) = (f.toHom.f n).hom x := rfl
+
+/-- The map on an `r`-page induced by a filtered cochain map. -/
+def Hom.mapPage (f : K ⟶ K') (r p n : ℤ) : K.page r p n →ₗ[R] K'.page r p n :=
+  Submodule.mapQ _ _ (f.mapZ r p n (n + 1)) (by
+    intro x hx
+    simp only [Submodule.mem_comap, Submodule.coe_subtype, Hom.mapZ_coe] at hx ⊢
+    exact f.map_B hx)
+
+@[simp] lemma Hom.mapPage_mk (f : K ⟶ K') (r p n : ℤ)
+    (x : ↥(K.Z r p n (n + 1))) :
+    f.mapPage r p n (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk (f.mapZ r p n (n + 1) x) :=
+  Submodule.mapQ_apply _ _ _ x
+
+@[simp] lemma Hom.mapPage_id (K : FilteredComplex.{u, v} R) (r p n : ℤ) :
+    (𝟙 K : K ⟶ K).mapPage r p n = LinearMap.id := by
+  apply Submodule.linearMap_qext
+  ext x
+  rfl
+
+@[simp] lemma Hom.mapPage_comp (f : K ⟶ K') (g : K' ⟶ K'') (r p n : ℤ) :
+    (f ≫ g).mapPage r p n = (g.mapPage r p n).comp (f.mapPage r p n) := by
+  apply Submodule.linearMap_qext
+  ext x
+  simp only [Hom.mapPage_mk, LinearMap.comp_apply, Submodule.mkQ_apply]
+  congr 1
+
+/-- Naturality of page differentials with respect to filtered cochain maps. -/
+theorem Hom.mapPage_dPageAux (f : K ⟶ K') (r p q n m : ℤ)
+    (hq : q = p + r) (hm : m = n + 1) :
+    (f.mapPage r q m).comp (K.dPageAux r p q n m hq hm) =
+      (K'.dPageAux r p q n m hq hm).comp (f.mapPage r p n) := by
+  apply Submodule.linearMap_qext
+  ext x
+  simp only [LinearMap.comp_apply, Submodule.mkQ_apply, dPageAux_mk, Hom.mapPage_mk]
+  congr 1
+  apply Subtype.ext
+  simpa only [Hom.mapZ_coe, dZ_coe] using (f.comm_d n m x).symm
+
+end Functoriality
 
 end FilteredComplex

--- a/FLT/Slop/SpectralSequence/FilteredModule.lean
+++ b/FLT/Slop/SpectralSequence/FilteredModule.lean
@@ -23,10 +23,10 @@ Following the Stacks Project, the heart of the construction is the case of a
 *filtered differential object*: a module `M` equipped with a differential
 `d : M →ₗ[R] M` satisfying `d ∘ d = 0` and a decreasing filtration
 `F : ℤ → Submodule R M` preserved by `d`.  The spectral sequence of a filtered
-*complex* is obtained by applying this construction to the total differential
-module `⨁ n, X n` (see the final section of this file); the extra grading only
-refines each page into a direct sum, it plays no role in the construction of
-the pages and differentials.
+*complex* has a separate graded implementation in `FilteredComplex.lean`, whose
+underlying object is mathlib's standard `CochainComplex (ModuleCat R) ℤ`.  The
+final section of this file also records a lower-level totalization constructor
+from raw consecutive differential data.
 
 ## Main definitions
 
@@ -51,27 +51,33 @@ subquotient-of-`gr^p` definition by the modular law):
 
 ## Convergence
 
-We define the limit page `pageInf` (`E_∞^p = (F^p ∩ ker d)/((F^{p+1} ∩ ker d) + (F^p ∩ im d))`)
-and the induced filtration `FH` on the homology `H = ker d / im d`, and prove:
+We define the limit term `pageInf` from the intersection of the normalised
+cycle submodules and the union of the normalised boundary submodules in `E₀`.
+We separately define `associatedGradedHomology`, the canonical abutment candidate
+`(F^p ∩ ker d)/((F^{p+1} ∩ ker d) + (F^p ∩ im d))`, and the induced
+filtration `FH` on `H = ker d / im d`.
 
-* `pageEquivPageInf` : `E_r^p ≅ E_∞^p` once `F^{p+r} = ⊥` and `F^{p-r+1} = ⊤`;
+* `pageEquivAssociatedGradedHomology` identifies a bounded finite page with the
+  associated-graded target, while `pageInfEquivAssociatedGradedHomology`
+  identifies the actual limit term with the same target under those bounds;
 * `dPage_eq_zero`, `dPageFrom_eq_zero` : the differentials at position `p` vanish
   in the same range, so the spectral sequence degenerates there;
-* `pageInfEquivGrHomology` : `E_∞^p ≅ gr^p H`;
+* `associatedGradedHomologyEquivGrHomology` identifies that target with `gr^p H`,
+  and `pageInfEquivGrHomology` gives the resulting bounded identification of
+  `E_∞^p`;
 * `pageEquivGrHomologyOfBounded` : **convergence** — for an exhaustive
   (`F^a = ⊤`) and bounded (`F^b = ⊥`) filtration, `E_r^p ≅ gr^p H` for all
   sufficiently large `r` (explicitly `b ≤ p + r` and `p - r + 1 ≤ a`), and in
   particular the pages stabilize (`pageSuccEquivPageOfBounded`).
 
-For *unbounded* filtrations we prove the classical convergence statements:
-`iInf_Z_eq_Zinf` (cocycle convergence, assuming only separatedness
-`⨅ q, F^q = ⊥`), `iSup_B_eq_Binf` (boundary convergence, assuming
+For *unbounded* filtrations we prove standard convergence ingredients:
+`iInf_Z_eq_abutmentZ` (cocycle convergence, assuming only separatedness
+`⨅ q, F^q = ⊥`), `iSup_B_eq_abutmentB` (boundary convergence, assuming
 exhaustiveness `⨆ q, F^q = ⊤` and a one-sided bound), and — under
 `F^{p+r} = ⊥` and exhaustiveness only, with the filtration possibly unbounded
 below — the natural surjections `pageTransition : E_r^p ↠ E_{r'}^p` and
-`pageToPageInf : E_r^p ↠ E_∞^p` together with `exists_pageTransition_eq_zero`,
-which exhibit `E_∞^p` as the colimit of the pages `E_r^p` (the classical
-convergence theorem; compare Weibel, Theorem 5.5.1).
+`pageToAssociatedGradedHomology`, together with the elementwise eventual-kernel
+statement `exists_pageTransition_eq_zero`.
 -/
 
 @[expose] public section
@@ -397,18 +403,32 @@ end MainTheorem
 
 /-! ## Convergence
 
-We define the limit page `E_∞^p = (F^p ∩ ker d) / ((F^{p+1} ∩ ker d) + (F^p ∩ im d))`
-and prove the two halves of the convergence theorem for (suitably bounded)
-filtrations, following the Stacks Project (tag 012A):
+The limit term is defined from the stable subquotient of `E₀`:
+
+`Z_∞^p = ⋂_r (Z_r^p + F^{p+1})`,
+`B_∞^p = ⋃_r (B_r^p + F^{p+1})`, and
+`E_∞^p = Z_∞^p / B_∞^p`.
+
+The sums with `F^{p+1}` are essential: the cycles and boundaries defining the
+limit are subobjects of `E₀^p = F^p/F^{p+1}`, not generally nested submodules
+of the ambient module `M`.
+
+Separately, we define the associated-graded homology target
+`(F^p ∩ ker d) / ((F^{p+1} ∩ ker d) + (F^p ∩ im d))` and prove the two
+halves of the convergence theorem for suitably bounded filtrations, following
+the Stacks Project (tag 012A):
 
 * **Stabilization**: if `F^{p+r} = ⊥` and `F^{p-r+1} = ⊤` (which happens for all
   sufficiently large `r` when the filtration is exhaustive and bounded), then
-  `E_r^p = E_∞^p` on the nose (`Z_eq_Zinf`, `B_eq_Binf`, `pageEquivPageInf`), and
+  both `E_r^p` and the limit term `E_∞^p` identify with the associated-graded
+  target (`pageEquivAssociatedGradedHomology`,
+  `pageInfEquivAssociatedGradedHomology`), and
   the differentials into and out of position `p` vanish (`dPage_eq_zero`,
   `dPageFrom_eq_zero`).
-* **Identification of the limit**: `E_∞^p ≅ gr^p H(M, d)`, where the homology
+* **Identification of the target**: the associated-graded target is canonically
+  isomorphic to `gr^p H(M, d)`, where the homology
   `H = ker d / im d` carries the filtration `F^p H = im(F^p ∩ ker d → H)`
-  (`pageInfEquivGrHomology`).
+  (`associatedGradedHomologyEquivGrHomology`).
 
 Combining the two (`pageEquivGrHomologyOfBounded`) gives the classical
 convergence statement `E_r^p ⇒ gr^p H` for bounded filtrations: the pages at
@@ -420,39 +440,196 @@ lemma range_d_le_ker_d : range K.d ≤ ker K.d := by
   rintro _ ⟨x, rfl⟩
   exact LinearMap.mem_ker.mpr (K.d_squared x)
 
-/-- The infinite cocycles `Z_∞^p = F^p ∩ ker d`. -/
-def Zinf (p : ℤ) : Submodule R M := K.F p ⊓ ker K.d
+/-- The cycle submodule used to present the associated-graded homology target:
+`F^p ∩ ker d`.  It agrees with the unnormalised intersection of the `Z_r^p`
+under separatedness, but is not the limit-cycle submodule in general. -/
+def abutmentZ (p : ℤ) : Submodule R M := K.F p ⊓ ker K.d
 
-/-- The infinite boundaries `B_∞^p = (F^{p+1} ∩ ker d) + (F^p ∩ im d)`. -/
-def Binf (p : ℤ) : Submodule R M :=
+/-- The boundary submodule used to present the associated-graded homology target:
+`(F^{p+1} ∩ ker d) + (F^p ∩ im d)`. -/
+def abutmentB (p : ℤ) : Submodule R M :=
   (K.F (p + 1) ⊓ ker K.d) ⊔ (K.F p ⊓ range K.d)
 
-lemma Zinf_le_ker (p : ℤ) : K.Zinf p ≤ ker K.d := inf_le_right
+lemma abutmentZ_le_ker (p : ℤ) : K.abutmentZ p ≤ ker K.d := inf_le_right
 
-lemma Binf_le_Zinf (p : ℤ) : K.Binf p ≤ K.Zinf p :=
+lemma abutmentB_le_abutmentZ (p : ℤ) : K.abutmentB p ≤ K.abutmentZ p :=
   sup_le (inf_le_inf_right _ (K.F_le p))
     (inf_le_inf_left _ (K.range_d_le_ker_d))
 
-/-- The limit page `E_∞^p = Z_∞^p / B_∞^p`. -/
-abbrev pageInf (p : ℤ) := ↥(K.Zinf p) ⧸ (K.Binf p).comap (K.Zinf p).subtype
+/-- The associated-graded homology target, presented inside the filtered module. -/
+abbrev associatedGradedHomology (p : ℤ) :=
+  ↥(K.abutmentZ p) ⧸ (K.abutmentB p).comap (K.abutmentZ p).subtype
+
+/-- The numerator of the limit term, represented in `F^p` before quotienting
+by `F^{p+1}`: `⋂_{r ≥ 0} (Z_r^p + F^{p+1})`. -/
+def limitZ (p : ℤ) : Submodule R M :=
+  ⨅ r : ℕ, K.Z (r : ℤ) p ⊔ K.F (p + 1)
+
+/-- The denominator of the limit term, represented in `F^p` before quotienting
+by `F^{p+1}`: `⋃_{r ≥ 0} (B_r^p + F^{p+1})`. -/
+def limitB (p : ℤ) : Submodule R M :=
+  ⨆ r : ℕ, K.B (r : ℤ) p ⊔ K.F (p + 1)
+
+lemma Z_mono {r s p : ℤ} (h : r ≤ s) : K.Z s p ≤ K.Z r p := by
+  intro x hx
+  obtain ⟨hxF, hdx⟩ := K.mem_Z.mp hx
+  exact K.mem_Z.mpr ⟨hxF, K.F_mono (by omega) hdx⟩
+
+lemma normalizedZ_antitone (p : ℤ) :
+    Antitone fun r : ℕ ↦ K.Z (r : ℤ) p ⊔ K.F (p + 1) := by
+  intro r s h
+  exact sup_le_sup (K.Z_mono (by exact_mod_cast h)) le_rfl
+
+lemma normalizedB_monotone (p : ℤ) :
+    Monotone fun r : ℕ ↦ K.B (r : ℤ) p ⊔ K.F (p + 1) := by
+  intro r s h
+  refine sup_le ?_ le_sup_right
+  intro x hx
+  obtain ⟨u, v, hu1, -, hv, hdv, rfl⟩ := K.B_cases hx
+  refine add_mem (Submodule.mem_sup_right hu1) (Submodule.mem_sup_left ?_)
+  exact K.mem_B_right (K.F_mono (by omega) hv) hdv
+
+lemma B_sup_F_le_Z_sup_F (r s p : ℤ) :
+    K.B r p ⊔ K.F (p + 1) ≤ K.Z s p ⊔ K.F (p + 1) := by
+  refine sup_le ?_ le_sup_right
+  intro x hx
+  obtain ⟨u, v, hu1, -, -, hdv, rfl⟩ := K.B_cases hx
+  refine add_mem (Submodule.mem_sup_right hu1) (Submodule.mem_sup_left ?_)
+  exact K.mem_Z.mpr ⟨hdv, by rw [K.d_squared]; exact zero_mem _⟩
+
+lemma limitB_le_limitZ (p : ℤ) : K.limitB p ≤ K.limitZ p := by
+  refine iSup_le fun r ↦ le_iInf fun s ↦ ?_
+  exact K.B_sup_F_le_Z_sup_F (r : ℤ) (s : ℤ) p
+
+lemma limitZ_le_F (p : ℤ) : K.limitZ p ≤ K.F p := by
+  refine le_trans (iInf_le (fun r : ℕ ↦ K.Z (r : ℤ) p ⊔ K.F (p + 1)) 0) ?_
+  exact sup_le inf_le_left (K.F_le p)
+
+lemma F_le_limitB (p : ℤ) : K.F (p + 1) ≤ K.limitB p :=
+  le_trans le_sup_right (le_iSup (fun r : ℕ ↦ K.B (r : ℤ) p ⊔ K.F (p + 1)) 0)
+
+/-- The limit term `E_∞^p`: the quotient of the intersection of the normalised
+cycle submodules by the union of the normalised boundary submodules.  It need
+not be equal to any finite page without a stabilization hypothesis. -/
+abbrev pageInf (p : ℤ) :=
+  ↥(K.limitZ p) ⧸ (K.limitB p).comap (K.limitZ p).subtype
 
 /-! ### Stabilization -/
 
-lemma Z_eq_Zinf {r p : ℤ} (hbot : K.F (p + r) = ⊥) : K.Z r p = K.Zinf p := by
-  unfold Z Zinf
+lemma Z_eq_abutmentZ {r p : ℤ} (hbot : K.F (p + r) = ⊥) : K.Z r p = K.abutmentZ p := by
+  unfold Z abutmentZ
   rw [hbot, Submodule.comap_bot]
 
-lemma B_eq_Binf {r p : ℤ} (hbot : K.F (p + r) = ⊥) (htop : K.F (p - r + 1) = ⊤) :
-    K.B r p = K.Binf p := by
-  unfold B Binf
+lemma B_eq_abutmentB {r p : ℤ} (hbot : K.F (p + r) = ⊥) (htop : K.F (p - r + 1) = ⊤) :
+    K.B r p = K.abutmentB p := by
+  unfold B abutmentB
   rw [hbot, htop, Submodule.comap_bot, Submodule.map_top]
 
-/-- Once `r` is large enough that `F^{p+r} = ⊥` and `F^{p-r+1} = ⊤`, the `r`-th page
-at `p` is (canonically isomorphic to) the limit page. -/
-noncomputable def pageEquivPageInf {r p : ℤ} (hbot : K.F (p + r) = ⊥)
-    (htop : K.F (p - r + 1) = ⊤) : K.page r p ≃ₗ[R] K.pageInf p :=
-  Submodule.Quotient.equiv _ _ (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)) (by
-    have hB := K.B_eq_Binf hbot htop
+/-- Once the cocycles have stabilized, the numerator of the limit term is the
+cycle numerator of the associated-graded target, together with the copy of
+`F^{p+1}` used to represent submodules of `E₀^p`. -/
+lemma limitZ_eq_abutmentZ_sup_F {r p : ℤ} (hbot : K.F (p + r) = ⊥) :
+    K.limitZ p = K.abutmentZ p ⊔ K.F (p + 1) := by
+  let N := r.toNat
+  have hrN : r ≤ (N : ℤ) := Int.self_le_toNat r
+  have hbotN : K.F (p + (N : ℤ)) = ⊥ :=
+    le_bot_iff.mp (hbot ▸ K.F_mono (by omega))
+  apply le_antisymm
+  · refine le_trans (iInf_le (fun s : ℕ ↦ K.Z (s : ℤ) p ⊔ K.F (p + 1)) N) ?_
+    rw [K.Z_eq_abutmentZ hbotN]
+  · refine le_iInf fun s ↦ sup_le ?_ le_sup_right
+    intro x hx
+    exact Submodule.mem_sup_left (K.mem_Z.mpr ⟨hx.1, by
+      rw [LinearMap.mem_ker.mp hx.2]
+      exact zero_mem _⟩)
+
+/-- Once both sides have stabilized, the denominator of the limit term is the
+boundary denominator of the associated-graded target, together with the copy
+of `F^{p+1}` used to represent submodules of `E₀^p`. -/
+lemma limitB_eq_abutmentB_sup_F {r p : ℤ} (hbot : K.F (p + r) = ⊥)
+    (htop : K.F (p - r + 1) = ⊤) :
+    K.limitB p = K.abutmentB p ⊔ K.F (p + 1) := by
+  let N := r.toNat
+  have hrN : r ≤ (N : ℤ) := Int.self_le_toNat r
+  have hbotN : K.F (p + (N : ℤ)) = ⊥ :=
+    le_bot_iff.mp (hbot ▸ K.F_mono (by omega))
+  have htopN : K.F (p - (N : ℤ) + 1) = ⊤ :=
+    top_le_iff.mp (htop ▸ K.F_mono (by omega))
+  apply le_antisymm
+  · refine iSup_le fun s ↦ sup_le ?_ le_sup_right
+    intro x hx
+    obtain ⟨u, v, hu1, -, -, hdv, rfl⟩ := K.B_cases hx
+    refine add_mem (Submodule.mem_sup_right hu1) (Submodule.mem_sup_left ?_)
+    exact Submodule.mem_sup_right ⟨hdv, ⟨v, rfl⟩⟩
+  · refine le_trans ?_ (le_iSup (fun s : ℕ ↦ K.B (s : ℤ) p ⊔ K.F (p + 1)) N)
+    rw [K.B_eq_abutmentB hbotN htopN]
+
+/-- Intersecting the associated-graded cycle numerator with the normalized
+boundary denominator recovers the unnormalized boundary denominator. -/
+lemma abutmentZ_inf_abutmentB_sup_F_eq_abutmentB (p : ℤ) :
+    K.abutmentZ p ⊓ (K.abutmentB p ⊔ K.F (p + 1)) = K.abutmentB p := by
+  apply le_antisymm
+  · rintro x ⟨hxZ, hx⟩
+    obtain ⟨b, hb, f, hf, rfl⟩ := Submodule.mem_sup.mp hx
+    refine add_mem hb ?_
+    have hfker : f ∈ ker K.d := by
+      have hbker : b ∈ ker K.d := (K.abutmentB_le_abutmentZ p hb).2
+      simpa using sub_mem hxZ.2 hbker
+    exact Submodule.mem_sup_left ⟨hf, hfker⟩
+  · exact le_inf (K.abutmentB_le_abutmentZ p) le_sup_left
+
+/-- The associated-graded homology target in its normalized presentation inside
+`E₀^p`: adjoining `F^{p+1}` to both numerator and denominator does not change
+the quotient. -/
+noncomputable def associatedGradedHomologyEquivNormalized (p : ℤ) :
+    K.associatedGradedHomology p ≃ₗ[R]
+      (↥(K.abutmentZ p ⊔ K.F (p + 1)) ⧸
+        ((K.abutmentB p ⊔ K.F (p + 1)).comap (K.abutmentZ p ⊔ K.F (p + 1)).subtype)) := by
+  let e := LinearMap.quotientInfEquivSupQuotient
+    (K.abutmentZ p) (K.abutmentB p ⊔ K.F (p + 1))
+  have hdom :
+      (K.abutmentB p).comap (K.abutmentZ p).subtype =
+        (K.abutmentZ p).comap (K.abutmentZ p).subtype ⊓
+          (K.abutmentB p ⊔ K.F (p + 1)).comap (K.abutmentZ p).subtype := by
+    ext x
+    change (x : M) ∈ K.abutmentB p ↔
+      (x : M) ∈ K.abutmentZ p ∧ (x : M) ∈ K.abutmentB p ⊔ K.F (p + 1)
+    rw [← Submodule.mem_inf, K.abutmentZ_inf_abutmentB_sup_F_eq_abutmentB]
+  have hnum : K.abutmentZ p ⊔ (K.abutmentB p ⊔ K.F (p + 1)) =
+      K.abutmentZ p ⊔ K.F (p + 1) := by
+    rw [← sup_assoc, sup_eq_left.mpr (K.abutmentB_le_abutmentZ p)]
+  rw [hnum] at e
+  exact (Submodule.quotEquivOfEq _ _ hdom).trans e
+
+/-- Under two-sided local bounds, the actual limit term is canonically
+isomorphic to the associated-graded homology target. -/
+noncomputable def pageInfEquivAssociatedGradedHomology {r p : ℤ}
+    (hbot : K.F (p + r) = ⊥) (htop : K.F (p - r + 1) = ⊤) :
+    K.pageInf p ≃ₗ[R] K.associatedGradedHomology p := by
+  let e₁ : K.pageInf p ≃ₗ[R]
+      (↥(K.abutmentZ p ⊔ K.F (p + 1)) ⧸
+        ((K.abutmentB p ⊔ K.F (p + 1)).comap (K.abutmentZ p ⊔ K.F (p + 1)).subtype)) :=
+    Submodule.Quotient.equiv _ _
+      (LinearEquiv.ofEq _ _ (K.limitZ_eq_abutmentZ_sup_F hbot)) (by
+        have hB := K.limitB_eq_abutmentB_sup_F hbot htop
+        ext x
+        simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
+        constructor
+        · rintro ⟨y, hy, rfl⟩
+          simpa [hB] using hy
+        · intro hx
+          refine ⟨(LinearEquiv.ofEq _ _ (K.limitZ_eq_abutmentZ_sup_F hbot)).symm x, ?_,
+            (LinearEquiv.ofEq _ _ (K.limitZ_eq_abutmentZ_sup_F hbot)).apply_symm_apply x⟩
+          simpa [hB] using hx)
+  exact e₁.trans (K.associatedGradedHomologyEquivNormalized p).symm
+
+/-- Once `r` is large enough that `F^{p+r} = ⊥` and `F^{p-r+1} = ⊤`, the `r`-th
+page at `p` is canonically isomorphic to the associated-graded homology target. -/
+noncomputable def pageEquivAssociatedGradedHomology {r p : ℤ}
+    (hbot : K.F (p + r) = ⊥) (htop : K.F (p - r + 1) = ⊤) :
+    K.page r p ≃ₗ[R] K.associatedGradedHomology p :=
+  Submodule.Quotient.equiv _ _ (LinearEquiv.ofEq _ _ (K.Z_eq_abutmentZ hbot)) (by
+    have hB := K.B_eq_abutmentB hbot htop
     ext ξ
     simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
     constructor
@@ -460,10 +637,18 @@ noncomputable def pageEquivPageInf {r p : ℤ} (hbot : K.F (p + r) = ⊥)
       rw [← hB]
       simpa using hη
     · intro hξ
-      refine ⟨(LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).symm ξ, ?_,
-        (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).apply_symm_apply ξ⟩
+      refine ⟨(LinearEquiv.ofEq _ _ (K.Z_eq_abutmentZ hbot)).symm ξ, ?_,
+        (LinearEquiv.ofEq _ _ (K.Z_eq_abutmentZ hbot)).apply_symm_apply ξ⟩
       rw [hB]
       simpa using hξ)
+
+/-- Under two-sided local bounds, the finite `r`-th page has stabilized to the
+limit term. -/
+noncomputable def pageEquivPageInf {r p : ℤ}
+    (hbot : K.F (p + r) = ⊥) (htop : K.F (p - r + 1) = ⊤) :
+    K.page r p ≃ₗ[R] K.pageInf p :=
+  (K.pageEquivAssociatedGradedHomology hbot htop).trans
+    (K.pageInfEquivAssociatedGradedHomology hbot htop).symm
 
 /-- Beyond the bound of the filtration, the differential leaving position `p` vanishes. -/
 theorem dPage_eq_zero {r p : ℤ} (hbot : K.F (p + r) = ⊥) : K.dPage r p = 0 := by
@@ -491,14 +676,14 @@ theorem dPageFrom_eq_zero {r p : ℤ} (htop : K.F (p - r + 1) = ⊤) :
   rw [htop]
   exact Submodule.mem_top
 
-/-! ### The limit page is the associated graded of homology -/
+/-! ### The associated-graded target -/
 
 /-- The homology `H = ker d / im d` of the underlying differential module. -/
 abbrev homology := ↥(ker K.d) ⧸ (range K.d).comap (ker K.d).subtype
 
 /-- The filtration induced on homology: `F^p H` is the image of `F^p ∩ ker d` in `H`. -/
 def FH (p : ℤ) : Submodule R K.homology :=
-  ((K.Zinf p).comap (ker K.d).subtype).map ((range K.d).comap (ker K.d).subtype).mkQ
+  ((K.abutmentZ p).comap (ker K.d).subtype).map ((range K.d).comap (ker K.d).subtype).mkQ
 
 lemma mem_FH_iff {p : ℤ} {h : K.homology} :
     h ∈ K.FH p ↔ ∃ z : ↥(ker K.d), (z : M) ∈ K.F p ∧ Submodule.Quotient.mk z = h := by
@@ -511,15 +696,15 @@ lemma mem_FH_iff {p : ℤ} {h : K.homology} :
     exact Submodule.mem_map.mpr
       ⟨z, Submodule.mem_comap.mpr (Submodule.mem_inf.mpr ⟨hz, z.2⟩), rfl⟩
 
-/-- The natural map `Z_∞^p → F^p H`. -/
-def toFH (p : ℤ) : ↥(K.Zinf p) →ₗ[R] ↥(K.FH p) :=
+/-- The natural map from the filtered cycle submodule `F^p ∩ ker d` to `F^p H`. -/
+def toFH (p : ℤ) : ↥(K.abutmentZ p) →ₗ[R] ↥(K.FH p) :=
   LinearMap.codRestrict _
-    (((range K.d).comap (ker K.d).subtype).mkQ.comp (Submodule.inclusion (K.Zinf_le_ker p)))
+    (((range K.d).comap (ker K.d).subtype).mkQ.comp (Submodule.inclusion (K.abutmentZ_le_ker p)))
     fun x ↦ Submodule.mem_map_of_mem (Submodule.mem_comap.mpr x.2)
 
-@[simp] lemma toFH_coe (p : ℤ) (x : ↥(K.Zinf p)) :
+@[simp] lemma toFH_coe (p : ℤ) (x : ↥(K.abutmentZ p)) :
     (K.toFH p x : K.homology) =
-      Submodule.Quotient.mk (Submodule.inclusion (K.Zinf_le_ker p) x) := rfl
+      Submodule.Quotient.mk (Submodule.inclusion (K.abutmentZ_le_ker p) x) := rfl
 
 lemma toFH_surjective (p : ℤ) : Function.Surjective (K.toFH p) := by
   rintro ⟨h, hmem⟩
@@ -529,8 +714,9 @@ lemma toFH_surjective (p : ℤ) : Function.Surjective (K.toFH p) := by
   rw [toFH_coe]
   exact congrArg _ (Subtype.ext rfl)
 
-/-- The composite `Z_∞^p → F^p H → F^p H / F^{p+1} H = gr^p H`. -/
-def toGrH (p : ℤ) : ↥(K.Zinf p) →ₗ[R]
+/-- The composite from filtered cycles to
+`F^p H → F^p H / F^{p+1} H = gr^p H`. -/
+def toGrH (p : ℤ) : ↥(K.abutmentZ p) →ₗ[R]
     (↥(K.FH p) ⧸ (K.FH (p + 1)).comap (K.FH p).subtype) :=
   ((K.FH (p + 1)).comap (K.FH p).subtype).mkQ.comp (K.toFH p)
 
@@ -540,7 +726,7 @@ lemma toGrH_surjective (p : ℤ) : Function.Surjective (K.toGrH p) := by
   simpa [toGrH, LinearMap.coe_comp] using h
 
 lemma ker_toGrH (p : ℤ) :
-    ker (K.toGrH p) = (K.Binf p).comap (K.Zinf p).subtype := by
+    ker (K.toGrH p) = (K.abutmentB p).comap (K.abutmentZ p).subtype := by
   ext ξ
   obtain ⟨x, hx⟩ := ξ
   have hxF : x ∈ K.F p := (Submodule.mem_inf.mp hx).1
@@ -552,9 +738,9 @@ lemma ker_toGrH (p : ℤ) :
     rw [Submodule.Quotient.eq] at hzeq
     have hd : (z : M) - x ∈ range K.d := by
       simpa using hzeq
-    have h1 : (z : M) ∈ K.Binf p :=
+    have h1 : (z : M) ∈ K.abutmentB p :=
       Submodule.mem_sup_left (Submodule.mem_inf.mpr ⟨hzF, z.2⟩)
-    have h2 : -((z : M) - x) ∈ K.Binf p :=
+    have h2 : -((z : M) - x) ∈ K.abutmentB p :=
       neg_mem (Submodule.mem_sup_right
         (Submodule.mem_inf.mpr ⟨sub_mem (K.F_le p hzF) hxF, hd⟩))
     have h3 := add_mem h1 h2
@@ -574,12 +760,23 @@ lemma ker_toGrH (p : ℤ) :
     rw [heq]
     exact neg_mem hw2
 
-/-- **Identification of the limit page**: `E_∞^p ≅ gr^p H`, the associated graded of
-homology with respect to the induced filtration. -/
-noncomputable def pageInfEquivGrHomology (p : ℤ) :
-    K.pageInf p ≃ₗ[R] (↥(K.FH p) ⧸ (K.FH (p + 1)).comap (K.FH p).subtype) :=
+/-- **Identification of the associated-graded target** with `gr^p H`, the associated
+graded of homology with respect to the induced filtration.  This is not an
+unconditional identification of the limit term `pageInf`. -/
+noncomputable def associatedGradedHomologyEquivGrHomology (p : ℤ) :
+    K.associatedGradedHomology p ≃ₗ[R]
+      (↥(K.FH p) ⧸ (K.FH (p + 1)).comap (K.FH p).subtype) :=
   (Submodule.quotEquivOfEq _ _ (K.ker_toGrH p).symm).trans
     ((K.toGrH p).quotKerEquivOfSurjective (K.toGrH_surjective p))
+
+/-- Under two-sided local bounds, the limit term is the associated graded of
+the induced filtration on homology. -/
+noncomputable def pageInfEquivGrHomology {r p : ℤ}
+    (hbot : K.F (p + r) = ⊥) (htop : K.F (p - r + 1) = ⊤) :
+    K.pageInf p ≃ₗ[R]
+      (↥(K.FH p) ⧸ (K.FH (p + 1)).comap (K.FH p).subtype) :=
+  (K.pageInfEquivAssociatedGradedHomology hbot htop).trans
+    (K.associatedGradedHomologyEquivGrHomology p)
 
 /-! ### Convergence for bounded filtrations -/
 
@@ -591,8 +788,9 @@ homology.  In particular the pages at each `p` are eventually constant. -/
 noncomputable def pageEquivGrHomologyOfBounded {a b r p : ℤ}
     (ha : K.F a = ⊤) (hb : K.F b = ⊥) (hr1 : b ≤ p + r) (hr2 : p - r + 1 ≤ a) :
     K.page r p ≃ₗ[R] (↥(K.FH p) ⧸ (K.FH (p + 1)).comap (K.FH p).subtype) :=
-  (K.pageEquivPageInf (le_bot_iff.mp (hb ▸ K.F_mono hr1))
-    (top_le_iff.mp (ha ▸ K.F_mono hr2))).trans (K.pageInfEquivGrHomology p)
+  (K.pageEquivAssociatedGradedHomology (le_bot_iff.mp (hb ▸ K.F_mono hr1))
+    (top_le_iff.mp (ha ▸ K.F_mono hr2))).trans
+      (K.associatedGradedHomologyEquivGrHomology p)
 
 /-- For bounded filtrations, consecutive large pages at `p` are isomorphic:
 the spectral sequence stabilizes. -/
@@ -604,25 +802,24 @@ noncomputable def pageSuccEquivPageOfBounded {a b r p : ℤ}
 
 /-! ### Convergence for unbounded filtrations
 
-Convergence does not require the filtration to be bounded.  We prove the classical
-unbounded statements:
+Useful convergence ingredients do not require the filtration to be two-sided
+bounded. We prove the standard unbounded convergence ingredients:
 
-* If the filtration is **separated** (`⨅ q, F^q = ⊥`) then the cocycles converge:
-  `⨅ r, Z_r^p = Z_∞^p` (`iInf_Z_eq_Zinf`).  No other hypothesis is needed.
+* If the filtration is **separated** (`⨅ q, F^q = ⊥`) then the raw cocycles
+  converge: `⨅ r, Z_r^p = abutmentZ p` (`iInf_Z_eq_abutmentZ`).  No other hypothesis is
+  needed.
 * If the filtration is **exhaustive** (`⨆ q, F^q = ⊤`) and `F^{p+r₀} = ⊥` for some
   `r₀` (boundedness on the *cocycle* side only — the filtration may well be
   unbounded below, so this covers e.g. exhaustive filtrations indexed by all of
-  `ℤ`), then the boundaries converge: `⨆_{r ≥ r₀}, B_r^p = B_∞^p`
-  (`iSup_B_eq_Binf`).
-* Under the same one-sided hypothesis `F^{p+r} = ⊥` there are natural *surjections*
-  `E_r^p ↠ E_{r'}^p ↠ E_∞^p` for `r ≤ r'` (`pageTransition`, `pageToPageInf`,
-  compatible by `pageToPageInf_comp_pageTransition`), and — assuming exhaustiveness —
-  every element of `ker(E_r^p → E_∞^p)` already dies on some finite page
-  (`exists_pageTransition_eq_zero`).  Together these say `E_∞^p = colim_r E_r^p`:
-  the spectral sequence of an exhaustive filtration that is bounded on the cocycle
-  side converges to `gr H` (via `pageInfEquivGrHomology`), even when the filtration
-  is unbounded.  This is the classical convergence theorem (compare Weibel,
-  *An Introduction to Homological Algebra*, Theorem 5.5.1).
+  `ℤ`), then the raw boundaries converge: `⨆_{r ≥ r₀}, B_r^p = abutmentB p`
+  (`iSup_B_eq_abutmentB`).
+* Under the same one-sided hypothesis `F^{p+r} = ⊥` there are natural
+  surjections from `E_r^p` to later pages and to the associated-graded homology
+  target (`pageTransition`, `pageToAssociatedGradedHomology`).  Assuming
+  exhaustiveness, every element in the kernel of the latter map dies on some
+  finite page (`exists_pageTransition_eq_zero`).  These are the elementwise
+  ingredients for the usual convergence/colimit statement; no categorical
+  colimit universal property is asserted here.
 
 Without such hypotheses convergence genuinely fails (Boardman); the missing
 ingredient in general is completeness of the filtration. -/
@@ -632,11 +829,12 @@ lemma F_add_bot_of_le {r r' p : ℤ} (hbot : K.F (p + r) = ⊥) (h : r ≤ r') :
   le_bot_iff.mp (hbot ▸ K.F_mono (by omega))
 
 /-- **Cocycle convergence for separated filtrations**: if `⨅ q, F^q = ⊥`, then
-`Z_∞^p` is exactly the intersection of the `Z_r^p`, with no boundedness hypothesis. -/
-theorem iInf_Z_eq_Zinf (hsep : ⨅ q, K.F q = ⊥) (p : ℤ) :
-    ⨅ r : ℤ, K.Z r p = K.Zinf p := by
+`abutmentZ p = F^p ∩ ker d` is exactly the intersection of the raw `Z_r^p`, with no
+boundedness hypothesis. -/
+theorem iInf_Z_eq_abutmentZ (hsep : ⨅ q, K.F q = ⊥) (p : ℤ) :
+    ⨅ r : ℤ, K.Z r p = K.abutmentZ p := by
   ext x
-  simp only [Submodule.mem_iInf, mem_Z, Zinf, Submodule.mem_inf, LinearMap.mem_ker]
+  simp only [Submodule.mem_iInf, mem_Z, abutmentZ, Submodule.mem_inf, LinearMap.mem_ker]
   constructor
   · intro h
     refine ⟨(h 0).1, ?_⟩
@@ -652,7 +850,7 @@ theorem iInf_Z_eq_Zinf (hsep : ⨅ q, K.F q = ⊥) (p : ℤ) :
 lemma directed_F : Directed (· ≤ ·) K.F :=
   fun i j ↦ ⟨min i j, K.F_mono (min_le_left i j), K.F_mono (min_le_right i j)⟩
 
-lemma B_le_Binf {r p : ℤ} (hbot : K.F (p + r) = ⊥) : K.B r p ≤ K.Binf p := by
+lemma B_le_abutmentB {r p : ℤ} (hbot : K.F (p + r) = ⊥) : K.B r p ≤ K.abutmentB p := by
   refine sup_le ?_ ?_
   · rw [hbot, Submodule.comap_bot]
     exact le_sup_left
@@ -671,12 +869,12 @@ lemma B_mono_of_bot {r r' p : ℤ} (hbot : K.F (p + r) = ⊥) (h : r ≤ r') :
   · exact le_trans (inf_le_inf_left _ (Submodule.map_mono (K.F_mono (by omega)))) le_sup_right
 
 /-- **Boundary convergence for exhaustive filtrations**: if `⨆ q, F^q = ⊤` and
-`F^{p+r₀} = ⊥`, then `B_∞^p` is exactly the (directed) union of the `B_r^p` for
-`r ≥ r₀` — even when the filtration is unbounded below. -/
-theorem iSup_B_eq_Binf {r₀ p : ℤ} (hbot : K.F (p + r₀) = ⊥) (hexh : ⨆ q, K.F q = ⊤) :
-    ⨆ r, ⨆ (_ : r₀ ≤ r), K.B r p = K.Binf p := by
+`F^{p+r₀} = ⊥`, then `abutmentB p` is exactly the directed union of the raw `B_r^p`
+for `r ≥ r₀`, even when the filtration is unbounded below. -/
+theorem iSup_B_eq_abutmentB {r₀ p : ℤ} (hbot : K.F (p + r₀) = ⊥) (hexh : ⨆ q, K.F q = ⊤) :
+    ⨆ r, ⨆ (_ : r₀ ≤ r), K.B r p = K.abutmentB p := by
   apply le_antisymm
-  · exact iSup₂_le fun r hr ↦ K.B_le_Binf (K.F_add_bot_of_le hbot hr)
+  · exact iSup₂_le fun r hr ↦ K.B_le_abutmentB (K.F_add_bot_of_le hbot hr)
   · refine sup_le ?_ ?_
     · refine le_trans ?_ (le_iSup₂ (f := fun r _ ↦ K.B r p) r₀ le_rfl)
       refine le_trans (inf_le_inf_left _ ?_) le_sup_left
@@ -692,35 +890,38 @@ theorem iSup_B_eq_Binf {r₀ p : ℤ} (hbot : K.F (p + r₀) = ⊥) (hexh : ⨆ 
           (K.F_mono (by have := le_max_right r₀ (p + 1 - q); omega) hq) hx1
       exact le_iSup₂ (f := fun r _ ↦ K.B r p) (max r₀ (p + 1 - q)) (le_max_left _ _) hmem
 
-/-- Once `F^{p+r} = ⊥`, the natural surjection from the `r`-th page onto the limit
-page.  (For smaller `r` there is no natural map in general.) -/
-def pageToPageInf {r p : ℤ} (hbot : K.F (p + r) = ⊥) :
-    K.page r p →ₗ[R] K.pageInf p :=
-  Submodule.mapQ _ _ (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).toLinearMap (by
+/-- Once `F^{p+r} = ⊥`, the natural surjection from the `r`-th page onto the
+associated-graded homology target.  This is a map to the abutment candidate,
+not an unconditional map to the limit term `pageInf`. -/
+def pageToAssociatedGradedHomology {r p : ℤ} (hbot : K.F (p + r) = ⊥) :
+    K.page r p →ₗ[R] K.associatedGradedHomology p :=
+  Submodule.mapQ _ _ (LinearEquiv.ofEq _ _ (K.Z_eq_abutmentZ hbot)).toLinearMap (by
     intro ζ hζ
     simp only [Submodule.mem_comap, Submodule.coe_subtype, LinearEquiv.coe_coe,
       LinearEquiv.coe_ofEq_apply] at hζ ⊢
-    exact K.B_le_Binf hbot hζ)
+    exact K.B_le_abutmentB hbot hζ)
 
-@[simp] lemma pageToPageInf_mk {r p : ℤ} (hbot : K.F (p + r) = ⊥) (ζ : ↥(K.Z r p)) :
-    K.pageToPageInf hbot (Submodule.Quotient.mk ζ) =
-      Submodule.Quotient.mk (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot) ζ) :=
+@[simp] lemma pageToAssociatedGradedHomology_mk {r p : ℤ}
+    (hbot : K.F (p + r) = ⊥) (ζ : ↥(K.Z r p)) :
+    K.pageToAssociatedGradedHomology hbot (Submodule.Quotient.mk ζ) =
+      Submodule.Quotient.mk (LinearEquiv.ofEq _ _ (K.Z_eq_abutmentZ hbot) ζ) :=
   Submodule.mapQ_apply _ _ _ ζ
 
-lemma pageToPageInf_surjective {r p : ℤ} (hbot : K.F (p + r) = ⊥) :
-    Function.Surjective (K.pageToPageInf hbot) := by
+lemma pageToAssociatedGradedHomology_surjective {r p : ℤ}
+    (hbot : K.F (p + r) = ⊥) :
+    Function.Surjective (K.pageToAssociatedGradedHomology hbot) := by
   intro ξ
   obtain ⟨ζ, rfl⟩ := Submodule.Quotient.mk_surjective _ ξ
-  refine ⟨Submodule.Quotient.mk ((LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).symm ζ), ?_⟩
-  rw [K.pageToPageInf_mk hbot]
-  exact congrArg _ ((LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).apply_symm_apply ζ)
+  refine ⟨Submodule.Quotient.mk ((LinearEquiv.ofEq _ _ (K.Z_eq_abutmentZ hbot)).symm ζ), ?_⟩
+  rw [K.pageToAssociatedGradedHomology_mk hbot]
+  exact congrArg _ ((LinearEquiv.ofEq _ _ (K.Z_eq_abutmentZ hbot)).apply_symm_apply ζ)
 
 /-- The natural surjection `E_r^p ↠ E_{r'}^p` for `r ≤ r'`, in the range where the
 cocycles have stabilized. -/
 def pageTransition {r r' p : ℤ} (hbot : K.F (p + r) = ⊥) (h : r ≤ r') :
     K.page r p →ₗ[R] K.page r' p :=
   Submodule.mapQ _ _ (LinearEquiv.ofEq _ _ (by
-      rw [K.Z_eq_Zinf hbot, K.Z_eq_Zinf (K.F_add_bot_of_le hbot h)])).toLinearMap (by
+      rw [K.Z_eq_abutmentZ hbot, K.Z_eq_abutmentZ (K.F_add_bot_of_le hbot h)])).toLinearMap (by
     intro ζ hζ
     simp only [Submodule.mem_comap, Submodule.coe_subtype, LinearEquiv.coe_coe,
       LinearEquiv.coe_ofEq_apply] at hζ ⊢
@@ -730,32 +931,34 @@ def pageTransition {r r' p : ℤ} (hbot : K.F (p + r) = ⊥) (h : r ≤ r') :
     (ζ : ↥(K.Z r p)) :
     K.pageTransition hbot h (Submodule.Quotient.mk ζ) =
       Submodule.Quotient.mk ((LinearEquiv.ofEq _ _ (by
-        rw [K.Z_eq_Zinf hbot, K.Z_eq_Zinf (K.F_add_bot_of_le hbot h)])) ζ) :=
+        rw [K.Z_eq_abutmentZ hbot, K.Z_eq_abutmentZ (K.F_add_bot_of_le hbot h)])) ζ) :=
   Submodule.mapQ_apply _ _ _ ζ
 
-/-- The surjections onto later pages are compatible with the surjection onto the
-limit page. -/
-theorem pageToPageInf_comp_pageTransition {r r' p : ℤ} (hbot : K.F (p + r) = ⊥)
+/-- The surjections onto later pages are compatible with the map to the
+associated-graded homology target. -/
+theorem pageToAssociatedGradedHomology_comp_pageTransition {r r' p : ℤ}
+    (hbot : K.F (p + r) = ⊥)
     (h : r ≤ r') :
-    (K.pageToPageInf (K.F_add_bot_of_le hbot h)).comp (K.pageTransition hbot h) =
-      K.pageToPageInf hbot := by
+    (K.pageToAssociatedGradedHomology (K.F_add_bot_of_le hbot h)).comp
+      (K.pageTransition hbot h) = K.pageToAssociatedGradedHomology hbot := by
   apply Submodule.linearMap_qext
   ext ζ
-  simp only [LinearMap.comp_apply, Submodule.mkQ_apply, pageTransition_mk, pageToPageInf_mk]
+  simp only [LinearMap.comp_apply, Submodule.mkQ_apply, pageTransition_mk,
+    pageToAssociatedGradedHomology_mk]
   exact congrArg Submodule.Quotient.mk (Subtype.ext rfl)
 
-/-- **The classical convergence theorem, unbounded case**: suppose `F^{p+r} = ⊥`
+/-- **Eventual-kernel statement for an unbounded filtration**: suppose `F^{p+r} = ⊥`
 (one-sided bound) and the filtration is exhaustive (`⨆ q, F^q = ⊤`), but otherwise
 arbitrary — in particular possibly unbounded below.  Then every element of the
-kernel of `E_r^p ↠ E_∞^p` already vanishes on some finite page `E_{r'}^p`.
-Combined with the surjectivity of `pageToPageInf` and `pageInfEquivGrHomology`,
-this says that `E_∞^p = colim_r E_r^p ≅ gr^p H`. -/
+kernel of the map from `E_r^p` to the associated-graded homology target already
+vanishes on some finite page `E_{r'}^p`. -/
 theorem exists_pageTransition_eq_zero {r p : ℤ} (hbot : K.F (p + r) = ⊥)
-    (hexh : ⨆ q, K.F q = ⊤) (ξ : K.page r p) (hξ : K.pageToPageInf hbot ξ = 0) :
+    (hexh : ⨆ q, K.F q = ⊤) (ξ : K.page r p)
+    (hξ : K.pageToAssociatedGradedHomology hbot ξ = 0) :
     ∃ (r' : ℤ) (h : r ≤ r'), K.pageTransition hbot h ξ = 0 := by
   obtain ⟨ζ, rfl⟩ := Submodule.Quotient.mk_surjective _ ξ
-  rw [K.pageToPageInf_mk hbot, Submodule.Quotient.mk_eq_zero] at hξ
-  have hζB : (ζ : M) ∈ K.Binf p := by
+  rw [K.pageToAssociatedGradedHomology_mk hbot, Submodule.Quotient.mk_eq_zero] at hξ
+  have hζB : (ζ : M) ∈ K.abutmentB p := by
     simpa using hξ
   obtain ⟨u, hu, w, hw, hsum⟩ := Submodule.mem_sup.mp hζB
   obtain ⟨hu1, hu2⟩ := Submodule.mem_inf.mp hu
@@ -796,6 +999,56 @@ structure Hom (K : FilteredDifferentialModule R M) (K' : FilteredDifferentialMod
   comm_d : ∀ x : M, toLinearMap (K.d x) = K'.d (toLinearMap x)
   /-- The map preserves the filtrations. -/
   map_F : ∀ (p : ℤ), ∀ x ∈ K.F p, toLinearMap x ∈ K'.F p
+
+namespace Hom
+
+variable {M'' : Type*} [AddCommGroup M''] [Module R M'']
+variable {K : FilteredDifferentialModule R M} {K' : FilteredDifferentialModule R M'}
+  {K'' : FilteredDifferentialModule R M''}
+
+@[ext]
+lemma ext {φ ψ : Hom K K'} (h : φ.toLinearMap = ψ.toLinearMap) : φ = ψ := by
+  cases φ
+  cases ψ
+  cases h
+  rfl
+
+/-- The identity morphism of a filtered differential module. -/
+def id (K : FilteredDifferentialModule R M) : Hom K K where
+  toLinearMap := LinearMap.id
+  comm_d := fun _ ↦ rfl
+  map_F := fun _ _ hx ↦ hx
+
+/-- Composition of morphisms of filtered differential modules. -/
+def comp (ψ : Hom K' K'') (φ : Hom K K') : Hom K K'' where
+  toLinearMap := ψ.toLinearMap.comp φ.toLinearMap
+  comm_d := fun x ↦ by rw [LinearMap.comp_apply, φ.comm_d, ψ.comm_d, LinearMap.comp_apply]
+  map_F := fun p x hx ↦ ψ.map_F p _ (φ.map_F p x hx)
+
+@[simp] lemma id_toLinearMap (K : FilteredDifferentialModule R M) :
+    (id K).toLinearMap = LinearMap.id := rfl
+
+@[simp] lemma comp_toLinearMap (ψ : Hom K' K'') (φ : Hom K K') :
+    (ψ.comp φ).toLinearMap = ψ.toLinearMap.comp φ.toLinearMap := rfl
+
+@[simp] lemma id_comp (φ : Hom K K') : (id K').comp φ = φ := by
+  apply ext
+  ext x
+  rfl
+
+@[simp] lemma comp_id (φ : Hom K K') : φ.comp (id K) = φ := by
+  apply ext
+  ext x
+  rfl
+
+lemma comp_assoc {M''' : Type*} [AddCommGroup M'''] [Module R M''']
+    {K''' : FilteredDifferentialModule R M'''} (χ : Hom K'' K''')
+    (ψ : Hom K' K'') (φ : Hom K K') : (χ.comp ψ).comp φ = χ.comp (ψ.comp φ) := by
+  apply ext
+  ext x
+  rfl
+
+end Hom
 
 /-- `B_r ∩ Z_{r+1} ⊆ B_{r+1}`: an `(r+1)`-cocycle which is an `r`-boundary is an
 `(r+1)`-boundary. -/
@@ -849,6 +1102,31 @@ def mapPage (r p : ℤ) : K.page r p →ₗ[R] K'.page r p :=
 @[simp] lemma mapPage_mk (r p : ℤ) (x : ↥(K.Z r p)) :
     φ.mapPage r p (Submodule.Quotient.mk x) = Submodule.Quotient.mk (φ.mapZ r p x) :=
   Submodule.mapQ_apply _ _ _ x
+
+@[simp] lemma mapZ_id (K : FilteredDifferentialModule R M) (r p : ℤ) :
+    (Hom.id K).mapZ r p = LinearMap.id := by
+  ext x
+  rfl
+
+@[simp] lemma mapZ_comp {M'' : Type*} [AddCommGroup M''] [Module R M'']
+    {K'' : FilteredDifferentialModule R M''} (ψ : Hom K' K'') (φ : Hom K K')
+    (r p : ℤ) : (ψ.comp φ).mapZ r p = (ψ.mapZ r p).comp (φ.mapZ r p) := by
+  ext x
+  rfl
+
+@[simp] lemma mapPage_id (K : FilteredDifferentialModule R M) (r p : ℤ) :
+    (Hom.id K).mapPage r p = LinearMap.id := by
+  apply Submodule.linearMap_qext
+  ext x
+  rfl
+
+@[simp] lemma mapPage_comp {M'' : Type*} [AddCommGroup M''] [Module R M'']
+    {K'' : FilteredDifferentialModule R M''} (ψ : Hom K' K'') (φ : Hom K K')
+    (r p : ℤ) :
+    (ψ.comp φ).mapPage r p = (ψ.mapPage r p).comp (φ.mapPage r p) := by
+  apply Submodule.linearMap_qext
+  ext x
+  rfl
 
 /-- Naturality: the induced maps on pages commute with the differentials. -/
 theorem mapPage_dPageAux (r p q : ℤ) (hq : q = p + r) :
@@ -1022,12 +1300,12 @@ noncomputable def totalD : (⨁ n, X n) →ₗ[R] ⨁ n, X n :=
 def totalF (p : ℤ) : Submodule R (⨁ n, X n) :=
   ⨆ n, (F p n).map (DirectSum.lof R ℤ X n)
 
-/-- **The filtered differential module associated to a filtered cochain complex**
-(Stacks Project, tag 012K).  Here `X` is a `ℤ`-indexed cochain complex with
+/-- **The filtered differential module associated to raw cochain-complex data**
+(Stacks Project, tag 012K).  Here `X` is a `ℤ`-indexed family with
 differentials `d n : X n → X (n+1)` squaring to zero, and `F` is a decreasing
-filtration by subcomplexes.  The pages, differentials and homology isomorphism
-of the spectral sequence of the filtered complex are `(ofComplex ...).page`,
-`(ofComplex ...).dPage` and `(ofComplex ...).pageSuccEquiv`. -/
+filtration preserved by the differential.  The primary graded API for a
+filtered complex is `FilteredComplex`; this constructor is useful when an
+ungraded total differential module is specifically desired. -/
 noncomputable def ofComplex
     (hd : ∀ (n : ℤ) (x : X n), d (n + 1) (d n x) = 0)
     (hF : ∀ p n, F (p + 1) n ≤ F p n)

--- a/FLT/Slop/SpectralSequence/FilteredModule.lean
+++ b/FLT/Slop/SpectralSequence/FilteredModule.lean
@@ -1,0 +1,1066 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import Mathlib.LinearAlgebra.Isomorphisms
+public import Mathlib.Algebra.DirectSum.Module
+public import Mathlib.Tactic.Abel
+public import Mathlib.Tactic.Ring
+
+/-!
+# The spectral sequence of a filtered complex
+
+This file formalizes the construction of the spectral sequence associated to a
+filtered differential object, following the Stacks Project:
+
+* Section 12.23 (tag 012A): "Spectral sequences: filtered differential objects"
+* Section 12.24 (tag 012K): "Spectral sequences: filtered complexes"
+
+Following the Stacks Project, the heart of the construction is the case of a
+*filtered differential object*: a module `M` equipped with a differential
+`d : M →ₗ[R] M` satisfying `d ∘ d = 0` and a decreasing filtration
+`F : ℤ → Submodule R M` preserved by `d`.  The spectral sequence of a filtered
+*complex* is obtained by applying this construction to the total differential
+module `⨁ n, X n` (see the final section of this file); the extra grading only
+refines each page into a direct sum, it plays no role in the construction of
+the pages and differentials.
+
+## Main definitions
+
+Let `K = (M, d, F)` be a filtered differential module.  For `r p : ℤ` we define
+(compare Stacks, tag 012A; we use the equivalent presentation of `E_r^p` as a
+quotient of the "absolute" cocycle module, which agrees with the Stacks
+subquotient-of-`gr^p` definition by the modular law):
+
+* `K.Z r p = F^p ∩ d⁻¹(F^{p+r})`, the `r`-cocycles;
+* `K.B r p = (F^{p+1} ∩ d⁻¹(F^{p+r})) + (F^p ∩ d(F^{p-r+1}))`, the `r`-boundaries;
+* `K.page r p = Z_r^p / B_r^p`, the `p`-th piece of the `r`-th page `E_r^p`;
+* `K.dPage r p : E_r^p → E_r^{p+r}`, the differential `d_r`, induced by `d`.
+
+## Main results
+
+* `dPageAux_comp`: `d_r ∘ d_r = 0`.
+* `pageSuccEquiv`: the main theorem, `E_{r+1}^p ≅ ker(d_r^p) / im(d_r^{p-r})`,
+  i.e. each page is the homology of the previous one.
+* `Z_zero`, `B_zero`: identification of the `0`-th page with the associated
+  graded `gr^p M = F^p/F^{p+1}` (so `E_1 = H(gr M)` is the case `r = 0` of the
+  main theorem).
+
+## Convergence
+
+We define the limit page `pageInf` (`E_∞^p = (F^p ∩ ker d)/((F^{p+1} ∩ ker d) + (F^p ∩ im d))`)
+and the induced filtration `FH` on the homology `H = ker d / im d`, and prove:
+
+* `pageEquivPageInf` : `E_r^p ≅ E_∞^p` once `F^{p+r} = ⊥` and `F^{p-r+1} = ⊤`;
+* `dPage_eq_zero`, `dPageFrom_eq_zero` : the differentials at position `p` vanish
+  in the same range, so the spectral sequence degenerates there;
+* `pageInfEquivGrHomology` : `E_∞^p ≅ gr^p H`;
+* `pageEquivGrHomologyOfBounded` : **convergence** — for an exhaustive
+  (`F^a = ⊤`) and bounded (`F^b = ⊥`) filtration, `E_r^p ≅ gr^p H` for all
+  sufficiently large `r` (explicitly `b ≤ p + r` and `p - r + 1 ≤ a`), and in
+  particular the pages stabilize (`pageSuccEquivPageOfBounded`).
+
+For *unbounded* filtrations we prove the classical convergence statements:
+`iInf_Z_eq_Zinf` (cocycle convergence, assuming only separatedness
+`⨅ q, F^q = ⊥`), `iSup_B_eq_Binf` (boundary convergence, assuming
+exhaustiveness `⨆ q, F^q = ⊤` and a one-sided bound), and — under
+`F^{p+r} = ⊥` and exhaustiveness only, with the filtration possibly unbounded
+below — the natural surjections `pageTransition : E_r^p ↠ E_{r'}^p` and
+`pageToPageInf : E_r^p ↠ E_∞^p` together with `exists_pageTransition_eq_zero`,
+which exhibit `E_∞^p` as the colimit of the pages `E_r^p` (the classical
+convergence theorem; compare Weibel, Theorem 5.5.1).
+-/
+
+@[expose] public section
+
+open Submodule LinearMap
+
+variable (R : Type*) [Ring R] (M : Type*) [AddCommGroup M] [Module R M]
+
+/-- A **filtered differential module**: a module together with a differential squaring
+to zero and a decreasing `ℤ`-indexed filtration compatible with the differential.
+This is (the module version of) a *filtered differential object* in the sense of the
+Stacks Project, tag 012A. -/
+structure FilteredDifferentialModule where
+  /-- The differential. -/
+  d : M →ₗ[R] M
+  /-- The differential squares to zero. -/
+  d_squared : ∀ x : M, d (d x) = 0
+  /-- The filtration. -/
+  F : ℤ → Submodule R M
+  /-- The filtration is decreasing. -/
+  F_le : ∀ p : ℤ, F (p + 1) ≤ F p
+  /-- The differential preserves the filtration. -/
+  d_mem_F : ∀ (p : ℤ), ∀ x ∈ F p, d x ∈ F p
+
+namespace FilteredDifferentialModule
+
+variable {R M} (K : FilteredDifferentialModule R M)
+
+lemma F_mono {p q : ℤ} (h : p ≤ q) : K.F q ≤ K.F p := by
+  obtain ⟨n, rfl⟩ := Int.le.dest h
+  clear h
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    refine le_trans ?_ ih
+    have e : (p + (m + 1 : ℕ) : ℤ) = (p + m) + 1 := by push_cast; ring
+    rw [e]
+    exact K.F_le (p + m)
+
+/-! ## Cocycles, boundaries, and the pages -/
+
+/-- The `r`-cocycles in filtration degree `p`:  `Z_r^p = F^p ∩ d⁻¹(F^{p+r})`. -/
+def Z (r p : ℤ) : Submodule R M := K.F p ⊓ (K.F (p + r)).comap K.d
+
+/-- The `r`-boundaries in filtration degree `p`:
+`B_r^p = (F^{p+1} ∩ d⁻¹(F^{p+r})) + (F^p ∩ d(F^{p-r+1}))`. -/
+def B (r p : ℤ) : Submodule R M :=
+  (K.F (p + 1) ⊓ (K.F (p + r)).comap K.d) ⊔ (K.F p ⊓ (K.F (p - r + 1)).map K.d)
+
+lemma mem_Z {r p : ℤ} {x : M} :
+    x ∈ K.Z r p ↔ x ∈ K.F p ∧ K.d x ∈ K.F (p + r) := by
+  simp only [Z, Submodule.mem_inf, Submodule.mem_comap]
+
+lemma mem_B_left {r p : ℤ} {u : M} (h1 : u ∈ K.F (p + 1)) (h2 : K.d u ∈ K.F (p + r)) :
+    u ∈ K.B r p :=
+  Submodule.mem_sup_left (Submodule.mem_inf.mpr ⟨h1, Submodule.mem_comap.mpr h2⟩)
+
+lemma mem_B_right {r p : ℤ} {v : M} (hv : v ∈ K.F (p - r + 1)) (h : K.d v ∈ K.F p) :
+    K.d v ∈ K.B r p :=
+  Submodule.mem_sup_right (Submodule.mem_inf.mpr ⟨h, Submodule.mem_map_of_mem hv⟩)
+
+lemma B_cases {r p : ℤ} {x : M} (hx : x ∈ K.B r p) :
+    ∃ u v, u ∈ K.F (p + 1) ∧ K.d u ∈ K.F (p + r) ∧ v ∈ K.F (p - r + 1) ∧
+      K.d v ∈ K.F p ∧ x = u + K.d v := by
+  obtain ⟨u, hu, w, hw, rfl⟩ := Submodule.mem_sup.mp hx
+  obtain ⟨hu1, hu2⟩ := Submodule.mem_inf.mp hu
+  obtain ⟨hw1, hw2⟩ := Submodule.mem_inf.mp hw
+  obtain ⟨v, hv, rfl⟩ := Submodule.mem_map.mp hw2
+  exact ⟨u, v, hu1, Submodule.mem_comap.mp hu2, hv, hw1, rfl⟩
+
+lemma B_le_Z (r p : ℤ) : K.B r p ≤ K.Z r p := by
+  intro x hx
+  obtain ⟨u, v, hu1, hu2, hv, hdv, rfl⟩ := K.B_cases hx
+  refine add_mem (K.mem_Z.mpr ⟨K.F_le p hu1, hu2⟩) (K.mem_Z.mpr ⟨hdv, ?_⟩)
+  rw [K.d_squared v]
+  exact zero_mem _
+
+lemma Z_succ_le (r p : ℤ) : K.Z (r + 1) p ≤ K.Z r p := by
+  intro x hx
+  obtain ⟨h1, h2⟩ := K.mem_Z.mp hx
+  exact K.mem_Z.mpr ⟨h1, K.F_le (p + r) (by rwa [show p + r + 1 = p + (r + 1) by ring])⟩
+
+/-- The `p`-th piece `E_r^p = Z_r^p / B_r^p` of the `r`-th page of the spectral sequence. -/
+abbrev page (r p : ℤ) := ↥(K.Z r p) ⧸ (K.B r p).comap (K.Z r p).subtype
+
+/-! ## The differentials on the pages -/
+
+lemma d_mem_Z {r p q : ℤ} (hq : q = p + r) {x : M} (hx : x ∈ K.Z r p) :
+    K.d x ∈ K.Z r q := by
+  subst hq
+  obtain ⟨h1, h2⟩ := K.mem_Z.mp hx
+  refine K.mem_Z.mpr ⟨h2, ?_⟩
+  rw [K.d_squared x]
+  exact zero_mem _
+
+lemma d_mem_B {r p q : ℤ} (hq : q = p + r) {x : M} (hx : x ∈ K.B r p) :
+    K.d x ∈ K.B r q := by
+  subst hq
+  obtain ⟨u, v, hu1, hu2, hv, hdv, rfl⟩ := K.B_cases hx
+  rw [map_add]
+  refine add_mem ?_ ?_
+  · refine K.mem_B_right ?_ hu2
+    rwa [show p + r - r + 1 = p + 1 by ring]
+  · rw [K.d_squared v]
+    exact zero_mem _
+
+/-- The differential restricted to the `r`-cocycles, with flexible target degree. -/
+def dZ (r p q : ℤ) (hq : q = p + r) : ↥(K.Z r p) →ₗ[R] ↥(K.Z r q) :=
+  K.d.restrict fun _ hx ↦ K.d_mem_Z hq hx
+
+@[simp] lemma dZ_coe (r p q : ℤ) (hq : q = p + r) (x : ↥(K.Z r p)) :
+    (K.dZ r p q hq x : M) = K.d x := rfl
+
+/-- The differential on the `r`-th page, with flexible target degree. -/
+def dPageAux (r p q : ℤ) (hq : q = p + r) : K.page r p →ₗ[R] K.page r q :=
+  Submodule.mapQ _ _ (K.dZ r p q hq) (by
+    intro x hx
+    simp only [Submodule.mem_comap, Submodule.coe_subtype, dZ_coe] at hx ⊢
+    exact K.d_mem_B hq hx)
+
+@[simp] lemma dPageAux_mk (r p q : ℤ) (hq : q = p + r) (x : ↥(K.Z r p)) :
+    K.dPageAux r p q hq (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk (K.dZ r p q hq x) :=
+  Submodule.mapQ_apply _ _ _ x
+
+/-- The differential `d_r : E_r^p → E_r^{p+r}` of the `r`-th page. -/
+abbrev dPage (r p : ℤ) : K.page r p →ₗ[R] K.page r (p + r) :=
+  K.dPageAux r p (p + r) rfl
+
+/-- The differential `d_r : E_r^{p-r} → E_r^p` of the `r`-th page, arriving at
+filtration degree `p`. -/
+abbrev dPageFrom (r p : ℤ) : K.page r (p - r) →ₗ[R] K.page r p :=
+  K.dPageAux r (p - r) p (by ring)
+
+/-- The composite of two consecutive differentials on a page vanishes. -/
+theorem dPageAux_comp (r p q s : ℤ) (hq : q = p + r) (hs : s = q + r) :
+    (K.dPageAux r q s hs).comp (K.dPageAux r p q hq) = 0 := by
+  apply Submodule.linearMap_qext
+  ext ζ
+  have h0 : K.dZ r q s hs (K.dZ r p q hq ζ) = 0 := by
+    apply Subtype.ext
+    simp [K.d_squared]
+  simp [h0]
+
+theorem dPage_comp_dPageFrom (r p : ℤ) :
+    (K.dPage r p).comp (K.dPageFrom r p) = 0 :=
+  K.dPageAux_comp r (p - r) p (p + r) (by ring) rfl
+
+lemma range_dPageFrom_le_ker_dPage (r p : ℤ) :
+    range (K.dPageFrom r p) ≤ ker (K.dPage r p) := by
+  rintro _ ⟨η, rfl⟩
+  rw [LinearMap.mem_ker, ← LinearMap.comp_apply, K.dPage_comp_dPageFrom, LinearMap.zero_apply]
+
+/-! ## The zeroth page is the associated graded -/
+
+lemma Z_zero (p : ℤ) : K.Z 0 p = K.F p := by
+  refine le_antisymm inf_le_left fun x hx ↦ ?_
+  refine K.mem_Z.mpr ⟨hx, ?_⟩
+  rw [show p + (0 : ℤ) = p by ring]
+  exact K.d_mem_F p x hx
+
+lemma B_zero (p : ℤ) : K.B 0 p = K.F (p + 1) := by
+  apply le_antisymm
+  · refine sup_le inf_le_left (le_trans inf_le_right ?_)
+    rw [show p - 0 + 1 = p + 1 by ring]
+    intro x hx
+    obtain ⟨y, hy, rfl⟩ := Submodule.mem_map.mp hx
+    exact K.d_mem_F _ y hy
+  · intro x hx
+    refine K.mem_B_left hx ?_
+    rw [show p + (0 : ℤ) = p by ring]
+    exact K.d_mem_F p x (K.F_le p hx)
+
+/-! ## The main theorem: each page is the homology of the previous one
+
+We construct a surjection `Z_{r+1}^p → ker(d_r^p)/im(d_r^{p-r})` and compute its
+kernel to be `B_{r+1}^p`, yielding the isomorphism
+`E_{r+1}^p ≅ ker(d_r^p)/im(d_r^{p-r})`. -/
+
+section MainTheorem
+
+variable (r p : ℤ)
+
+/-- The natural map `Z_{r+1}^p → ker(d_r : E_r^p → E_r^{p+r})`. -/
+def toKer : ↥(K.Z (r + 1) p) →ₗ[R] ↥(ker (K.dPage r p)) :=
+  LinearMap.codRestrict _
+    (((K.B r p).comap (K.Z r p).subtype).mkQ.comp (Submodule.inclusion (K.Z_succ_le r p)))
+    fun z ↦ by
+      rw [LinearMap.mem_ker, LinearMap.comp_apply, Submodule.mkQ_apply, K.dPageAux_mk,
+        Submodule.Quotient.mk_eq_zero]
+      simp only [Submodule.mem_comap, Submodule.coe_subtype, dZ_coe, Submodule.coe_inclusion]
+      have hz := K.mem_Z.mp z.2
+      refine K.mem_B_left ?_ ?_
+      · rw [show p + r + 1 = p + (r + 1) by ring]
+        exact hz.2
+      · rw [K.d_squared]
+        exact zero_mem _
+
+@[simp] lemma toKer_coe (z : ↥(K.Z (r + 1) p)) :
+    (K.toKer r p z : K.page r p) =
+      Submodule.Quotient.mk (Submodule.inclusion (K.Z_succ_le r p) z) := rfl
+
+lemma toKer_surjective : Function.Surjective (K.toKer r p) := by
+  rintro ⟨c, hc⟩
+  obtain ⟨⟨z, hzZ⟩, rfl⟩ := Submodule.Quotient.mk_surjective _ c
+  rw [LinearMap.mem_ker, K.dPageAux_mk, Submodule.Quotient.mk_eq_zero] at hc
+  simp only [Submodule.mem_comap, Submodule.coe_subtype, dZ_coe] at hc
+  -- `hc : K.d z ∈ K.B r (p + r)`; decompose `d z = u + d v`.
+  obtain ⟨u, v, hu1, hu2, hv, hdv, hsum⟩ := K.B_cases hc
+  rw [show p + r - r + 1 = p + 1 by ring] at hv
+  have hzF : z ∈ K.F p := (K.mem_Z.mp hzZ).1
+  have hz' : z - v ∈ K.Z (r + 1) p := by
+    refine K.mem_Z.mpr ⟨sub_mem hzF (K.F_le p hv), ?_⟩
+    have hdz' : K.d (z - v) = u := by
+      rw [map_sub, hsum]
+      abel
+    rw [hdz', show p + (r + 1) = p + r + 1 by ring]
+    exact hu1
+  refine ⟨⟨z - v, hz'⟩, ?_⟩
+  apply Subtype.ext
+  rw [toKer_coe, Submodule.Quotient.eq]
+  simp only [Submodule.mem_comap, Submodule.coe_subtype, AddSubgroupClass.coe_sub,
+    Submodule.coe_inclusion]
+  have : z - v - z = -v := by abel
+  rw [this]
+  exact neg_mem (K.mem_B_left hv hdv)
+
+/-- The composite `Z_{r+1}^p → ker(d_r^p) → ker(d_r^p)/im(d_r^{p-r})`. -/
+def toHomology : ↥(K.Z (r + 1) p) →ₗ[R]
+    ↥(ker (K.dPage r p)) ⧸ (range (K.dPageFrom r p)).comap (ker (K.dPage r p)).subtype :=
+  ((range (K.dPageFrom r p)).comap (ker (K.dPage r p)).subtype).mkQ.comp (K.toKer r p)
+
+lemma toHomology_surjective : Function.Surjective (K.toHomology r p) := by
+  have h := (Submodule.mkQ_surjective
+    ((range (K.dPageFrom r p)).comap (ker (K.dPage r p)).subtype)).comp
+      (K.toKer_surjective r p)
+  simpa [toHomology, LinearMap.coe_comp] using h
+
+/-- Membership in the image of `d_r^{p-r}`, in concrete terms. -/
+lemma mk_mem_range_dPageFrom_iff (z : ↥(K.Z r p)) :
+    Submodule.Quotient.mk z ∈ range (K.dPageFrom r p) ↔
+      ∃ y ∈ K.Z r (p - r), K.d y - ↑z ∈ K.B r p := by
+  constructor
+  · rintro ⟨η, hη⟩
+    obtain ⟨y, rfl⟩ := Submodule.Quotient.mk_surjective _ η
+    refine ⟨↑y, y.2, ?_⟩
+    rw [K.dPageAux_mk, Submodule.Quotient.eq] at hη
+    simpa only [Submodule.mem_comap, Submodule.coe_subtype, AddSubgroupClass.coe_sub,
+      dZ_coe] using hη
+  · rintro ⟨y, hyZ, hy⟩
+    refine ⟨Submodule.Quotient.mk ⟨y, hyZ⟩, ?_⟩
+    rw [K.dPageAux_mk, Submodule.Quotient.eq]
+    simpa only [Submodule.mem_comap, Submodule.coe_subtype, AddSubgroupClass.coe_sub,
+      dZ_coe] using hy
+
+/-- Key computation, "⊇" direction: an element of `B_{r+1}^p` becomes, on the `r`-th
+page, a boundary for `d_r`. -/
+lemma exists_of_mem_B_succ {z : M} (hzB : z ∈ K.B (r + 1) p) :
+    ∃ y ∈ K.Z r (p - r), K.d y - z ∈ K.B r p := by
+  obtain ⟨u, v, hu1, hu2, hv, hdv, hsum⟩ := K.B_cases hzB
+  rw [show p - (r + 1) + 1 = p - r by ring] at hv
+  refine ⟨v, K.mem_Z.mpr ⟨hv, by rw [show p - r + r = p by ring]; exact hdv⟩, ?_⟩
+  have : K.d v - z = -u := by
+    rw [hsum]
+    abel
+  rw [this]
+  refine neg_mem (K.mem_B_left hu1 (K.F_le (p + r) ?_))
+  rw [show p + r + 1 = p + (r + 1) by ring]
+  exact hu2
+
+/-- Key computation, "⊆" direction: an `(r+1)`-cocycle which is a `d_r`-boundary on
+the `r`-th page lies in `B_{r+1}^p`. -/
+lemma mem_B_succ_of {z : M} (hz : z ∈ K.Z (r + 1) p)
+    (h : ∃ y ∈ K.Z r (p - r), K.d y - z ∈ K.B r p) : z ∈ K.B (r + 1) p := by
+  obtain ⟨y, hyZ, hy⟩ := h
+  obtain ⟨hy1, hy2⟩ := K.mem_Z.mp hyZ
+  rw [show p - r + r = p by ring] at hy2
+  obtain ⟨u, t, hu1, hu2, ht, hdt, hsum⟩ := K.B_cases hy
+  -- `hsum : d y - z = u + d t`.  Set `y' := y - t`; then `z = d y' - u`.
+  have hy' : y - t ∈ K.F (p - r) := sub_mem hy1 (K.F_le (p - r) ht)
+  have hdy' : K.d (y - t) ∈ K.F p := by
+    rw [map_sub]
+    exact sub_mem hy2 hdt
+  have hu_eq : K.d (y - t) - z = u := by
+    calc K.d (y - t) - z = K.d y - K.d t - z := by rw [map_sub]
+      _ = K.d y - z - K.d t := by abel
+      _ = u := by rw [hsum]; abel
+  have hz_eq : z = K.d (y - t) - u := by
+    rw [← hu_eq]
+    abel
+  have hdu : K.d u ∈ K.F (p + (r + 1)) := by
+    have hdu_eq : K.d u = -K.d z := by
+      rw [← hu_eq, map_sub, K.d_squared (y - t), zero_sub]
+    rw [hdu_eq]
+    exact neg_mem (K.mem_Z.mp hz).2
+  rw [hz_eq]
+  refine sub_mem ?_ (K.mem_B_left hu1 hdu)
+  refine K.mem_B_right ?_ hdy'
+  rw [show p - (r + 1) + 1 = p - r by ring]
+  exact hy'
+
+lemma ker_toHomology :
+    ker (K.toHomology r p) = (K.B (r + 1) p).comap (K.Z (r + 1) p).subtype := by
+  ext ζ
+  obtain ⟨z, hz⟩ := ζ
+  simp only [LinearMap.mem_ker, toHomology, LinearMap.comp_apply, Submodule.mkQ_apply,
+    Submodule.Quotient.mk_eq_zero, Submodule.mem_comap, Submodule.coe_subtype, toKer_coe]
+  rw [K.mk_mem_range_dPageFrom_iff]
+  simp only [Submodule.coe_inclusion]
+  exact ⟨fun h ↦ K.mem_B_succ_of r p hz h, fun h ↦ K.exists_of_mem_B_succ r p h⟩
+
+/-- **The spectral sequence of a filtered differential module** (Stacks Project,
+tag 012A): the `(r+1)`-st page is canonically isomorphic to the homology of the
+`r`-th page with respect to the differential `d_r`. -/
+noncomputable def pageSuccEquiv :
+    K.page (r + 1) p ≃ₗ[R]
+      (↥(ker (K.dPage r p)) ⧸
+        (range (K.dPageFrom r p)).comap (ker (K.dPage r p)).subtype) :=
+  (Submodule.quotEquivOfEq _ _ (K.ker_toHomology r p).symm).trans
+    ((K.toHomology r p).quotKerEquivOfSurjective (K.toHomology_surjective r p))
+
+end MainTheorem
+
+/-! ## Convergence
+
+We define the limit page `E_∞^p = (F^p ∩ ker d) / ((F^{p+1} ∩ ker d) + (F^p ∩ im d))`
+and prove the two halves of the convergence theorem for (suitably bounded)
+filtrations, following the Stacks Project (tag 012A):
+
+* **Stabilization**: if `F^{p+r} = ⊥` and `F^{p-r+1} = ⊤` (which happens for all
+  sufficiently large `r` when the filtration is exhaustive and bounded), then
+  `E_r^p = E_∞^p` on the nose (`Z_eq_Zinf`, `B_eq_Binf`, `pageEquivPageInf`), and
+  the differentials into and out of position `p` vanish (`dPage_eq_zero`,
+  `dPageFrom_eq_zero`).
+* **Identification of the limit**: `E_∞^p ≅ gr^p H(M, d)`, where the homology
+  `H = ker d / im d` carries the filtration `F^p H = im(F^p ∩ ker d → H)`
+  (`pageInfEquivGrHomology`).
+
+Combining the two (`pageEquivGrHomologyOfBounded`) gives the classical
+convergence statement `E_r^p ⇒ gr^p H` for bounded filtrations: the pages at
+each `p` are eventually constant, equal to the associated graded of homology. -/
+
+section Convergence
+
+lemma range_d_le_ker_d : range K.d ≤ ker K.d := by
+  rintro _ ⟨x, rfl⟩
+  exact LinearMap.mem_ker.mpr (K.d_squared x)
+
+/-- The infinite cocycles `Z_∞^p = F^p ∩ ker d`. -/
+def Zinf (p : ℤ) : Submodule R M := K.F p ⊓ ker K.d
+
+/-- The infinite boundaries `B_∞^p = (F^{p+1} ∩ ker d) + (F^p ∩ im d)`. -/
+def Binf (p : ℤ) : Submodule R M :=
+  (K.F (p + 1) ⊓ ker K.d) ⊔ (K.F p ⊓ range K.d)
+
+lemma Zinf_le_ker (p : ℤ) : K.Zinf p ≤ ker K.d := inf_le_right
+
+lemma Binf_le_Zinf (p : ℤ) : K.Binf p ≤ K.Zinf p :=
+  sup_le (inf_le_inf_right _ (K.F_le p))
+    (inf_le_inf_left _ (K.range_d_le_ker_d))
+
+/-- The limit page `E_∞^p = Z_∞^p / B_∞^p`. -/
+abbrev pageInf (p : ℤ) := ↥(K.Zinf p) ⧸ (K.Binf p).comap (K.Zinf p).subtype
+
+/-! ### Stabilization -/
+
+lemma Z_eq_Zinf {r p : ℤ} (hbot : K.F (p + r) = ⊥) : K.Z r p = K.Zinf p := by
+  unfold Z Zinf
+  rw [hbot, Submodule.comap_bot]
+
+lemma B_eq_Binf {r p : ℤ} (hbot : K.F (p + r) = ⊥) (htop : K.F (p - r + 1) = ⊤) :
+    K.B r p = K.Binf p := by
+  unfold B Binf
+  rw [hbot, htop, Submodule.comap_bot, Submodule.map_top]
+
+/-- Once `r` is large enough that `F^{p+r} = ⊥` and `F^{p-r+1} = ⊤`, the `r`-th page
+at `p` is (canonically isomorphic to) the limit page. -/
+noncomputable def pageEquivPageInf {r p : ℤ} (hbot : K.F (p + r) = ⊥)
+    (htop : K.F (p - r + 1) = ⊤) : K.page r p ≃ₗ[R] K.pageInf p :=
+  Submodule.Quotient.equiv _ _ (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)) (by
+    have hB := K.B_eq_Binf hbot htop
+    ext ξ
+    simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
+    constructor
+    · rintro ⟨η, hη, rfl⟩
+      rw [← hB]
+      simpa using hη
+    · intro hξ
+      refine ⟨(LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).symm ξ, ?_,
+        (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).apply_symm_apply ξ⟩
+      rw [hB]
+      simpa using hξ)
+
+/-- Beyond the bound of the filtration, the differential leaving position `p` vanishes. -/
+theorem dPage_eq_zero {r p : ℤ} (hbot : K.F (p + r) = ⊥) : K.dPage r p = 0 := by
+  apply Submodule.linearMap_qext
+  ext ζ
+  have h0 : K.dZ r p (p + r) rfl ζ = 0 := by
+    apply Subtype.ext
+    have h := (K.mem_Z.mp ζ.2).2
+    rw [hbot] at h
+    simpa using h
+  simp [h0]
+
+/-- Beyond the bound of the filtration, the differential arriving at position `p` vanishes. -/
+theorem dPageFrom_eq_zero {r p : ℤ} (htop : K.F (p - r + 1) = ⊤) :
+    K.dPageFrom r p = 0 := by
+  apply Submodule.linearMap_qext
+  ext ζ
+  simp only [LinearMap.comp_apply, Submodule.mkQ_apply, K.dPageAux_mk, LinearMap.zero_comp,
+    LinearMap.zero_apply, Submodule.Quotient.mk_eq_zero, Submodule.mem_comap,
+    Submodule.coe_subtype, dZ_coe]
+  have h2 : K.d (ζ : M) ∈ K.F p := by
+    have h := (K.mem_Z.mp ζ.2).2
+    rwa [show p - r + r = p by ring] at h
+  refine K.mem_B_right ?_ h2
+  rw [htop]
+  exact Submodule.mem_top
+
+/-! ### The limit page is the associated graded of homology -/
+
+/-- The homology `H = ker d / im d` of the underlying differential module. -/
+abbrev homology := ↥(ker K.d) ⧸ (range K.d).comap (ker K.d).subtype
+
+/-- The filtration induced on homology: `F^p H` is the image of `F^p ∩ ker d` in `H`. -/
+def FH (p : ℤ) : Submodule R K.homology :=
+  ((K.Zinf p).comap (ker K.d).subtype).map ((range K.d).comap (ker K.d).subtype).mkQ
+
+lemma mem_FH_iff {p : ℤ} {h : K.homology} :
+    h ∈ K.FH p ↔ ∃ z : ↥(ker K.d), (z : M) ∈ K.F p ∧ Submodule.Quotient.mk z = h := by
+  constructor
+  · intro hh
+    obtain ⟨ζ, hζ, rfl⟩ := Submodule.mem_map.mp hh
+    have := Submodule.mem_comap.mp hζ
+    exact ⟨ζ, (Submodule.mem_inf.mp this).1, rfl⟩
+  · rintro ⟨z, hz, rfl⟩
+    exact Submodule.mem_map.mpr
+      ⟨z, Submodule.mem_comap.mpr (Submodule.mem_inf.mpr ⟨hz, z.2⟩), rfl⟩
+
+/-- The natural map `Z_∞^p → F^p H`. -/
+def toFH (p : ℤ) : ↥(K.Zinf p) →ₗ[R] ↥(K.FH p) :=
+  LinearMap.codRestrict _
+    (((range K.d).comap (ker K.d).subtype).mkQ.comp (Submodule.inclusion (K.Zinf_le_ker p)))
+    fun x ↦ Submodule.mem_map_of_mem (Submodule.mem_comap.mpr x.2)
+
+@[simp] lemma toFH_coe (p : ℤ) (x : ↥(K.Zinf p)) :
+    (K.toFH p x : K.homology) =
+      Submodule.Quotient.mk (Submodule.inclusion (K.Zinf_le_ker p) x) := rfl
+
+lemma toFH_surjective (p : ℤ) : Function.Surjective (K.toFH p) := by
+  rintro ⟨h, hmem⟩
+  obtain ⟨ζ, hζ, rfl⟩ := Submodule.mem_map.mp hmem
+  refine ⟨⟨↑ζ, Submodule.mem_comap.mp hζ⟩, ?_⟩
+  apply Subtype.ext
+  rw [toFH_coe]
+  exact congrArg _ (Subtype.ext rfl)
+
+/-- The composite `Z_∞^p → F^p H → F^p H / F^{p+1} H = gr^p H`. -/
+def toGrH (p : ℤ) : ↥(K.Zinf p) →ₗ[R]
+    (↥(K.FH p) ⧸ (K.FH (p + 1)).comap (K.FH p).subtype) :=
+  ((K.FH (p + 1)).comap (K.FH p).subtype).mkQ.comp (K.toFH p)
+
+lemma toGrH_surjective (p : ℤ) : Function.Surjective (K.toGrH p) := by
+  have h := (Submodule.mkQ_surjective
+    ((K.FH (p + 1)).comap (K.FH p).subtype)).comp (K.toFH_surjective p)
+  simpa [toGrH, LinearMap.coe_comp] using h
+
+lemma ker_toGrH (p : ℤ) :
+    ker (K.toGrH p) = (K.Binf p).comap (K.Zinf p).subtype := by
+  ext ξ
+  obtain ⟨x, hx⟩ := ξ
+  have hxF : x ∈ K.F p := (Submodule.mem_inf.mp hx).1
+  simp only [LinearMap.mem_ker, toGrH, LinearMap.comp_apply, Submodule.mkQ_apply,
+    Submodule.Quotient.mk_eq_zero, Submodule.mem_comap, Submodule.coe_subtype, toFH_coe]
+  rw [K.mem_FH_iff]
+  constructor
+  · rintro ⟨z, hzF, hzeq⟩
+    rw [Submodule.Quotient.eq] at hzeq
+    have hd : (z : M) - x ∈ range K.d := by
+      simpa using hzeq
+    have h1 : (z : M) ∈ K.Binf p :=
+      Submodule.mem_sup_left (Submodule.mem_inf.mpr ⟨hzF, z.2⟩)
+    have h2 : -((z : M) - x) ∈ K.Binf p :=
+      neg_mem (Submodule.mem_sup_right
+        (Submodule.mem_inf.mpr ⟨sub_mem (K.F_le p hzF) hxF, hd⟩))
+    have h3 := add_mem h1 h2
+    have heq : (z : M) + -((z : M) - x) = x := by abel
+    rwa [heq] at h3
+  · intro hxB
+    obtain ⟨u, hu, w, hw, hsum⟩ := Submodule.mem_sup.mp hxB
+    obtain ⟨hu1, hu2⟩ := Submodule.mem_inf.mp hu
+    obtain ⟨hw1, hw2⟩ := Submodule.mem_inf.mp hw
+    refine ⟨⟨u, hu2⟩, hu1, ?_⟩
+    rw [Submodule.Quotient.eq]
+    simp only [Submodule.mem_comap, Submodule.coe_subtype, AddSubgroupClass.coe_sub,
+      Submodule.coe_inclusion]
+    have heq : u - x = -w := by
+      rw [← hsum]
+      abel
+    rw [heq]
+    exact neg_mem hw2
+
+/-- **Identification of the limit page**: `E_∞^p ≅ gr^p H`, the associated graded of
+homology with respect to the induced filtration. -/
+noncomputable def pageInfEquivGrHomology (p : ℤ) :
+    K.pageInf p ≃ₗ[R] (↥(K.FH p) ⧸ (K.FH (p + 1)).comap (K.FH p).subtype) :=
+  (Submodule.quotEquivOfEq _ _ (K.ker_toGrH p).symm).trans
+    ((K.toGrH p).quotKerEquivOfSurjective (K.toGrH_surjective p))
+
+/-! ### Convergence for bounded filtrations -/
+
+/-- **Convergence of the spectral sequence of a filtered differential module**
+(Stacks Project, tag 012A): if the filtration is exhaustive (`F^a = ⊤`) and bounded
+(`F^b = ⊥`), then for every `r` large enough (explicitly, `b ≤ p + r` and
+`p - r + 1 ≤ a`) the `r`-th page at `p` is canonically isomorphic to `gr^p H` of
+homology.  In particular the pages at each `p` are eventually constant. -/
+noncomputable def pageEquivGrHomologyOfBounded {a b r p : ℤ}
+    (ha : K.F a = ⊤) (hb : K.F b = ⊥) (hr1 : b ≤ p + r) (hr2 : p - r + 1 ≤ a) :
+    K.page r p ≃ₗ[R] (↥(K.FH p) ⧸ (K.FH (p + 1)).comap (K.FH p).subtype) :=
+  (K.pageEquivPageInf (le_bot_iff.mp (hb ▸ K.F_mono hr1))
+    (top_le_iff.mp (ha ▸ K.F_mono hr2))).trans (K.pageInfEquivGrHomology p)
+
+/-- For bounded filtrations, consecutive large pages at `p` are isomorphic:
+the spectral sequence stabilizes. -/
+noncomputable def pageSuccEquivPageOfBounded {a b r p : ℤ}
+    (ha : K.F a = ⊤) (hb : K.F b = ⊥) (hr1 : b ≤ p + r) (hr2 : p - r + 1 ≤ a) :
+    K.page (r + 1) p ≃ₗ[R] K.page r p :=
+  (K.pageEquivGrHomologyOfBounded ha hb (by omega) (by omega)).trans
+    (K.pageEquivGrHomologyOfBounded ha hb hr1 hr2).symm
+
+/-! ### Convergence for unbounded filtrations
+
+Convergence does not require the filtration to be bounded.  We prove the classical
+unbounded statements:
+
+* If the filtration is **separated** (`⨅ q, F^q = ⊥`) then the cocycles converge:
+  `⨅ r, Z_r^p = Z_∞^p` (`iInf_Z_eq_Zinf`).  No other hypothesis is needed.
+* If the filtration is **exhaustive** (`⨆ q, F^q = ⊤`) and `F^{p+r₀} = ⊥` for some
+  `r₀` (boundedness on the *cocycle* side only — the filtration may well be
+  unbounded below, so this covers e.g. exhaustive filtrations indexed by all of
+  `ℤ`), then the boundaries converge: `⨆_{r ≥ r₀}, B_r^p = B_∞^p`
+  (`iSup_B_eq_Binf`).
+* Under the same one-sided hypothesis `F^{p+r} = ⊥` there are natural *surjections*
+  `E_r^p ↠ E_{r'}^p ↠ E_∞^p` for `r ≤ r'` (`pageTransition`, `pageToPageInf`,
+  compatible by `pageToPageInf_comp_pageTransition`), and — assuming exhaustiveness —
+  every element of `ker(E_r^p → E_∞^p)` already dies on some finite page
+  (`exists_pageTransition_eq_zero`).  Together these say `E_∞^p = colim_r E_r^p`:
+  the spectral sequence of an exhaustive filtration that is bounded on the cocycle
+  side converges to `gr H` (via `pageInfEquivGrHomology`), even when the filtration
+  is unbounded.  This is the classical convergence theorem (compare Weibel,
+  *An Introduction to Homological Algebra*, Theorem 5.5.1).
+
+Without such hypotheses convergence genuinely fails (Boardman); the missing
+ingredient in general is completeness of the filtration. -/
+
+lemma F_add_bot_of_le {r r' p : ℤ} (hbot : K.F (p + r) = ⊥) (h : r ≤ r') :
+    K.F (p + r') = ⊥ :=
+  le_bot_iff.mp (hbot ▸ K.F_mono (by omega))
+
+/-- **Cocycle convergence for separated filtrations**: if `⨅ q, F^q = ⊥`, then
+`Z_∞^p` is exactly the intersection of the `Z_r^p`, with no boundedness hypothesis. -/
+theorem iInf_Z_eq_Zinf (hsep : ⨅ q, K.F q = ⊥) (p : ℤ) :
+    ⨅ r : ℤ, K.Z r p = K.Zinf p := by
+  ext x
+  simp only [Submodule.mem_iInf, mem_Z, Zinf, Submodule.mem_inf, LinearMap.mem_ker]
+  constructor
+  · intro h
+    refine ⟨(h 0).1, ?_⟩
+    have hmem : K.d x ∈ ⨅ q, K.F q := by
+      refine Submodule.mem_iInf _ |>.mpr fun q ↦ ?_
+      have h2 := (h (q - p)).2
+      rwa [show p + (q - p) = q by ring] at h2
+    rw [hsep] at hmem
+    simpa using hmem
+  · rintro ⟨h1, h2⟩ r
+    exact ⟨h1, by rw [h2]; exact zero_mem _⟩
+
+lemma directed_F : Directed (· ≤ ·) K.F :=
+  fun i j ↦ ⟨min i j, K.F_mono (min_le_left i j), K.F_mono (min_le_right i j)⟩
+
+lemma B_le_Binf {r p : ℤ} (hbot : K.F (p + r) = ⊥) : K.B r p ≤ K.Binf p := by
+  refine sup_le ?_ ?_
+  · rw [hbot, Submodule.comap_bot]
+    exact le_sup_left
+  · refine le_trans (inf_le_inf_left _ ?_) le_sup_right
+    rintro x hx
+    obtain ⟨y, _, rfl⟩ := Submodule.mem_map.mp hx
+    exact ⟨y, rfl⟩
+
+lemma B_mono_of_bot {r r' p : ℤ} (hbot : K.F (p + r) = ⊥) (h : r ≤ r') :
+    K.B r p ≤ K.B r' p := by
+  refine sup_le ?_ ?_
+  · rw [hbot, Submodule.comap_bot]
+    refine le_trans (inf_le_inf_left _ ?_) le_sup_left
+    intro x hx
+    exact Submodule.mem_comap.mpr (by rw [LinearMap.mem_ker.mp hx]; exact zero_mem _)
+  · exact le_trans (inf_le_inf_left _ (Submodule.map_mono (K.F_mono (by omega)))) le_sup_right
+
+/-- **Boundary convergence for exhaustive filtrations**: if `⨆ q, F^q = ⊤` and
+`F^{p+r₀} = ⊥`, then `B_∞^p` is exactly the (directed) union of the `B_r^p` for
+`r ≥ r₀` — even when the filtration is unbounded below. -/
+theorem iSup_B_eq_Binf {r₀ p : ℤ} (hbot : K.F (p + r₀) = ⊥) (hexh : ⨆ q, K.F q = ⊤) :
+    ⨆ r, ⨆ (_ : r₀ ≤ r), K.B r p = K.Binf p := by
+  apply le_antisymm
+  · exact iSup₂_le fun r hr ↦ K.B_le_Binf (K.F_add_bot_of_le hbot hr)
+  · refine sup_le ?_ ?_
+    · refine le_trans ?_ (le_iSup₂ (f := fun r _ ↦ K.B r p) r₀ le_rfl)
+      refine le_trans (inf_le_inf_left _ ?_) le_sup_left
+      intro x hx
+      exact Submodule.mem_comap.mpr (by rw [LinearMap.mem_ker.mp hx]; exact zero_mem _)
+    · intro x hx
+      obtain ⟨hx1, hx2⟩ := Submodule.mem_inf.mp hx
+      obtain ⟨y, rfl⟩ := LinearMap.mem_range.mp hx2
+      have hy : y ∈ ⨆ q, K.F q := hexh.symm ▸ Submodule.mem_top
+      obtain ⟨q, hq⟩ := (Submodule.mem_iSup_of_directed _ K.directed_F).mp hy
+      have hmem : K.d y ∈ K.B (max r₀ (p + 1 - q)) p :=
+        K.mem_B_right
+          (K.F_mono (by have := le_max_right r₀ (p + 1 - q); omega) hq) hx1
+      exact le_iSup₂ (f := fun r _ ↦ K.B r p) (max r₀ (p + 1 - q)) (le_max_left _ _) hmem
+
+/-- Once `F^{p+r} = ⊥`, the natural surjection from the `r`-th page onto the limit
+page.  (For smaller `r` there is no natural map in general.) -/
+def pageToPageInf {r p : ℤ} (hbot : K.F (p + r) = ⊥) :
+    K.page r p →ₗ[R] K.pageInf p :=
+  Submodule.mapQ _ _ (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).toLinearMap (by
+    intro ζ hζ
+    simp only [Submodule.mem_comap, Submodule.coe_subtype, LinearEquiv.coe_coe,
+      LinearEquiv.coe_ofEq_apply] at hζ ⊢
+    exact K.B_le_Binf hbot hζ)
+
+@[simp] lemma pageToPageInf_mk {r p : ℤ} (hbot : K.F (p + r) = ⊥) (ζ : ↥(K.Z r p)) :
+    K.pageToPageInf hbot (Submodule.Quotient.mk ζ) =
+      Submodule.Quotient.mk (LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot) ζ) :=
+  Submodule.mapQ_apply _ _ _ ζ
+
+lemma pageToPageInf_surjective {r p : ℤ} (hbot : K.F (p + r) = ⊥) :
+    Function.Surjective (K.pageToPageInf hbot) := by
+  intro ξ
+  obtain ⟨ζ, rfl⟩ := Submodule.Quotient.mk_surjective _ ξ
+  refine ⟨Submodule.Quotient.mk ((LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).symm ζ), ?_⟩
+  rw [K.pageToPageInf_mk hbot]
+  exact congrArg _ ((LinearEquiv.ofEq _ _ (K.Z_eq_Zinf hbot)).apply_symm_apply ζ)
+
+/-- The natural surjection `E_r^p ↠ E_{r'}^p` for `r ≤ r'`, in the range where the
+cocycles have stabilized. -/
+def pageTransition {r r' p : ℤ} (hbot : K.F (p + r) = ⊥) (h : r ≤ r') :
+    K.page r p →ₗ[R] K.page r' p :=
+  Submodule.mapQ _ _ (LinearEquiv.ofEq _ _ (by
+      rw [K.Z_eq_Zinf hbot, K.Z_eq_Zinf (K.F_add_bot_of_le hbot h)])).toLinearMap (by
+    intro ζ hζ
+    simp only [Submodule.mem_comap, Submodule.coe_subtype, LinearEquiv.coe_coe,
+      LinearEquiv.coe_ofEq_apply] at hζ ⊢
+    exact K.B_mono_of_bot hbot h hζ)
+
+@[simp] lemma pageTransition_mk {r r' p : ℤ} (hbot : K.F (p + r) = ⊥) (h : r ≤ r')
+    (ζ : ↥(K.Z r p)) :
+    K.pageTransition hbot h (Submodule.Quotient.mk ζ) =
+      Submodule.Quotient.mk ((LinearEquiv.ofEq _ _ (by
+        rw [K.Z_eq_Zinf hbot, K.Z_eq_Zinf (K.F_add_bot_of_le hbot h)])) ζ) :=
+  Submodule.mapQ_apply _ _ _ ζ
+
+/-- The surjections onto later pages are compatible with the surjection onto the
+limit page. -/
+theorem pageToPageInf_comp_pageTransition {r r' p : ℤ} (hbot : K.F (p + r) = ⊥)
+    (h : r ≤ r') :
+    (K.pageToPageInf (K.F_add_bot_of_le hbot h)).comp (K.pageTransition hbot h) =
+      K.pageToPageInf hbot := by
+  apply Submodule.linearMap_qext
+  ext ζ
+  simp only [LinearMap.comp_apply, Submodule.mkQ_apply, pageTransition_mk, pageToPageInf_mk]
+  exact congrArg Submodule.Quotient.mk (Subtype.ext rfl)
+
+/-- **The classical convergence theorem, unbounded case**: suppose `F^{p+r} = ⊥`
+(one-sided bound) and the filtration is exhaustive (`⨆ q, F^q = ⊤`), but otherwise
+arbitrary — in particular possibly unbounded below.  Then every element of the
+kernel of `E_r^p ↠ E_∞^p` already vanishes on some finite page `E_{r'}^p`.
+Combined with the surjectivity of `pageToPageInf` and `pageInfEquivGrHomology`,
+this says that `E_∞^p = colim_r E_r^p ≅ gr^p H`. -/
+theorem exists_pageTransition_eq_zero {r p : ℤ} (hbot : K.F (p + r) = ⊥)
+    (hexh : ⨆ q, K.F q = ⊤) (ξ : K.page r p) (hξ : K.pageToPageInf hbot ξ = 0) :
+    ∃ (r' : ℤ) (h : r ≤ r'), K.pageTransition hbot h ξ = 0 := by
+  obtain ⟨ζ, rfl⟩ := Submodule.Quotient.mk_surjective _ ξ
+  rw [K.pageToPageInf_mk hbot, Submodule.Quotient.mk_eq_zero] at hξ
+  have hζB : (ζ : M) ∈ K.Binf p := by
+    simpa using hξ
+  obtain ⟨u, hu, w, hw, hsum⟩ := Submodule.mem_sup.mp hζB
+  obtain ⟨hu1, hu2⟩ := Submodule.mem_inf.mp hu
+  obtain ⟨hw1, hw2⟩ := Submodule.mem_inf.mp hw
+  obtain ⟨y, rfl⟩ := LinearMap.mem_range.mp hw2
+  have hy : y ∈ ⨆ q, K.F q := hexh.symm ▸ Submodule.mem_top
+  obtain ⟨q, hq⟩ := (Submodule.mem_iSup_of_directed _ K.directed_F).mp hy
+  refine ⟨max r (p + 1 - q), le_max_left _ _, ?_⟩
+  rw [K.pageTransition_mk, Submodule.Quotient.mk_eq_zero]
+  simp only [Submodule.mem_comap, Submodule.coe_subtype, LinearEquiv.coe_ofEq_apply]
+  rw [← hsum]
+  refine add_mem (K.mem_B_left hu1 ?_) ?_
+  · rw [LinearMap.mem_ker.mp hu2]
+    exact zero_mem _
+  · exact K.mem_B_right
+      (K.F_mono (by have := le_max_right r (p + 1 - q); omega) hq) hw1
+
+end Convergence
+
+/-! ## Functoriality and the mapping lemma
+
+A morphism of filtered differential modules induces morphisms on all pages,
+commuting with the differentials (`mapPage`, `mapPage_dPageAux`).  The
+**mapping lemma** (`Hom.bijective_mapPage_succ`, `Hom.bijective_mapPage_of_le`):
+if the induced map is bijective on every spot of the `r`-th page, it is
+bijective on all later pages. -/
+
+section Functoriality
+
+variable {M' : Type*} [AddCommGroup M'] [Module R M']
+
+/-- A **morphism of filtered differential modules**: a linear map commuting with
+the differentials and preserving the filtrations. -/
+structure Hom (K : FilteredDifferentialModule R M) (K' : FilteredDifferentialModule R M') where
+  /-- The underlying linear map. -/
+  toLinearMap : M →ₗ[R] M'
+  /-- The map commutes with the differentials. -/
+  comm_d : ∀ x : M, toLinearMap (K.d x) = K'.d (toLinearMap x)
+  /-- The map preserves the filtrations. -/
+  map_F : ∀ (p : ℤ), ∀ x ∈ K.F p, toLinearMap x ∈ K'.F p
+
+/-- `B_r ∩ Z_{r+1} ⊆ B_{r+1}`: an `(r+1)`-cocycle which is an `r`-boundary is an
+`(r+1)`-boundary. -/
+lemma mem_B_succ_of_mem_B {r p : ℤ} {z : M} (hz : z ∈ K.Z (r + 1) p)
+    (hzB : z ∈ K.B r p) : z ∈ K.B (r + 1) p := by
+  obtain ⟨u, v, hu1, hu2, hv, hdv, rfl⟩ := K.B_cases hzB
+  have hdu : K.d u ∈ K.F (p + (r + 1)) := by
+    have h2 := (K.mem_Z.mp hz).2
+    rw [map_add, K.d_squared v, add_zero] at h2
+    exact h2
+  refine add_mem (K.mem_B_left hu1 hdu) (K.mem_B_right ?_ hdv)
+  rw [show p - (r + 1) + 1 = p - r by ring]
+  exact K.F_le (p - r) hv
+
+namespace Hom
+
+variable {K : FilteredDifferentialModule R M} {K' : FilteredDifferentialModule R M'}
+variable (φ : Hom K K')
+
+lemma map_Z {r p : ℤ} {x : M} (hx : x ∈ K.Z r p) : φ.toLinearMap x ∈ K'.Z r p := by
+  obtain ⟨h1, h2⟩ := K.mem_Z.mp hx
+  refine K'.mem_Z.mpr ⟨φ.map_F p x h1, ?_⟩
+  rw [← φ.comm_d]
+  exact φ.map_F _ _ h2
+
+lemma map_B {r p : ℤ} {x : M} (hx : x ∈ K.B r p) : φ.toLinearMap x ∈ K'.B r p := by
+  obtain ⟨u, v, hu1, hu2, hv, hdv, rfl⟩ := K.B_cases hx
+  rw [map_add]
+  refine add_mem (K'.mem_B_left (φ.map_F _ _ hu1) ?_) ?_
+  · rw [← φ.comm_d]
+    exact φ.map_F _ _ hu2
+  · rw [φ.comm_d]
+    refine K'.mem_B_right (φ.map_F _ _ hv) ?_
+    rw [← φ.comm_d]
+    exact φ.map_F _ _ hdv
+
+/-- The induced map on the cocycles. -/
+def mapZ (r p : ℤ) : ↥(K.Z r p) →ₗ[R] ↥(K'.Z r p) :=
+  φ.toLinearMap.restrict fun _ hx ↦ φ.map_Z hx
+
+@[simp] lemma mapZ_coe (r p : ℤ) (x : ↥(K.Z r p)) :
+    (φ.mapZ r p x : M') = φ.toLinearMap x := rfl
+
+/-- The induced map on the pages. -/
+def mapPage (r p : ℤ) : K.page r p →ₗ[R] K'.page r p :=
+  Submodule.mapQ _ _ (φ.mapZ r p) (by
+    intro x hx
+    simp only [Submodule.mem_comap, Submodule.coe_subtype, mapZ_coe] at hx ⊢
+    exact φ.map_B hx)
+
+@[simp] lemma mapPage_mk (r p : ℤ) (x : ↥(K.Z r p)) :
+    φ.mapPage r p (Submodule.Quotient.mk x) = Submodule.Quotient.mk (φ.mapZ r p x) :=
+  Submodule.mapQ_apply _ _ _ x
+
+/-- Naturality: the induced maps on pages commute with the differentials. -/
+theorem mapPage_dPageAux (r p q : ℤ) (hq : q = p + r) :
+    (φ.mapPage r q).comp (K.dPageAux r p q hq)
+      = (K'.dPageAux r p q hq).comp (φ.mapPage r p) := by
+  apply Submodule.linearMap_qext
+  ext ζ
+  simp only [LinearMap.comp_apply, Submodule.mkQ_apply, dPageAux_mk, mapPage_mk]
+  congr 1
+  apply Subtype.ext
+  simp [φ.comm_d]
+
+/-- **Mapping lemma, surjectivity half.** -/
+lemma surjective_mapPage_succ (r p : ℤ)
+    (hsurj : ∀ p', Function.Surjective (φ.mapPage r p'))
+    (hinj : ∀ p', Function.Injective (φ.mapPage r p')) :
+    Function.Surjective (φ.mapPage (r + 1) p) := by
+  intro c'
+  obtain ⟨⟨z', hz'⟩, rfl⟩ := Submodule.Quotient.mk_surjective _ c'
+  -- lift the class of `z'` on the `r`-th page
+  obtain ⟨c, hc⟩ := hsurj p (Submodule.Quotient.mk ⟨z', K'.Z_succ_le r p hz'⟩)
+  obtain ⟨⟨ζ, hζ⟩, rfl⟩ := Submodule.Quotient.mk_surjective _ c
+  rw [mapPage_mk, Submodule.Quotient.eq] at hc
+  have hb' : φ.toLinearMap ζ - z' ∈ K'.B r p := by
+    simpa using hc
+  -- the class of `d ζ` on the `r`-th page dies, by injectivity
+  have hfz : φ.toLinearMap (K.d ζ) ∈ K'.B r (p + r) := by
+    rw [φ.comm_d]
+    have heq : K'.d (φ.toLinearMap ζ)
+        = K'.d z' + K'.d (φ.toLinearMap ζ - z') := by
+      rw [← map_add]
+      congr 1
+      abel
+    rw [heq]
+    refine add_mem (K'.mem_B_left ?_ ?_) (K'.d_mem_B rfl hb')
+    · have h2 := (K'.mem_Z.mp hz').2
+      rwa [show p + r + 1 = p + (r + 1) by ring]
+    · rw [K'.d_squared]
+      exact zero_mem _
+  have hdz : K.d ζ ∈ K.B r (p + r) := by
+    have h0 : φ.mapPage r (p + r) (Submodule.Quotient.mk ⟨K.d ζ, K.d_mem_Z rfl hζ⟩) = 0 := by
+      rw [mapPage_mk, Submodule.Quotient.mk_eq_zero]
+      simpa using hfz
+    have h1 := hinj (p + r) (by rw [h0, map_zero] :
+      φ.mapPage r (p + r) (Submodule.Quotient.mk ⟨K.d ζ, K.d_mem_Z rfl hζ⟩)
+        = φ.mapPage r (p + r) 0)
+    rw [Submodule.Quotient.mk_eq_zero] at h1
+    simpa using h1
+  -- correct `ζ` to an `(r+1)`-cocycle, as in the surjectivity chase of the main theorem
+  obtain ⟨u, v, hu1, hu2, hv, hdv, hsum⟩ := K.B_cases hdz
+  rw [show p + r - r + 1 = p + 1 by ring] at hv
+  have hζF : ζ ∈ K.F p := (K.mem_Z.mp hζ).1
+  have hz'' : ζ - v ∈ K.Z (r + 1) p := by
+    refine K.mem_Z.mpr ⟨sub_mem hζF (K.F_le p hv), ?_⟩
+    have hd : K.d (ζ - v) = u := by
+      rw [map_sub, hsum]
+      abel
+    rw [hd, show p + (r + 1) = p + r + 1 by ring]
+    exact hu1
+  refine ⟨Submodule.Quotient.mk ⟨ζ - v, hz''⟩, ?_⟩
+  rw [mapPage_mk, Submodule.Quotient.eq]
+  simp only [Submodule.mem_comap, Submodule.coe_subtype, AddSubgroupClass.coe_sub, mapZ_coe]
+  refine K'.mem_B_succ_of_mem_B (sub_mem (φ.map_Z hz'') hz') ?_
+  have heq2 : φ.toLinearMap (ζ - v) - z'
+      = (φ.toLinearMap ζ - z') - φ.toLinearMap v := by
+    rw [map_sub]
+    abel
+  rw [heq2]
+  exact sub_mem hb' (φ.map_B (K.mem_B_left hv hdv))
+
+/-- **Mapping lemma, injectivity half.** -/
+lemma injective_mapPage_succ (r p : ℤ)
+    (hsurj : ∀ p', Function.Surjective (φ.mapPage r p'))
+    (hinj : ∀ p', Function.Injective (φ.mapPage r p')) :
+    Function.Injective (φ.mapPage (r + 1) p) := by
+  rw [← LinearMap.ker_eq_bot]
+  refine le_antisymm (fun c hc ↦ ?_) bot_le
+  obtain ⟨⟨z, hz⟩, rfl⟩ := Submodule.Quotient.mk_surjective _ c
+  rw [LinearMap.mem_ker, mapPage_mk, Submodule.Quotient.mk_eq_zero] at hc
+  have hfz : φ.toLinearMap z ∈ K'.B (r + 1) p := by
+    simpa using hc
+  -- decompose and lift the `v'`-part through the previous spot
+  obtain ⟨u', v', hu1', hu2', hv', hdv', hsum'⟩ := K'.B_cases hfz
+  rw [show p - (r + 1) + 1 = p - r by ring] at hv'
+  have hv'Z : v' ∈ K'.Z r (p - r) :=
+    K'.mem_Z.mpr ⟨hv', by rw [show p - r + r = p by ring]; exact hdv'⟩
+  obtain ⟨c₂, hc₂⟩ := hsurj (p - r) (Submodule.Quotient.mk ⟨v', hv'Z⟩)
+  obtain ⟨⟨w, hw⟩, rfl⟩ := Submodule.Quotient.mk_surjective _ c₂
+  rw [mapPage_mk, Submodule.Quotient.eq] at hc₂
+  have hb : φ.toLinearMap w - v' ∈ K'.B r (p - r) := by
+    simpa using hc₂
+  -- `z - d w` dies on the `r`-th page after mapping
+  have hzw : z - K.d w ∈ K.Z r p :=
+    sub_mem (K.Z_succ_le r p hz) (K.d_mem_Z (by ring) hw)
+  have hmap0 : φ.toLinearMap (z - K.d w) ∈ K'.B r p := by
+    have heq : φ.toLinearMap (z - K.d w)
+        = u' - K'.d (φ.toLinearMap w - v') := by
+      rw [map_sub, φ.comm_d, map_sub, hsum']
+      abel
+    rw [heq]
+    refine sub_mem (K'.mem_B_left hu1' ?_) (K'.d_mem_B (by ring) hb)
+    refine K'.F_le (p + r) ?_
+    rwa [show p + r + 1 = p + (r + 1) by ring]
+  have h0 : φ.mapPage r p (Submodule.Quotient.mk ⟨z - K.d w, hzw⟩) = 0 := by
+    rw [mapPage_mk, Submodule.Quotient.mk_eq_zero]
+    simpa using hmap0
+  have h1 := hinj p (by rw [h0, map_zero] :
+    φ.mapPage r p (Submodule.Quotient.mk ⟨z - K.d w, hzw⟩) = φ.mapPage r p 0)
+  rw [Submodule.Quotient.mk_eq_zero] at h1
+  have hzB : z - K.d w ∈ K.B r p := by
+    simpa using h1
+  -- conclude via the kernel identity of the main theorem
+  rw [Submodule.mem_bot, Submodule.Quotient.mk_eq_zero]
+  have hmem : z ∈ K.B (r + 1) p := by
+    refine K.mem_B_succ_of r p hz ⟨w, hw, ?_⟩
+    have heq3 : K.d w - z = -(z - K.d w) := by abel
+    rw [heq3]
+    exact neg_mem hzB
+  exact Submodule.mem_comap.mpr hmem
+
+/-- **The mapping lemma**: a morphism of filtered differential modules that is
+bijective on every spot of the `r`-th page is bijective on every spot of the
+`(r+1)`-st page. -/
+theorem bijective_mapPage_succ (r : ℤ)
+    (hbij : ∀ p', Function.Bijective (φ.mapPage r p')) (p : ℤ) :
+    Function.Bijective (φ.mapPage (r + 1) p) :=
+  ⟨φ.injective_mapPage_succ r p (fun p' ↦ (hbij p').2) (fun p' ↦ (hbij p').1),
+    φ.surjective_mapPage_succ r p (fun p' ↦ (hbij p').2) (fun p' ↦ (hbij p').1)⟩
+
+/-- **The mapping lemma, iterated**: bijectivity on the `r`-th page propagates to
+all later pages. -/
+theorem bijective_mapPage_of_le {r r' : ℤ} (h : r ≤ r')
+    (hbij : ∀ p', Function.Bijective (φ.mapPage r p')) :
+    ∀ p, Function.Bijective (φ.mapPage r' p) := by
+  induction r', h using Int.leInduction with
+  | base => exact hbij
+  | succ n hn ih => exact φ.bijective_mapPage_succ n ih
+
+end Hom
+
+end Functoriality
+
+/-! ## The spectral sequence of a filtered complex
+
+Following the Stacks Project (tag 012K), a filtered cochain complex
+`(X n, d n, F p n)` gives rise to a filtered differential module on the total
+module `⨁ n, X n`, and *the spectral sequence of the filtered complex* is the
+spectral sequence of this filtered differential module.  (The classical bigraded
+pages `E_r^{p,q}` decompose each of our pages `E_r^p` according to the grading
+`q = n - p`; the grading plays no role in the construction of the pages, the
+differentials, or the homology isomorphism.) -/
+
+section FilteredComplex
+
+open DirectSum
+
+variable (R)
+variable (X : ℤ → Type*) [∀ n, AddCommGroup (X n)] [∀ n, Module R (X n)]
+variable (d : ∀ n : ℤ, X n →ₗ[R] X (n + 1))
+variable (F : ℤ → ∀ n : ℤ, Submodule R (X n))
+
+/-- The total differential on `⨁ n, X n` induced by the differentials of a complex. -/
+noncomputable def totalD : (⨁ n, X n) →ₗ[R] ⨁ n, X n :=
+  DirectSum.toModule R ℤ _ fun n ↦ (DirectSum.lof R ℤ X (n + 1)).comp (d n)
+
+@[simp] lemma totalD_lof (n : ℤ) (x : X n) :
+    totalD R X d (DirectSum.lof R ℤ X n x) = DirectSum.lof R ℤ X (n + 1) (d n x) := by
+  simp [totalD]
+
+/-- The total filtration on `⨁ n, X n` induced by a filtration of a complex. -/
+def totalF (p : ℤ) : Submodule R (⨁ n, X n) :=
+  ⨆ n, (F p n).map (DirectSum.lof R ℤ X n)
+
+/-- **The filtered differential module associated to a filtered cochain complex**
+(Stacks Project, tag 012K).  Here `X` is a `ℤ`-indexed cochain complex with
+differentials `d n : X n → X (n+1)` squaring to zero, and `F` is a decreasing
+filtration by subcomplexes.  The pages, differentials and homology isomorphism
+of the spectral sequence of the filtered complex are `(ofComplex ...).page`,
+`(ofComplex ...).dPage` and `(ofComplex ...).pageSuccEquiv`. -/
+noncomputable def ofComplex
+    (hd : ∀ (n : ℤ) (x : X n), d (n + 1) (d n x) = 0)
+    (hF : ∀ p n, F (p + 1) n ≤ F p n)
+    (hdF : ∀ p n, (F p n).map (d n) ≤ F p (n + 1)) :
+    FilteredDifferentialModule R (⨁ n, X n) where
+  d := totalD R X d
+  d_squared := by
+    intro ξ
+    induction ξ using DirectSum.induction_on with
+    | zero => simp
+    | of n x =>
+      rw [← DirectSum.lof_eq_of R, totalD_lof, totalD_lof, hd]
+      simp
+    | add a b ha hb => rw [map_add, map_add, ha, hb, add_zero]
+  F := totalF R X F
+  F_le := fun p ↦
+    iSup_le fun n ↦ le_trans (Submodule.map_mono (hF p n))
+      (le_iSup (fun n ↦ (F p n).map (DirectSum.lof R ℤ X n)) n)
+  d_mem_F := by
+    intro p x hx
+    have hcomp : ∀ n, (totalD R X d).comp (DirectSum.lof R ℤ X n) =
+        (DirectSum.lof R ℤ X (n + 1)).comp (d n) := by
+      intro n
+      ext y
+      simp
+    have hmap : (totalF R X F p).map (totalD R X d) ≤ totalF R X F p := by
+      rw [totalF, Submodule.map_iSup]
+      refine iSup_le fun n ↦ ?_
+      rw [← Submodule.map_comp, hcomp n, Submodule.map_comp]
+      exact le_trans (Submodule.map_mono (hdF p n))
+        (le_iSup (fun m ↦ (F p m).map (DirectSum.lof R ℤ X m)) (n + 1))
+    exact hmap (Submodule.mem_map_of_mem hx)
+
+end FilteredComplex
+
+end FilteredDifferentialModule

--- a/FLT/Slop/SpectralSequence/FilteredModule.lean
+++ b/FLT/Slop/SpectralSequence/FilteredModule.lean
@@ -82,6 +82,8 @@ statement `exists_pageTransition_eq_zero`.
 
 @[expose] public section
 
+namespace Slop
+
 open Submodule LinearMap
 
 variable (R : Type*) [Ring R] (M : Type*) [AddCommGroup M] [Module R M]
@@ -1342,3 +1344,5 @@ noncomputable def ofComplex
 end FilteredComplex
 
 end FilteredDifferentialModule
+
+end Slop

--- a/FLT/Slop/SpectralSequence/FiveTerm.lean
+++ b/FLT/Slop/SpectralSequence/FiveTerm.lean
@@ -35,8 +35,7 @@ needed to identify `d₂` with the abstract page differentials.
   complex.
 * `FilteredComplex.d2` : the transgression `d₂ : E_2^{0,1} → E_2^{2,0}`.
 * `FilteredComplex.f1`, `FilteredComplex.f2`, `FilteredComplex.f4` : the edge
-  edge maps `E_2^{1,0} → H¹` and `H¹ → E_2^{0,1}`, and
-  `E_2^{2,0} → H²`.
+  maps `E_2^{1,0} → H¹` and `H¹ → E_2^{0,1}`, and `E_2^{2,0} → H²`.
 * `FilteredComplex.five_term_exact` : the five-term exact sequence — `f1` is
   injective and the sequence is exact at `H¹`, `E_2^{0,1}` and `E_2^{2,0}`.
 * `FilteredComplex.pageSuccEquivOfStable`, `FilteredComplex.quotComapTopEquiv` :

--- a/FLT/Slop/SpectralSequence/FiveTerm.lean
+++ b/FLT/Slop/SpectralSequence/FiveTerm.lean
@@ -1,0 +1,236 @@
+/-
+Copyright (c) 2026 Akhil Mathew. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Akhil Mathew
+-/
+module
+
+public import FLT.Slop.SpectralSequence.FilteredComplex
+public import Mathlib.Algebra.Exact.Basic
+public import Mathlib.Tactic.NormNum
+
+/-!
+# The five-term exact sequence of low-degree terms
+
+For a **first-quadrant** filtered complex — the filtration is `⊥` strictly above
+the diagonal and `⊤` at or below `0` (`FilteredComplex.FirstQuadrant`), which is
+what the column/row filtrations of a first-quadrant double complex satisfy — the
+spectral sequence yields the classical five-term exact sequence of low-degree
+terms (FOAG §1.7)
+
+`0 → E_2^{1,0} → H¹ → E_2^{0,1} →^{d₂} E_2^{2,0} → H²`.
+
+The construction is entirely limit-free: each of the corner spots `(1,0)`,
+`(0,1)`, `(2,0)` is reached from the convergence isomorphism
+`FilteredComplex.pageEquivGrHOfBounded` plus the observation that in the first
+quadrant the only differential touching these corners is the single
+transgression `d₂ : E_2^{0,1} → E_2^{2,0}`.  Using concrete integer indices
+`0, 1, 2` throughout lets the kernel discharge the index arithmetic
+(`(0 + 2) - 2 = 0` etc.) definitionally, so no dependent-type transport is
+needed to identify `d₂` with the abstract page differentials.
+
+## Main definitions and results
+
+* `FilteredComplex.FirstQuadrant` : the first-quadrant condition on a filtered
+  complex.
+* `FilteredComplex.d2` : the transgression `d₂ : E_2^{0,1} → E_2^{2,0}`.
+* `FilteredComplex.f1`, `FilteredComplex.f2`, `FilteredComplex.f4` : the edge
+  maps `E_2^{1,0} → H¹` (inflation), `H¹ → E_2^{0,1}` (restriction) and
+  `E_2^{2,0} → H²`.
+* `FilteredComplex.five_term_exact` : the five-term exact sequence — `f1` is
+  injective and the sequence is exact at `H¹`, `E_2^{0,1}` and `E_2^{2,0}`.
+* `FilteredComplex.pageSuccEquivOfStable`, `FilteredComplex.quotComapTopEquiv` :
+  stabilization at a spot with vanishing differentials, and a quotient
+  convenience used to peel off `⊤` filtration steps.
+-/
+
+@[expose] public section
+
+open Submodule LinearMap
+
+namespace FilteredComplex
+
+variable {R : Type*} [Ring R] (K : FilteredComplex R)
+
+section FiveTerm
+
+/-- If `S = ⊤`, then `↥S ⧸ N.comap S.subtype ≅ M ⧸ N`.  (A convenience for pushing a
+quotient through the identification `↥(⊤) ≅ M`.) -/
+noncomputable def quotComapTopEquiv {M : Type*} [AddCommGroup M] [Module R M]
+    {S : Submodule R M} (hS : S = ⊤) (N : Submodule R M) :
+    (↥S ⧸ N.comap S.subtype) ≃ₗ[R] (M ⧸ N) := by
+  refine Submodule.Quotient.equiv _ _
+    ((LinearEquiv.ofEq S ⊤ hS).trans Submodule.topEquiv) ?_
+  ext x
+  simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
+  constructor
+  · rintro ⟨y, hy, rfl⟩; exact hy
+  · intro hx; exact ⟨⟨x, hS ▸ Submodule.mem_top⟩, hx, rfl⟩
+
+/-- **Stabilization at a spot with vanishing differentials.**  If both the outgoing
+differential `d_r : E_r^{p,n} → E_r^{p+r,n+1}` and the incoming differential
+`d_r : E_r^{p-r,n-1} → E_r^{p,n}` vanish, then `E_{r+1}^{p,n} ≅ E_r^{p,n}`. -/
+noncomputable def pageSuccEquivOfStable {r p n : ℤ}
+    (hout : K.dPage r p n = 0) (hin : K.dPageFrom r p n = 0) :
+    K.page (r + 1) p n ≃ₗ[R] K.page r p n := by
+  refine (K.pageSuccEquiv r p n).trans
+    ((Submodule.quotEquivOfEqBot _ ?_).trans
+      ((LinearEquiv.ofEq _ _ ?_).trans Submodule.topEquiv))
+  · rw [hin, LinearMap.range_zero, Submodule.comap_bot, Submodule.ker_subtype]
+  · rw [hout, LinearMap.ker_zero]
+
+/-- **First-quadrant condition** on a filtered complex: the filtration is `⊥`
+strictly above the diagonal (`n < p`) and `⊤` at or below `0`.  The column and row
+filtrations of a first-quadrant double complex both satisfy this. -/
+structure FirstQuadrant : Prop where
+  /-- The filtration vanishes strictly above the diagonal. -/
+  bot : ∀ {p n : ℤ}, n < p → K.F p n = ⊥
+  /-- The filtration is everything at or below filtration degree `0`. -/
+  top : ∀ {p n : ℤ}, p ≤ 0 → K.F p n = ⊤
+
+variable {K}
+
+/-- If `F^p_n = ⊥` then the induced filtration piece `F^p H^n = ⊥`. -/
+lemma FH_eq_bot {p n : ℤ} (hF : K.F p n = ⊥) : K.FH p n = ⊥ := by
+  have hZ : K.Zinf p n = ⊥ := by unfold Zinf; rw [hF, bot_inf_eq]
+  unfold FH
+  rw [hZ, Submodule.comap_bot, Submodule.ker_subtype, Submodule.map_bot]
+
+/-- If `F^p_n = ⊤` then the induced filtration piece `F^p H^n = ⊤`. -/
+lemma FH_eq_top {p n : ℤ} (hF : K.F p n = ⊤) : K.FH p n = ⊤ := by
+  have hZ : K.Zinf p n = ker (K.d n (n + 1)) := by unfold Zinf; rw [hF, top_inf_eq]
+  unfold FH
+  rw [hZ, Submodule.comap_subtype_self, Submodule.map_top, Submodule.range_mkQ]
+
+/-! ### The middle map `d₂ : E_2^{0,1} → E_2^{2,0}` -/
+
+/-- The transgression `d₂ : E_2^{0,1} → E_2^{2,0}` with clean literal indices. -/
+noncomputable def d2 : K.page 2 0 1 →ₗ[R] K.page 2 2 2 :=
+  K.dPageAux 2 0 2 1 2 (by norm_num) (by norm_num)
+
+/-- `d₂` and the abstract outgoing differential at `(0,1)` have the same kernel
+(they are definitionally the same map). -/
+lemma ker_d2_eq : ker K.d2 = ker (K.dPage 2 0 1) := rfl
+
+/-- `d₂` and the abstract incoming differential at `(2,2)` have the same range
+(they are definitionally the same map). -/
+lemma range_d2_eq : range K.d2 = range (K.dPageFrom 2 2 2) := rfl
+
+/-! ### Left edge `f₁ : E_2^{1,0} → H¹` (inflation) -/
+
+/-- `E_2^{1,0} ≅ F^1 H^1`: the `(1,0)` spot already stabilizes at page 2 (no
+differential touches it in the first quadrant), and its graded piece is the top of
+the 2-step filtration on `H¹`. -/
+noncomputable def e2Iso10 (hK : K.FirstQuadrant) :
+    K.page 2 1 1 ≃ₗ[R] ↥(K.FH 1 1) := by
+  have hb : K.F (1 + 2) (1 + 1) = ⊥ := hK.bot (by norm_num)
+  have ht : K.F (1 - 2 + 1) (1 - 1) = ⊤ := hK.top (by norm_num)
+  refine (K.pageEquivGrHOfBounded hb ht).trans (Submodule.quotEquivOfEqBot _ ?_)
+  rw [FH_eq_bot (hK.bot (show (1:ℤ) < 1 + 1 by norm_num)),
+    Submodule.comap_bot, Submodule.ker_subtype]
+
+/-- The **left edge map** `f₁ : E_2^{1,0} → H^1` (inflation). -/
+noncomputable def f1 (hK : K.FirstQuadrant) : K.page 2 1 1 →ₗ[R] K.homology 1 :=
+  (K.FH 1 1).subtype.comp (e2Iso10 hK).toLinearMap
+
+lemma f1_injective (hK : K.FirstQuadrant) : Function.Injective (f1 hK) :=
+  (Subtype.val_injective).comp (e2Iso10 hK).injective
+
+lemma range_f1 (hK : K.FirstQuadrant) : range (f1 hK) = K.FH 1 1 := by
+  rw [f1, LinearMap.range_comp, LinearEquiv.range, Submodule.map_top,
+    Submodule.range_subtype]
+
+/-! ### Bottom edge `f₂ : H¹ → E_2^{0,1}` (restriction) -/
+
+/-- `E_∞^{0,1} = pageInf 0 1 ≅ ker(d₂)`: at `(0,1)` only the outgoing `d₂` survives,
+so page 3 = page ∞ and equals `ker d₂`. -/
+noncomputable def pageInfIso01 (hK : K.FirstQuadrant) :
+    K.pageInf 0 1 ≃ₗ[R] ↥(ker (K.dPage 2 0 1)) := by
+  have hb : K.F (0 + 3) (1 + 1) = ⊥ := hK.bot (by norm_num)
+  have ht : K.F (0 - 3 + 1) (1 - 1) = ⊤ := hK.top (by norm_num)
+  refine (K.pageEquivPageInf hb ht).symm.trans
+    ((K.pageSuccEquiv 2 0 1).trans (Submodule.quotEquivOfEqBot _ ?_))
+  rw [K.dPageFrom_eq_zero (hK.top (show (0:ℤ) - 2 + 1 ≤ 0 by norm_num)),
+    LinearMap.range_zero, Submodule.comap_bot, Submodule.ker_subtype]
+
+/-- `H¹ ⧸ F^1 H^1 ≅ E_∞^{0,1}`: the bottom graded piece of the filtration on `H¹`. -/
+noncomputable def grH1Iso (hK : K.FirstQuadrant) :
+    (K.homology 1 ⧸ K.FH 1 1) ≃ₗ[R] K.pageInf 0 1 :=
+  ((K.pageInfEquivGrH 0 1).trans
+    (quotComapTopEquiv (FH_eq_top (hK.top (show (0:ℤ) ≤ 0 by norm_num) : K.F 0 1 = ⊤))
+      (K.FH 1 1))).symm
+
+/-- The **bottom edge map** `f₂ : H^1 → E_2^{0,1}` (restriction). -/
+noncomputable def f2 (hK : K.FirstQuadrant) : K.homology 1 →ₗ[R] K.page 2 0 1 :=
+  ((ker (K.dPage 2 0 1)).subtype.comp
+    ((pageInfIso01 hK).toLinearMap.comp (grH1Iso hK).toLinearMap)).comp (K.FH 1 1).mkQ
+
+lemma f2_L_injective (hK : K.FirstQuadrant) :
+    Function.Injective ((ker (K.dPage 2 0 1)).subtype.comp
+      ((pageInfIso01 hK).toLinearMap.comp (grH1Iso hK).toLinearMap)) :=
+  (Subtype.val_injective).comp ((pageInfIso01 hK).injective.comp (grH1Iso hK).injective)
+
+lemma ker_f2 (hK : K.FirstQuadrant) : ker (f2 hK) = K.FH 1 1 := by
+  rw [f2, LinearMap.ker_comp, LinearMap.ker_eq_bot.mpr (f2_L_injective hK),
+    Submodule.comap_bot, Submodule.ker_mkQ]
+
+lemma range_f2 (hK : K.FirstQuadrant) : range (f2 hK) = ker (K.dPage 2 0 1) := by
+  rw [f2, LinearMap.range_comp, Submodule.range_mkQ, Submodule.map_top,
+    LinearMap.range_comp, LinearMap.range_comp, LinearEquiv.range, Submodule.map_top,
+    LinearEquiv.range, Submodule.map_top, Submodule.range_subtype]
+
+/-! ### Right edge `f₄ : E_2^{2,0} → H²` -/
+
+/-- `E_2^{2,0} ⧸ im(d₂) ≅ F^2 H^2 = E_∞^{2,0}`: at `(2,0)` only the incoming `d₂`
+survives, so page 3 = page ∞ and equals the top graded piece of `H²`. -/
+noncomputable def e2Iso20 (hK : K.FirstQuadrant) :
+    (K.page 2 2 2 ⧸ range (K.dPageFrom 2 2 2)) ≃ₗ[R] ↥(K.FH 2 2) := by
+  have hz : K.dPage 2 2 2 = 0 := K.dPage_eq_zero (hK.bot (show (2:ℤ) + 1 < 2 + 2 by norm_num))
+  have hker : ker (K.dPage 2 2 2) = ⊤ := by rw [hz, LinearMap.ker_zero]
+  have step2 : (K.page 2 2 2 ⧸ range (K.dPageFrom 2 2 2)) ≃ₗ[R] K.page 3 2 2 :=
+    ((K.pageSuccEquiv 2 2 2).trans
+      (quotComapTopEquiv hker (range (K.dPageFrom 2 2 2)))).symm
+  have hb : K.F (2 + 3) (2 + 1) = ⊥ := hK.bot (by norm_num)
+  have ht : K.F (2 - 3 + 1) (2 - 1) = ⊤ := hK.top (by norm_num)
+  refine step2.trans ((K.pageEquivGrHOfBounded hb ht).trans (Submodule.quotEquivOfEqBot _ ?_))
+  rw [FH_eq_bot (hK.bot (show (2:ℤ) < 2 + 1 by norm_num)),
+    Submodule.comap_bot, Submodule.ker_subtype]
+
+/-- The **right edge map** `f₄ : E_2^{2,0} → H^2`. -/
+noncomputable def f4 (hK : K.FirstQuadrant) : K.page 2 2 2 →ₗ[R] K.homology 2 :=
+  ((K.FH 2 2).subtype.comp (e2Iso20 hK).toLinearMap).comp
+    (range (K.dPageFrom 2 2 2)).mkQ
+
+lemma ker_f4 (hK : K.FirstQuadrant) : ker (f4 hK) = range (K.dPageFrom 2 2 2) := by
+  rw [f4, LinearMap.ker_comp,
+    LinearMap.ker_eq_bot.mpr ((Subtype.val_injective).comp (e2Iso20 hK).injective),
+    Submodule.comap_bot, Submodule.ker_mkQ]
+
+lemma range_f4 (hK : K.FirstQuadrant) : range (f4 hK) = K.FH 2 2 := by
+  rw [f4, LinearMap.range_comp, Submodule.range_mkQ, Submodule.map_top,
+    LinearMap.range_comp, LinearEquiv.range, Submodule.map_top, Submodule.range_subtype]
+
+/-! ### The five-term exact sequence -/
+
+/-- **The five-term exact sequence of a first-quadrant filtered complex** (FOAG §1.7,
+the "exact sequence of low-degree terms"):
+
+`0 → E_2^{1,0} → H¹ → E_2^{0,1} →^{d₂} E_2^{2,0} → H²`,
+
+i.e. `f₁` is injective and the sequence is exact at `H¹`, `E_2^{0,1}`, and
+`E_2^{2,0}`.  The middle map is the transgression `d₂`.  Applies to either spectral
+sequence of a first-quadrant double complex (both filtrations satisfy
+`FirstQuadrant`). -/
+theorem five_term_exact (hK : K.FirstQuadrant) :
+    Function.Injective (f1 hK) ∧
+    Function.Exact (f1 hK) (f2 hK) ∧
+    Function.Exact (f2 hK) K.d2 ∧
+    Function.Exact K.d2 (f4 hK) := by
+  refine ⟨f1_injective hK, ?_, ?_, ?_⟩
+  · rw [LinearMap.exact_iff, ker_f2, range_f1]
+  · rw [LinearMap.exact_iff, ker_d2_eq, range_f2]
+  · rw [LinearMap.exact_iff, ker_f4, range_d2_eq]
+
+end FiveTerm
+
+end FilteredComplex

--- a/FLT/Slop/SpectralSequence/FiveTerm.lean
+++ b/FLT/Slop/SpectralSequence/FiveTerm.lean
@@ -13,7 +13,7 @@ public import Mathlib.Tactic.NormNum
 # The five-term exact sequence of low-degree terms
 
 For a **first-quadrant** filtered complex — the filtration is `⊥` strictly above
-the diagonal and `⊤` at or below `0` (`FilteredComplex.FirstQuadrant`), which is
+the diagonal and `⊤` at or below `0` (`FilteredComplex.IsFirstQuadrant`), which is
 what the column/row filtrations of a first-quadrant double complex satisfy — the
 spectral sequence yields the classical five-term exact sequence of low-degree
 terms (FOAG §1.7)
@@ -31,11 +31,11 @@ needed to identify `d₂` with the abstract page differentials.
 
 ## Main definitions and results
 
-* `FilteredComplex.FirstQuadrant` : the first-quadrant condition on a filtered
+* `FilteredComplex.IsFirstQuadrant` : the first-quadrant condition on a filtered
   complex.
 * `FilteredComplex.d2` : the transgression `d₂ : E_2^{0,1} → E_2^{2,0}`.
 * `FilteredComplex.f1`, `FilteredComplex.f2`, `FilteredComplex.f4` : the edge
-  maps `E_2^{1,0} → H¹` (inflation), `H¹ → E_2^{0,1}` (restriction) and
+  edge maps `E_2^{1,0} → H¹` and `H¹ → E_2^{0,1}`, and
   `E_2^{2,0} → H²`.
 * `FilteredComplex.five_term_exact` : the five-term exact sequence — `f1` is
   injective and the sequence is exact at `H¹`, `E_2^{0,1}` and `E_2^{2,0}`.
@@ -82,7 +82,7 @@ noncomputable def pageSuccEquivOfStable {r p n : ℤ}
 /-- **First-quadrant condition** on a filtered complex: the filtration is `⊥`
 strictly above the diagonal (`n < p`) and `⊤` at or below `0`.  The column and row
 filtrations of a first-quadrant double complex both satisfy this. -/
-structure FirstQuadrant : Prop where
+structure IsFirstQuadrant : Prop where
   /-- The filtration vanishes strictly above the diagonal. -/
   bot : ∀ {p n : ℤ}, n < p → K.F p n = ⊥
   /-- The filtration is everything at or below filtration degree `0`. -/
@@ -92,13 +92,13 @@ variable {K}
 
 /-- If `F^p_n = ⊥` then the induced filtration piece `F^p H^n = ⊥`. -/
 lemma FH_eq_bot {p n : ℤ} (hF : K.F p n = ⊥) : K.FH p n = ⊥ := by
-  have hZ : K.Zinf p n = ⊥ := by unfold Zinf; rw [hF, bot_inf_eq]
+  have hZ : K.abutmentZ p n = ⊥ := by unfold abutmentZ; rw [hF, bot_inf_eq]
   unfold FH
   rw [hZ, Submodule.comap_bot, Submodule.ker_subtype, Submodule.map_bot]
 
 /-- If `F^p_n = ⊤` then the induced filtration piece `F^p H^n = ⊤`. -/
 lemma FH_eq_top {p n : ℤ} (hF : K.F p n = ⊤) : K.FH p n = ⊤ := by
-  have hZ : K.Zinf p n = ker (K.d n (n + 1)) := by unfold Zinf; rw [hF, top_inf_eq]
+  have hZ : K.abutmentZ p n = ker (K.d n (n + 1)) := by unfold abutmentZ; rw [hF, top_inf_eq]
   unfold FH
   rw [hZ, Submodule.comap_subtype_self, Submodule.map_top, Submodule.range_mkQ]
 
@@ -116,12 +116,12 @@ lemma ker_d2_eq : ker K.d2 = ker (K.dPage 2 0 1) := rfl
 (they are definitionally the same map). -/
 lemma range_d2_eq : range K.d2 = range (K.dPageFrom 2 2 2) := rfl
 
-/-! ### Left edge `f₁ : E_2^{1,0} → H¹` (inflation) -/
+/-! ### Left edge `f₁ : E_2^{1,0} → H¹` -/
 
 /-- `E_2^{1,0} ≅ F^1 H^1`: the `(1,0)` spot already stabilizes at page 2 (no
 differential touches it in the first quadrant), and its graded piece is the top of
 the 2-step filtration on `H¹`. -/
-noncomputable def e2Iso10 (hK : K.FirstQuadrant) :
+noncomputable def e2Iso10 (hK : K.IsFirstQuadrant) :
     K.page 2 1 1 ≃ₗ[R] ↥(K.FH 1 1) := by
   have hb : K.F (1 + 2) (1 + 1) = ⊥ := hK.bot (by norm_num)
   have ht : K.F (1 - 2 + 1) (1 - 1) = ⊤ := hK.top (by norm_num)
@@ -129,61 +129,63 @@ noncomputable def e2Iso10 (hK : K.FirstQuadrant) :
   rw [FH_eq_bot (hK.bot (show (1:ℤ) < 1 + 1 by norm_num)),
     Submodule.comap_bot, Submodule.ker_subtype]
 
-/-- The **left edge map** `f₁ : E_2^{1,0} → H^1` (inflation). -/
-noncomputable def f1 (hK : K.FirstQuadrant) : K.page 2 1 1 →ₗ[R] K.homology 1 :=
+/-- The **left edge map** `f₁ : E_2^{1,0} → H^1`. -/
+noncomputable def f1 (hK : K.IsFirstQuadrant) : K.page 2 1 1 →ₗ[R] K.homology 1 :=
   (K.FH 1 1).subtype.comp (e2Iso10 hK).toLinearMap
 
-lemma f1_injective (hK : K.FirstQuadrant) : Function.Injective (f1 hK) :=
+lemma f1_injective (hK : K.IsFirstQuadrant) : Function.Injective (f1 hK) :=
   (Subtype.val_injective).comp (e2Iso10 hK).injective
 
-lemma range_f1 (hK : K.FirstQuadrant) : range (f1 hK) = K.FH 1 1 := by
+lemma range_f1 (hK : K.IsFirstQuadrant) : range (f1 hK) = K.FH 1 1 := by
   rw [f1, LinearMap.range_comp, LinearEquiv.range, Submodule.map_top,
     Submodule.range_subtype]
 
-/-! ### Bottom edge `f₂ : H¹ → E_2^{0,1}` (restriction) -/
+/-! ### Bottom edge `f₂ : H¹ → E_2^{0,1}` -/
 
-/-- `E_∞^{0,1} = pageInf 0 1 ≅ ker(d₂)`: at `(0,1)` only the outgoing `d₂` survives,
-so page 3 = page ∞ and equals `ker d₂`. -/
-noncomputable def pageInfIso01 (hK : K.FirstQuadrant) :
-    K.pageInf 0 1 ≃ₗ[R] ↥(ker (K.dPage 2 0 1)) := by
+/-- At `(0,1)`, the finite pages stabilize at the associated-graded target,
+which is isomorphic to `ker(d₂)`: only the outgoing `d₂` survives. -/
+noncomputable def associatedGradedHomologyIso01 (hK : K.IsFirstQuadrant) :
+    K.associatedGradedHomology 0 1 ≃ₗ[R] ↥(ker (K.dPage 2 0 1)) := by
   have hb : K.F (0 + 3) (1 + 1) = ⊥ := hK.bot (by norm_num)
   have ht : K.F (0 - 3 + 1) (1 - 1) = ⊤ := hK.top (by norm_num)
-  refine (K.pageEquivPageInf hb ht).symm.trans
+  refine (K.pageEquivAssociatedGradedHomology hb ht).symm.trans
     ((K.pageSuccEquiv 2 0 1).trans (Submodule.quotEquivOfEqBot _ ?_))
   rw [K.dPageFrom_eq_zero (hK.top (show (0:ℤ) - 2 + 1 ≤ 0 by norm_num)),
     LinearMap.range_zero, Submodule.comap_bot, Submodule.ker_subtype]
 
-/-- `H¹ ⧸ F^1 H^1 ≅ E_∞^{0,1}`: the bottom graded piece of the filtration on `H¹`. -/
-noncomputable def grH1Iso (hK : K.FirstQuadrant) :
-    (K.homology 1 ⧸ K.FH 1 1) ≃ₗ[R] K.pageInf 0 1 :=
-  ((K.pageInfEquivGrH 0 1).trans
+/-- `H¹ ⧸ F^1 H^1` is isomorphic to the associated-graded target at `(0,1)`. -/
+noncomputable def grH1Iso (hK : K.IsFirstQuadrant) :
+    (K.homology 1 ⧸ K.FH 1 1) ≃ₗ[R] K.associatedGradedHomology 0 1 :=
+  ((K.associatedGradedHomologyEquivGrH 0 1).trans
     (quotComapTopEquiv (FH_eq_top (hK.top (show (0:ℤ) ≤ 0 by norm_num) : K.F 0 1 = ⊤))
       (K.FH 1 1))).symm
 
-/-- The **bottom edge map** `f₂ : H^1 → E_2^{0,1}` (restriction). -/
-noncomputable def f2 (hK : K.FirstQuadrant) : K.homology 1 →ₗ[R] K.page 2 0 1 :=
+/-- The **bottom edge map** `f₂ : H^1 → E_2^{0,1}`. -/
+noncomputable def f2 (hK : K.IsFirstQuadrant) : K.homology 1 →ₗ[R] K.page 2 0 1 :=
   ((ker (K.dPage 2 0 1)).subtype.comp
-    ((pageInfIso01 hK).toLinearMap.comp (grH1Iso hK).toLinearMap)).comp (K.FH 1 1).mkQ
+    ((associatedGradedHomologyIso01 hK).toLinearMap.comp
+      (grH1Iso hK).toLinearMap)).comp (K.FH 1 1).mkQ
 
-lemma f2_L_injective (hK : K.FirstQuadrant) :
+lemma f2_aux_injective (hK : K.IsFirstQuadrant) :
     Function.Injective ((ker (K.dPage 2 0 1)).subtype.comp
-      ((pageInfIso01 hK).toLinearMap.comp (grH1Iso hK).toLinearMap)) :=
-  (Subtype.val_injective).comp ((pageInfIso01 hK).injective.comp (grH1Iso hK).injective)
+      ((associatedGradedHomologyIso01 hK).toLinearMap.comp (grH1Iso hK).toLinearMap)) :=
+  (Subtype.val_injective).comp
+    ((associatedGradedHomologyIso01 hK).injective.comp (grH1Iso hK).injective)
 
-lemma ker_f2 (hK : K.FirstQuadrant) : ker (f2 hK) = K.FH 1 1 := by
-  rw [f2, LinearMap.ker_comp, LinearMap.ker_eq_bot.mpr (f2_L_injective hK),
+lemma ker_f2 (hK : K.IsFirstQuadrant) : ker (f2 hK) = K.FH 1 1 := by
+  rw [f2, LinearMap.ker_comp, LinearMap.ker_eq_bot.mpr (f2_aux_injective hK),
     Submodule.comap_bot, Submodule.ker_mkQ]
 
-lemma range_f2 (hK : K.FirstQuadrant) : range (f2 hK) = ker (K.dPage 2 0 1) := by
+lemma range_f2 (hK : K.IsFirstQuadrant) : range (f2 hK) = ker (K.dPage 2 0 1) := by
   rw [f2, LinearMap.range_comp, Submodule.range_mkQ, Submodule.map_top,
     LinearMap.range_comp, LinearMap.range_comp, LinearEquiv.range, Submodule.map_top,
     LinearEquiv.range, Submodule.map_top, Submodule.range_subtype]
 
 /-! ### Right edge `f₄ : E_2^{2,0} → H²` -/
 
-/-- `E_2^{2,0} ⧸ im(d₂) ≅ F^2 H^2 = E_∞^{2,0}`: at `(2,0)` only the incoming `d₂`
-survives, so page 3 = page ∞ and equals the top graded piece of `H²`. -/
-noncomputable def e2Iso20 (hK : K.FirstQuadrant) :
+/-- `E_2^{2,0} ⧸ im(d₂) ≅ F^2 H^2`: at `(2,0)` only the incoming `d₂`
+survives, so the finite pages stabilize at the top graded piece of `H²`. -/
+noncomputable def e2Iso20 (hK : K.IsFirstQuadrant) :
     (K.page 2 2 2 ⧸ range (K.dPageFrom 2 2 2)) ≃ₗ[R] ↥(K.FH 2 2) := by
   have hz : K.dPage 2 2 2 = 0 := K.dPage_eq_zero (hK.bot (show (2:ℤ) + 1 < 2 + 2 by norm_num))
   have hker : ker (K.dPage 2 2 2) = ⊤ := by rw [hz, LinearMap.ker_zero]
@@ -197,16 +199,16 @@ noncomputable def e2Iso20 (hK : K.FirstQuadrant) :
     Submodule.comap_bot, Submodule.ker_subtype]
 
 /-- The **right edge map** `f₄ : E_2^{2,0} → H^2`. -/
-noncomputable def f4 (hK : K.FirstQuadrant) : K.page 2 2 2 →ₗ[R] K.homology 2 :=
+noncomputable def f4 (hK : K.IsFirstQuadrant) : K.page 2 2 2 →ₗ[R] K.homology 2 :=
   ((K.FH 2 2).subtype.comp (e2Iso20 hK).toLinearMap).comp
     (range (K.dPageFrom 2 2 2)).mkQ
 
-lemma ker_f4 (hK : K.FirstQuadrant) : ker (f4 hK) = range (K.dPageFrom 2 2 2) := by
+lemma ker_f4 (hK : K.IsFirstQuadrant) : ker (f4 hK) = range (K.dPageFrom 2 2 2) := by
   rw [f4, LinearMap.ker_comp,
     LinearMap.ker_eq_bot.mpr ((Subtype.val_injective).comp (e2Iso20 hK).injective),
     Submodule.comap_bot, Submodule.ker_mkQ]
 
-lemma range_f4 (hK : K.FirstQuadrant) : range (f4 hK) = K.FH 2 2 := by
+lemma range_f4 (hK : K.IsFirstQuadrant) : range (f4 hK) = K.FH 2 2 := by
   rw [f4, LinearMap.range_comp, Submodule.range_mkQ, Submodule.map_top,
     LinearMap.range_comp, LinearEquiv.range, Submodule.map_top, Submodule.range_subtype]
 
@@ -220,8 +222,8 @@ the "exact sequence of low-degree terms"):
 i.e. `f₁` is injective and the sequence is exact at `H¹`, `E_2^{0,1}`, and
 `E_2^{2,0}`.  The middle map is the transgression `d₂`.  Applies to either spectral
 sequence of a first-quadrant double complex (both filtrations satisfy
-`FirstQuadrant`). -/
-theorem five_term_exact (hK : K.FirstQuadrant) :
+`IsFirstQuadrant`). -/
+theorem five_term_exact (hK : K.IsFirstQuadrant) :
     Function.Injective (f1 hK) ∧
     Function.Exact (f1 hK) (f2 hK) ∧
     Function.Exact (f2 hK) K.d2 ∧

--- a/FLT/Slop/SpectralSequence/FiveTerm.lean
+++ b/FLT/Slop/SpectralSequence/FiveTerm.lean
@@ -45,6 +45,8 @@ needed to identify `d₂` with the abstract page differentials.
 
 @[expose] public section
 
+namespace Slop
+
 open Submodule LinearMap
 
 namespace FilteredComplex
@@ -235,3 +237,5 @@ theorem five_term_exact (hK : K.IsFirstQuadrant) :
 end FiveTerm
 
 end FilteredComplex
+
+end Slop

--- a/FLT/Slop/SpectralSequence/README.md
+++ b/FLT/Slop/SpectralSequence/README.md
@@ -113,18 +113,18 @@ and no `sorry`, and the following all report exactly
 `[propext, Classical.choice, Quot.sound]`:
 
 ```lean
-#print axioms FilteredDifferentialModule.pageSuccEquiv
-#print axioms FilteredDifferentialModule.pageInfEquivGrHomology
-#print axioms FilteredDifferentialModule.gradedExactCouple
-#print axioms FilteredComplex.pageSuccEquiv
-#print axioms FilteredComplex.pageInfEquivGrH
-#print axioms FilteredComplex.toCohomologicalSpectralSequence
-#print axioms FilteredComplex.five_term_exact
-#print axioms DoubleComplex.totalIso
-#print axioms DoubleComplex.colPageOneEquiv
-#print axioms DoubleComplex.rowPageOneEquiv
-#print axioms DoubleComplex.colFiltered_five_term_exact
-#print axioms FilteredDifferentialModule.range_iMap_eq_ker_jMap
+#print axioms Slop.FilteredDifferentialModule.pageSuccEquiv
+#print axioms Slop.FilteredDifferentialModule.pageInfEquivGrHomology
+#print axioms Slop.FilteredDifferentialModule.gradedExactCouple
+#print axioms Slop.FilteredComplex.pageSuccEquiv
+#print axioms Slop.FilteredComplex.pageInfEquivGrH
+#print axioms Slop.FilteredComplex.toCohomologicalSpectralSequence
+#print axioms Slop.FilteredComplex.five_term_exact
+#print axioms Slop.DoubleComplex.totalIso
+#print axioms Slop.DoubleComplex.colPageOneEquiv
+#print axioms Slop.DoubleComplex.rowPageOneEquiv
+#print axioms Slop.DoubleComplex.colFiltered_five_term_exact
+#print axioms Slop.FilteredDifferentialModule.range_iMap_eq_ker_jMap
 ```
 
 ## Sources, and how the formalization deviates from them

--- a/FLT/Slop/SpectralSequence/README.md
+++ b/FLT/Slop/SpectralSequence/README.md
@@ -1,7 +1,8 @@
 # The spectral sequence of a filtered complex
 
-This folder constructs, from scratch at module level, the spectral sequence of
-a filtered differential module and of a filtered cochain complex, through to
+This folder constructs the spectral sequence of a filtered differential module
+and of a filtered cochain complex, using mathlib's standard complex and
+bicomplex structures, through to
 the classical applications: convergence to the associated graded of
 (co)homology, the five-term exact sequence of low-degree terms, and the two
 spectral sequences of a first-quadrant double complex with their
@@ -12,11 +13,18 @@ spectral sequences of a first-quadrant double complex with their
 noncomputable def FilteredComplex.pageSuccEquiv ... :
     K.page (r + 1) p n ≃ₗ[R] (ker (K.dPage r p n) ⧸ ...)
 
+-- the concrete pages packaged in mathlib's categorical API
+noncomputable def FilteredComplex.toCohomologicalSpectralSequence ... :
+    CategoryTheory.CohomologicalSpectralSequence (ModuleCat R) r₀
+
 -- convergence at a bounded spot: E_r^{p,n} ≅ gr^p H^n
 noncomputable def FilteredComplex.pageEquivGrHOfBounded ...
 
+-- the actual limit term has the same bounded identification
+noncomputable def FilteredComplex.pageInfEquivGrH ...
+
 -- the five-term exact sequence for a first-quadrant filtered complex
-theorem FilteredComplex.five_term_exact (hK : K.FirstQuadrant) :
+theorem FilteredComplex.five_term_exact (hK : K.IsFirstQuadrant) :
     Function.Injective K.f1 ∧ ... -- 0 → E₂^{1,0} → H¹ → E₂^{0,1} → E₂^{2,0} → H²
 
 -- E₁ of the column filtration is vertical cohomology
@@ -29,19 +37,24 @@ noncomputable def DoubleComplex.colPageOneEquiv ...
   differential `d` (`d² = 0`) and a decreasing `ℤ`-filtration preserved by
   `d`. Pages `E_r^p = Z_r^p / B_r^p`, page differentials with `d_r² = 0`, the
   main theorem `pageSuccEquiv : E_{r+1}^p ≅ ker d_r / im d_r`, `E₀` = the
-  associated graded, and the convergence theory: stabilization, the limit
-  page, `E_∞ ≅ gr H` for bounded filtrations, one-sided unbounded results,
+  associated graded, and the convergence theory: the limit term
+  `E_∞ = (⋂ (Z_r + F^{p+1}))/(⋃ (B_r + F^{p+1}))` (formed in `E₀`), the separate
+  associated-graded homology target, their identification under two-sided local
+  bounds, bounded-page convergence, and one-sided unbounded results,
   functoriality and the mapping lemma.
-- `FilteredComplex.lean` — the graded refinement `FilteredComplex R`
-  (`ℤ`-indexed modules, differential of degree one, filtration `F^p`): graded
-  pages `E_r^{p,n}`, the same main theorem per bidegree, and per-spot
-  convergence `pageEquivGrHOfBounded : E_r^{p,n} ≅ gr^p H^n`.
+- `FilteredComplex.lean` — the graded refinement `FilteredComplex R`, whose
+  underlying object is a standard `CochainComplex (ModuleCat R) ℤ` equipped
+  with a filtration by subcomplexes: graded pages `E_r^{p,n}`, the same main
+  theorem per bidegree, and per-spot convergence
+  `pageEquivGrHOfBounded : E_r^{p,n} ≅ gr^p H^n`.
 - `FiveTerm.lean` — for first-quadrant filtered complexes: the transgression
   `d₂`, the edge maps, and `five_term_exact`:
   `0 → E₂^{1,0} → H¹ → E₂^{0,1} → E₂^{2,0} → H²`.
-- `DoubleComplex.lean` — anticommuting double complexes, the total complex,
-  the column and row filtrations (on literally the same total complex, so
-  comparing the two abutments is `rfl`), first-quadrant boundedness, the
+- `DoubleComplex.lean` — mathlib `HomologicalComplex₂` objects, their standard
+  signed total differential, and column and row filtrations on the same
+  concrete total complex (hence with definitionally the same underlying
+  cohomology),
+  first-quadrant boundedness, the
   identifications `E₀` = the double complex itself with `d₀ = dv` (resp.
   `dh`), the full first-page identifications `colPageOneEquiv` /
   `rowPageOneEquiv` (`E₁` = vertical/horizontal cohomology, FOAG §1.7), and
@@ -51,7 +64,12 @@ noncomputable def DoubleComplex.colPageOneEquiv ...
   module, bridging to `FLT.Slop.ExactCouple`: `D^p = H(F^p M)`,
   `E^p = E₁^p`, the maps `i, j, k`, and the three exactness theorems
   `range_iMap_eq_ker_jMap`, `range_jMap_eq_ker_kMap`,
-  `range_kMap_eq_ker_iMap`, per filtration degree.
+  `range_kMap_eq_ker_iMap`, assembled as
+  `FilteredDifferentialModule.gradedExactCouple` on direct sums over the
+  filtration degree.
+- `CategoryTheory.lean` — packages each bigraded page as a
+  `HomologicalComplex (ModuleCat R)` and the full construction as mathlib's
+  `CategoryTheory.CohomologicalSpectralSequence`.
 
 ## What Is Proved
 
@@ -60,30 +78,33 @@ filtrations and no boundedness assumptions except where stated:
 
 - The full page/differential calculus of a filtered differential module and
   of a filtered complex, with `E_{r+1} ≅ H(E_r, d_r)` at every page and spot.
-- Convergence: `E_∞` and `E_r ≅ gr H` under (per-spot) boundedness; separated
-  and exhaustive statements in the unbounded case; functoriality of pages and
-  the mapping lemma (a filtered map inducing isomorphisms on one page does so
-  on all later pages).
+- Convergence: the true limit term `E_∞` is distinguished from the
+  associated-graded homology target; under two-sided local bounds they are
+  canonically isomorphic, and bounded finite pages satisfy `E_r ≅ gr H`.
+  There are also separated and exhaustive statements in the unbounded case.
+  Functoriality for `FilteredDifferentialModule.Hom` and its mapping lemma show
+  that a filtered map inducing isomorphisms on one page does so on all later
+  pages. `FilteredComplex.Hom` also induces maps on every page and a categorical
+  page functor.
 - The five-term exact sequence for any first-quadrant filtered complex, hence
   for both filtrations of any first-quadrant double complex.
 - `E₁` of the column (row) filtration of a double complex *is* vertical
   (horizontal) cohomology, at the level of differentials and of pages.
-- The per-degree exact couple of a filtered differential module.
+- The graded exact couple of a filtered differential module, with `i`, `j`,
+  and `k` of filtration degrees `-1`, `0`, and `1`.
 
 ## What Is Not Proved Here
 
-- The per-degree exact couple is not assembled into a
-  `GradedExactCouple` on `⨁_p H(F^p M)` (direct-sum packaging of the three
-  exactness statements), and the pages of the iterated couple are not yet
-  reconciled with the concrete `Z_r/B_r` pages — the classical comparison
-  theorem. This is the natural next step for the `ExactCouple` folder.
+- The pages of the iterated exact couple are not yet reconciled with the
+  concrete `Z_r/B_r` pages; that is the classical comparison theorem.
+- Naturality of `pageHomologyIso`, and hence a functor from filtered complexes
+  to `CategoryTheory.SpectralSequence`. The categorical construction is
+  packaged objectwise and is functorial page by page.
 - The abelian-category version of this machinery (it exists in the upstream
   development this folder is extracted from, over any abelian category via
   `Subobject`s, but is not part of this contribution).
 - Unbounded *conditional* convergence (Boardman) and multiplicative
   structures.
-- Adapters from mathlib's `HomologicalComplex`/`HomologicalComplex₂` (also
-  existing upstream, not included here).
 
 ## Verification
 
@@ -93,8 +114,13 @@ and no `sorry`, and the following all report exactly
 
 ```lean
 #print axioms FilteredDifferentialModule.pageSuccEquiv
+#print axioms FilteredDifferentialModule.pageInfEquivGrHomology
+#print axioms FilteredDifferentialModule.gradedExactCouple
 #print axioms FilteredComplex.pageSuccEquiv
+#print axioms FilteredComplex.pageInfEquivGrH
+#print axioms FilteredComplex.toCohomologicalSpectralSequence
 #print axioms FilteredComplex.five_term_exact
+#print axioms DoubleComplex.totalIso
 #print axioms DoubleComplex.colPageOneEquiv
 #print axioms DoubleComplex.rowPageOneEquiv
 #print axioms DoubleComplex.colFiltered_five_term_exact
@@ -109,30 +135,33 @@ and no `sorry`, and the following all report exactly
 2. C. Weibel, *An Introduction to Homological Algebra*, §5.4–5.5; R. Vakil,
    *The Rising Sea* (FOAG), §1.7 — for double complexes and the five-term
    sequence.
-3. Deviations chosen for formalization: the differential of a filtered
-   complex is an "all-pairs" family `d i j` (only `d n (n+1)` is nonzero),
-   and cycle/boundary submodules carry flexible index arguments, so that
+3. Formalization choices: the underlying filtered complex uses mathlib's
+   all-pairs `HomologicalComplex` differential (its shape axiom forces every
+   nonconsecutive component to be zero), and cycle/boundary submodules carry
+   flexible index arguments, so that
    index arithmetic like `(n+1)-1 = n` rewrites an *argument* of a
-   submodule-valued function rather than transporting along a type equality —
-   the entire development is free of `Eq.rec`. The column and row filtrations
-   of a double complex are filtrations of literally the same total complex,
-   so the two spectral sequences converge to the same abutment by `rfl`.
+   submodule-valued function rather than transporting along a type equality.
+   The column and row filtrations use literally the same total complex, so
+   their underlying cohomology objects agree definitionally; the induced
+   filtrations and associated-graded objects are different.
    The five-term sequence is stated at concrete indices `0, 1, 2`, letting
    the kernel discharge the index arithmetic definitionally.
 
 ## Relation to existing formalizations
 
 Mathlib's abstract `SpectralObject`/`SpectralSequence` frameworks (see the
-discussion in `FLT/Slop/ExactCouple/README.md`) contain no spectral sequence
-of a filtered complex of modules; the concrete construction here is
-independent of them. The sibling folder `FLT/Slop/ExactCouple` provides
-Massey's exact couples; `ExactCoupleBridge.lean` connects the two.
+discussion in `FLT/Slop/ExactCouple/README.md`) do not themselves construct the
+spectral sequence of a filtered complex of modules. The concrete construction
+here is independent at the proof level, while `CategoryTheory.lean` packages
+its pages and successor isomorphisms in mathlib's `SpectralSequence` API. The
+sibling folder `FLT/Slop/ExactCouple` provides Massey's exact couples;
+`ExactCoupleBridge.lean` connects the two.
 
 ## Possible next steps
 
-- Assemble `ExactCoupleBridge` into a `GradedExactCouple` on `⨁_p H(F^p M)`
-  and reconcile the couple's pages with `Z_r/B_r`.
-- The abelian-category version and the mathlib `HomologicalComplex` adapters.
+- Reconcile the iterated exact couple's pages with the concrete `Z_r/B_r`
+  construction.
+- Develop the abelian-category version.
 - The Hochschild–Serre spectral sequence: the descended `G ⧸ S`-action on
   `H^q(S, A)` (the `E₂` coefficient system) is already available in the
   `FLT/Slop/HochschildSerre` development.

--- a/FLT/Slop/SpectralSequence/README.md
+++ b/FLT/Slop/SpectralSequence/README.md
@@ -1,0 +1,138 @@
+# The spectral sequence of a filtered complex
+
+This folder constructs, from scratch at module level, the spectral sequence of
+a filtered differential module and of a filtered cochain complex, through to
+the classical applications: convergence to the associated graded of
+(co)homology, the five-term exact sequence of low-degree terms, and the two
+spectral sequences of a first-quadrant double complex with their
+`E₁ = column/row cohomology` identifications.
+
+```lean
+-- each page is the homology of the previous one
+noncomputable def FilteredComplex.pageSuccEquiv ... :
+    K.page (r + 1) p n ≃ₗ[R] (ker (K.dPage r p n) ⧸ ...)
+
+-- convergence at a bounded spot: E_r^{p,n} ≅ gr^p H^n
+noncomputable def FilteredComplex.pageEquivGrHOfBounded ...
+
+-- the five-term exact sequence for a first-quadrant filtered complex
+theorem FilteredComplex.five_term_exact (hK : K.FirstQuadrant) :
+    Function.Injective K.f1 ∧ ... -- 0 → E₂^{1,0} → H¹ → E₂^{0,1} → E₂^{2,0} → H²
+
+-- E₁ of the column filtration is vertical cohomology
+noncomputable def DoubleComplex.colPageOneEquiv ...
+```
+
+## File Guide
+
+- `FilteredModule.lean` — `FilteredDifferentialModule R M`: a module with a
+  differential `d` (`d² = 0`) and a decreasing `ℤ`-filtration preserved by
+  `d`. Pages `E_r^p = Z_r^p / B_r^p`, page differentials with `d_r² = 0`, the
+  main theorem `pageSuccEquiv : E_{r+1}^p ≅ ker d_r / im d_r`, `E₀` = the
+  associated graded, and the convergence theory: stabilization, the limit
+  page, `E_∞ ≅ gr H` for bounded filtrations, one-sided unbounded results,
+  functoriality and the mapping lemma.
+- `FilteredComplex.lean` — the graded refinement `FilteredComplex R`
+  (`ℤ`-indexed modules, differential of degree one, filtration `F^p`): graded
+  pages `E_r^{p,n}`, the same main theorem per bidegree, and per-spot
+  convergence `pageEquivGrHOfBounded : E_r^{p,n} ≅ gr^p H^n`.
+- `FiveTerm.lean` — for first-quadrant filtered complexes: the transgression
+  `d₂`, the edge maps, and `five_term_exact`:
+  `0 → E₂^{1,0} → H¹ → E₂^{0,1} → E₂^{2,0} → H²`.
+- `DoubleComplex.lean` — anticommuting double complexes, the total complex,
+  the column and row filtrations (on literally the same total complex, so
+  comparing the two abutments is `rfl`), first-quadrant boundedness, the
+  identifications `E₀` = the double complex itself with `d₀ = dv` (resp.
+  `dh`), the full first-page identifications `colPageOneEquiv` /
+  `rowPageOneEquiv` (`E₁` = vertical/horizontal cohomology, FOAG §1.7), and
+  the two five-term exact sequences `colFiltered_five_term_exact` /
+  `rowFiltered_five_term_exact`.
+- `ExactCoupleBridge.lean` — the exact couple of a filtered differential
+  module, bridging to `FLT.Slop.ExactCouple`: `D^p = H(F^p M)`,
+  `E^p = E₁^p`, the maps `i, j, k`, and the three exactness theorems
+  `range_iMap_eq_ker_jMap`, `range_jMap_eq_ker_kMap`,
+  `range_kMap_eq_ker_iMap`, per filtration degree.
+
+## What Is Proved
+
+Everything is for modules over an arbitrary ring, with `ℤ`-indexed decreasing
+filtrations and no boundedness assumptions except where stated:
+
+- The full page/differential calculus of a filtered differential module and
+  of a filtered complex, with `E_{r+1} ≅ H(E_r, d_r)` at every page and spot.
+- Convergence: `E_∞` and `E_r ≅ gr H` under (per-spot) boundedness; separated
+  and exhaustive statements in the unbounded case; functoriality of pages and
+  the mapping lemma (a filtered map inducing isomorphisms on one page does so
+  on all later pages).
+- The five-term exact sequence for any first-quadrant filtered complex, hence
+  for both filtrations of any first-quadrant double complex.
+- `E₁` of the column (row) filtration of a double complex *is* vertical
+  (horizontal) cohomology, at the level of differentials and of pages.
+- The per-degree exact couple of a filtered differential module.
+
+## What Is Not Proved Here
+
+- The per-degree exact couple is not assembled into a
+  `GradedExactCouple` on `⨁_p H(F^p M)` (direct-sum packaging of the three
+  exactness statements), and the pages of the iterated couple are not yet
+  reconciled with the concrete `Z_r/B_r` pages — the classical comparison
+  theorem. This is the natural next step for the `ExactCouple` folder.
+- The abelian-category version of this machinery (it exists in the upstream
+  development this folder is extracted from, over any abelian category via
+  `Subobject`s, but is not part of this contribution).
+- Unbounded *conditional* convergence (Boardman) and multiplicative
+  structures.
+- Adapters from mathlib's `HomologicalComplex`/`HomologicalComplex₂` (also
+  existing upstream, not included here).
+
+## Verification
+
+`lake build FLT.Slop.SpectralSequence` compiles with no errors, no warnings,
+and no `sorry`, and the following all report exactly
+`[propext, Classical.choice, Quot.sound]`:
+
+```lean
+#print axioms FilteredDifferentialModule.pageSuccEquiv
+#print axioms FilteredComplex.pageSuccEquiv
+#print axioms FilteredComplex.five_term_exact
+#print axioms DoubleComplex.colPageOneEquiv
+#print axioms DoubleComplex.rowPageOneEquiv
+#print axioms DoubleComplex.colFiltered_five_term_exact
+#print axioms FilteredDifferentialModule.range_iMap_eq_ker_jMap
+```
+
+## Sources, and how the formalization deviates from them
+
+1. Stacks Project, tags 012A (filtered differential objects) and 012K
+   (filtered complexes) — the construction of the pages follows the Stacks
+   presentation.
+2. C. Weibel, *An Introduction to Homological Algebra*, §5.4–5.5; R. Vakil,
+   *The Rising Sea* (FOAG), §1.7 — for double complexes and the five-term
+   sequence.
+3. Deviations chosen for formalization: the differential of a filtered
+   complex is an "all-pairs" family `d i j` (only `d n (n+1)` is nonzero),
+   and cycle/boundary submodules carry flexible index arguments, so that
+   index arithmetic like `(n+1)-1 = n` rewrites an *argument* of a
+   submodule-valued function rather than transporting along a type equality —
+   the entire development is free of `Eq.rec`. The column and row filtrations
+   of a double complex are filtrations of literally the same total complex,
+   so the two spectral sequences converge to the same abutment by `rfl`.
+   The five-term sequence is stated at concrete indices `0, 1, 2`, letting
+   the kernel discharge the index arithmetic definitionally.
+
+## Relation to existing formalizations
+
+Mathlib's abstract `SpectralObject`/`SpectralSequence` frameworks (see the
+discussion in `FLT/Slop/ExactCouple/README.md`) contain no spectral sequence
+of a filtered complex of modules; the concrete construction here is
+independent of them. The sibling folder `FLT/Slop/ExactCouple` provides
+Massey's exact couples; `ExactCoupleBridge.lean` connects the two.
+
+## Possible next steps
+
+- Assemble `ExactCoupleBridge` into a `GradedExactCouple` on `⨁_p H(F^p M)`
+  and reconcile the couple's pages with `Z_r/B_r`.
+- The abelian-category version and the mathlib `HomologicalComplex` adapters.
+- The Hochschild–Serre spectral sequence: the descended `G ⧸ S`-action on
+  `H^q(S, A)` (the `E₂` coefficient system) is already available in the
+  `FLT/Slop/HochschildSerre` development.


### PR DESCRIPTION
## Summary

Follow-up to #1108, stacked on its branch: the first four commits here *are* #1108, and only the last two are new. The delta is easiest to read at
https://github.com/j2d9w5xtjn-png/FLT/compare/slop-exact-couples...slop-exact-couples-namespace (commits `86cfd672` and `cc3a25a8`).

- **doc**: drop a dangling `GradedAbelian.grH` cross-reference (a module that is not part of the contribution) from the `grH` docstring, and fix an "edge edge maps" typo in the `FiveTerm` module docstring.
- **refactor**: move all declarations into the `Slop` namespace, per the `FLT/Slop` dedicated-namespace convention: `Slop.ExactCouple`, `Slop.GradedExactCouple`, `Slop.FilteredDifferentialModule`, `Slop.FilteredComplex`, `Slop.DoubleComplex`, with the auxiliary direct-sum helpers at `Slop.DirectSum.*` — no more additions to root namespaces. The READMEs' declaration names and namespace rationale are updated to match.

One subtlety worth a reviewer's eye: once imports populate the `Slop.DirectSum` namespace, a later file inside `namespace Slop` that writes `open scoped DirectSum` silently resolves to `Slop.DirectSum` and loses mathlib's `⨁` notation. `ExactCoupleBridge.lean` therefore opens `scoped _root_.DirectSum`, with a comment explaining why.

## Verification

- `lake build FLT` — 8,883 jobs, no errors, no warnings;
- `lake exe runLinter FLT` — passed;
- the fourteen representative `#print axioms` checks listed in the two READMEs all still report exactly `[propext, Classical.choice, Quot.sound]` under the `Slop.`-prefixed names.

Blocked on #1108; do not merge before it. Will rebase if #1108 changes during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
