### PR TITLE
Make CI enforce --iofail on lake test; fix FLTTest copyright headers

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -81,7 +81,7 @@ jobs:
       # Remove once leanprover/lean-action#153 is merged.
       - name: Set TEST_ARGS manually
         run: |
-          echo "TEST_ARGS='--iofail'" >> $GITHUB_ENV
+          echo "TEST_ARGS=--iofail" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Build and lint project

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -76,6 +76,14 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
 
+      # lean-action drops the test-args input (leanprover/lean-action#163), so
+      # export TEST_ARGS directly: lake_test.sh reads it from the environment.
+      # Remove once leanprover/lean-action#153 is merged.
+      - name: Set TEST_ARGS manually
+        run: |
+          echo "TEST_ARGS='--iofail'" >> $GITHUB_ENV
+        shell: bash
+
       - name: Build and lint project
         uses: leanprover/lean-action@v1
         with:

--- a/FLTTest/FLTTest.lean
+++ b/FLTTest/FLTTest.lean
@@ -1,6 +1,1 @@
-/-
-Copyright (c) 2026 Kevin Buzzard. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kevin Buzzard
--/
 import FLTTest.MathlibCompatibility

--- a/FLTTest/FLTTest.lean
+++ b/FLTTest/FLTTest.lean
@@ -1,1 +1,6 @@
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
 import FLTTest.MathlibCompatibility

--- a/FLTTest/MathlibCompatibility.lean
+++ b/FLTTest/MathlibCompatibility.lean
@@ -9,3 +9,6 @@ import FLT
 /-!
 Check that no FLT declarations conflict with Mathlib.
 -/
+
+-- CANARY: temporary, to be reverted
+#eval 1

--- a/FLTTest/MathlibCompatibility.lean
+++ b/FLTTest/MathlibCompatibility.lean
@@ -9,6 +9,3 @@ import FLT
 /-!
 Check that no FLT declarations conflict with Mathlib.
 -/
-
--- CANARY: temporary, to be reverted
-#eval 1

--- a/FLTTest/MathlibCompatibility.lean
+++ b/FLTTest/MathlibCompatibility.lean
@@ -1,7 +1,11 @@
 /-
-
-Check that no FLT declarations conflict with Mathlib.
-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
 -/
 import Mathlib
 import FLT
+
+/-!
+Check that no FLT declarations conflict with Mathlib.
+-/


### PR DESCRIPTION
CI declares `test-args: --iofail` on the `lean-action` step, but lean-action silently drops the `test-args` input (leanprover/lean-action#163). So `lake test` has been running with no arguments, and warnings in test targets don't fail CI.

This PR:

1. Adds the `GITHUB_ENV` workaround (same as [cslib's](https://github.com/leanprover/cslib/commit/1d91c3f242d435f8d97b4511d254b35e82dea4c3)): a step exporting `TEST_ARGS='--iofail'`, which does reach `lake_test.sh`. The existing `test-args` input stays so behavior is unchanged when the action is fixed, at which point the workaround step can be deleted
2. Fixes the headers that would otherwise fail under the now-enforced flag