### PR TITLE
feat: prove injective_hRat and injective_zHat in HurwitzRatHat

### DIFF
--- a/FLT/Data/Hurwitz.lean
+++ b/FLT/Data/Hurwitz.lean
@@ -591,4 +591,17 @@ lemma left_ideal_princ (I : Submodule 𝓞 𝓞) : ∃ a : 𝓞, I = Submodule.s
   · rw [Submodule.span_singleton_le_iff_mem]
     exact a.2.1
 
+open Quaternion in
+/-- The embedding of the Hurwitz integers into the rational quaternions, as an additive
+monoid homomorphism. -/
+noncomputable def toQuaternionAddHom : 𝓞 →+ ℍ where
+  toFun := toQuaternion
+  map_zero' := toQuaternion_zero
+  map_add' := toQuaternion_add
+
+open Quaternion in
+instance : IsAddTorsionFree 𝓞 :=
+  have : IsAddTorsionFree ℍ := IsAddTorsionFree.of_isTorsionFree ℝ ℍ
+  Function.Injective.isAddTorsionFree toQuaternionAddHom toQuaternion_injective
+
 end Hurwitz

--- a/FLT/Data/HurwitzRatHat.lean
+++ b/FLT/Data/HurwitzRatHat.lean
@@ -8,6 +8,7 @@ module
 public import FLT.Data.Hurwitz
 public import FLT.Data.QHat
 import Mathlib.CategoryTheory.Category.Init
+import Mathlib.RingTheory.Flat.TorsionFree
 import Mathlib.Tactic.Positivity.Finset
 
 /-!
@@ -38,6 +39,8 @@ scoped notation "𝓞^" => HurwitzHat
 
 noncomputable instance : Ring 𝓞^ := Algebra.TensorProduct.instRing
 
+instance : Module.Flat ℤ 𝓞^ := by unfold HurwitzHat; infer_instance
+
 end HurwitzHat
 
 /-- The quaternion algebra ℚ + ℚi + ℚj + ℚk. -/
@@ -49,6 +52,8 @@ namespace HurwitzRat
 scoped notation "D" => HurwitzRat
 
 noncomputable instance : Ring D := Algebra.TensorProduct.instRing
+
+instance : Module.Flat ℤ D := by unfold HurwitzRat; infer_instance
 
 end HurwitzRat
 
@@ -71,7 +76,17 @@ noncomputable abbrev j₁ : D →ₐ[ℤ] D^ := Algebra.TensorProduct.includeLef
 -- (Algebra.TensorProduct.assoc ℤ ℚ 𝓞 ZHat).symm.trans Algebra.TensorProduct.includeLeft
 
 lemma injective_hRat :
-    Function.Injective j₁ := sorry -- flatness
+    Function.Injective j₁ := by
+  intro a b h
+  have h₁ := LinearMap.lTensor_tmul D (f := Algebra.linearMap ℤ ZHat) a 1
+  have h₂ := LinearMap.lTensor_tmul D (f := Algebra.linearMap ℤ ZHat) b 1
+  simp only [Algebra.linearMap_apply, map_one] at h₁ h₂
+  replace h : a ⊗ₜ[ℤ] (1 : ZHat) = b ⊗ₜ[ℤ] 1 := h
+  rw [← h₁, ← h₂] at h
+  replace h := Module.Flat.lTensor_preserves_injective_linearMap
+    (M := D) (Algebra.linearMap ℤ ZHat) (FaithfulSMul.algebraMap_injective ℤ ZHat) h
+  have := congrArg (TensorProduct.rid ℤ D) h
+  simpa using this
 
 -- this stopped working in 4.29
 noncomputable instance : Ring (ℚ ⊗[ℤ] 𝓞^) := Algebra.TensorProduct.instRing
@@ -86,8 +101,22 @@ noncomputable abbrev j₂ : 𝓞^ →ₐ[ℤ] D^ :=
   ((Algebra.TensorProduct.assoc ℤ ℤ ℤ ℚ 𝓞 ZHat).symm : ℚ ⊗[ℤ] 𝓞^ ≃ₐ[ℤ] D ⊗[ℤ] ZHat).toAlgHom.comp
   (Algebra.TensorProduct.includeRight : 𝓞^ →ₐ[ℤ] ℚ ⊗[ℤ] 𝓞^)
 
