### PR TITLE
Convert FLTTest to the module system

### DIFF
--- a/FLTTest.lean
+++ b/FLTTest.lean
@@ -1,2 +1,4 @@
-import FLTTest.FLTTest
-import FLTTest.MathlibCompatibility
+module  -- shake: keep-all --deprecated_module: ignore
+
+public import FLTTest.FLTTest
+public import FLTTest.MathlibCompatibility

--- a/FLTTest/FLTTest.lean
+++ b/FLTTest/FLTTest.lean
@@ -3,4 +3,6 @@ Copyright (c) 2026 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard
 -/
-import FLTTest.MathlibCompatibility
+module
+
+public import FLTTest.MathlibCompatibility

--- a/FLTTest/MathlibCompatibility.lean
+++ b/FLTTest/MathlibCompatibility.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard
 -/
-import Mathlib
-import FLT
+module
+
+public import Mathlib
+public import FLT
 
 /-!
 Check that no FLT declarations conflict with Mathlib.


### PR DESCRIPTION
## What changed

- Convert the `FLTTest` library and its aggregator to the module system.
- Use public imports throughout the test library.
- Make the generated `FLTTest.lean` agree with `lake exe mk_all --module`.

## Why

Running `lake exe mk_all --module` converted `FLTTest.lean` into a module, but its imported files remained legacy non-module files. Consequently, `lake test` failed with `cannot import non-module FLTTest.FLTTest from module`.

Converting the complete test library fixes that module boundary and makes regeneration idempotent.

## Validation

- `lake test --iofail`
- `lake build --iofail`
- `lake lint --iofail`
- `lake exe mk_all --check`
- `lake exe mk_all --module` reports `No update necessary`

Closes #1116