+lemma injective_includeRight :
+    Function.Injective (Algebra.TensorProduct.includeRight : 𝓞^ →ₐ[ℤ] ℚ ⊗[ℤ] 𝓞^) := by
+  intro a b h
+  have h₁ := LinearMap.rTensor_tmul 𝓞^ (f := Algebra.linearMap ℤ ℚ) a 1
+  have h₂ := LinearMap.rTensor_tmul 𝓞^ (f := Algebra.linearMap ℤ ℚ) b 1
+  simp only [Algebra.linearMap_apply, map_one] at h₁ h₂
+  dsimp at h
+  rw [← h₁, ← h₂] at h
+  replace h := Module.Flat.rTensor_preserves_injective_linearMap
+    (M := 𝓞^) (Algebra.linearMap ℤ ℚ) (fun _ _ ↦ by simp) h
+  have := congrArg (TensorProduct.lid ℤ 𝓞^) h
+  simpa using this
+
 lemma injective_zHat :
-    Function.Injective j₂ := sorry -- flatness
+    Function.Injective j₂ :=
+  (Algebra.TensorProduct.assoc ℤ ℤ ℤ ℚ 𝓞 ZHat).symm.injective.comp injective_includeRight
 
 -- should I rearrange tensors? Not sure if D^ should be (ℚ ⊗ 𝓞) ⊗ ℤhat or ℚ ⊗ (𝓞 ⊗ Zhat)
 lemma canonicalForm (z : D^) : ∃ (N : ℕ+) (z' : 𝓞^), z = j₁ ((N⁻¹ : ℚ) ⊗ₜ 1 : D) * j₂ z' := by

--- a/FLT/Data/HurwitzRatHat.lean
+++ b/FLT/Data/HurwitzRatHat.lean
@@ -39,7 +39,7 @@ scoped notation "𝓞^" => HurwitzHat
 
 noncomputable instance : Ring 𝓞^ := Algebra.TensorProduct.instRing
 
-instance : Module.Flat ℤ 𝓞^ := by unfold HurwitzHat; infer_instance
+instance : Module.Flat ℤ 𝓞^ := inferInstanceAs (Module.Flat ℤ (𝓞 ⊗[ℤ] ZHat))
 
 end HurwitzHat
 
@@ -53,7 +53,7 @@ scoped notation "D" => HurwitzRat
 
 noncomputable instance : Ring D := Algebra.TensorProduct.instRing
 
-instance : Module.Flat ℤ D := by unfold HurwitzRat; infer_instance
+instance : Module.Flat ℤ D := inferInstanceAs (Module.Flat ℤ (ℚ ⊗[ℤ] 𝓞))
 
 end HurwitzRat
 


### PR DESCRIPTION
Fills the two sorries marked `-- flatness` in `FLT/Data/HurwitzRatHat.lean`.

The missing piece was a `Module.Flat ℤ 𝓞` instance for the Hurwitz order. This PR:

- adds an `IsAddTorsionFree 𝓞` instance in `FLT/Data/Hurwitz.lean`, transported along the injective `toQuaternion` via a new bundled `toQuaternionAddHom : 𝓞 →+ ℍ` (ℍ is torsion-free as an ℝ-module, and torsion-free over the Dedekind domain ℤ gives flatness via existing mathlib instances);
- adds `Module.Flat ℤ` instances for `𝓞^` and `D` (tensor products of flats);
- proves `injective_hRat` (`lTensor` of the injective `ℤ → ℤ̂` into the flat `D`) and `injective_zHat` (an `injective_includeRight` helper mirroring `QHat.injective_zHat`, composed with the injective `assoc.symm`).

The two remaining sorries (`canonicalForm`, `completed_units`) are genuinely different (denominator-clearing / units machinery) and are left for follow-ups.

Verification: `lake build FLT` green on top of current `main` (post-#1100 mathlib bump); the four new declarations depend only on `propext`, `Classical.choice`, `Quot.sound`.