### PR TITLE
perf: remove the respectTransparency workarounds in the #889/#891 hotspot files

### DIFF
--- a/FLT/DedekindDomain/Completion/BaseChange.lean
+++ b/FLT/DedekindDomain/Completion/BaseChange.lean
@@ -106,6 +106,14 @@ end assumptions
 
 variable [Algebra.IsIntegral A B] [IsFractionRing B L] [IsDedekindDomain B]
 
+/- The `K_v`-algebra structure on `∏_{w|v} L_w` is built through `adicCompletion.semialgHomPi`,
+`Pi.semialgHom` and `RingHom.pi`, so instance-implicit defeq checks (e.g. relating `ψ.toAlgebra`
+with the componentwise `Pi` instances) must be able to see through them at `instances`
+transparency (`backward.isDefEq.respectTransparency := true`, the default since Lean v4.29).
+`semialgHomPi` and FLT's own `Pi.semialgHom` are tagged `@[implicit_reducible]` at their
+definitions; mathlib-owned `RingHom.pi` gets a local attribute here. -/
+attribute [local implicit_reducible] RingHom.pi
+
 namespace IsDedekindDomain.HeightOneSpectrum
 
 variable (v : HeightOneSpectrum A) {A B}
@@ -251,6 +259,7 @@ namespace adicCompletion
 variable (B)
 
 /-- The canonical map `K_v → ∏_{w|v} L_w` extending K → L. -/
+@[implicit_reducible]
 noncomputable def semialgHomPi :
     v.adicCompletion K →ₛₐ[algebraMap K L] ∀ w : v.Extension B, w.1.adicCompletion L :=
   Pi.semialgHom _ _ fun i ↦ i.adicCompletionSemialgHom K L
@@ -291,7 +300,6 @@ noncomputable local instance :
     · apply ne_of_lt
       rwa [valuation_of_algebraMap, intValuation_lt_one_iff_mem]
 
-set_option backward.isDefEq.respectTransparency false in
 open scoped TensorProduct.RightActions in
 /-- The canonical map `L ⊗[K] K_v → ∏_{w|v} L_w` is surjective. -/
 lemma baseChangeRight_surjective [FiniteDimensional K L] :
@@ -779,7 +787,6 @@ noncomputable def baseChangeAlgEquiv :
     L ⊗[K] v.adicCompletion K ≃ₐ[L] Π w : v.Extension B, w.1.adicCompletion L :=
   AlgEquiv.ofBijective (baseChange K L B v) <| baseChange_bijective K L B v
 
-set_option backward.isDefEq.respectTransparency false in
 open scoped TensorProduct.RightActions in
 /-- The continuous L-algebra isomorphism `L ⊗[K] K_v ≅ ∏_{w|v} L_w`. -/
 noncomputable def baseChangeContinuousAlgEquiv :

--- a/FLT/DivisionAlgebra/Finiteness.lean
+++ b/FLT/DivisionAlgebra/Finiteness.lean
@@ -515,6 +515,14 @@ instance (vi : InfinitePlace K) : IsModuleTopology ℝ (D ⊗[K] vi.Completion) 
 instance : IsModuleTopology ℝ (Π vi : InfinitePlace K, (D ⊗[K] vi.Completion)) :=
   IsModuleTopology.instPi
 
+/- This lemma still needs the pre-Lean-v4.29 permissive defeq behaviour: its `simp_all` calls
+unfold `ringEquiv_mixedSpace`, and re-typechecking the resulting structure literals requires
+unfolding the field auxiliaries (`instCommRingInfiniteAdeleRing._aux_*`) of the `deriving`-
+generated `CommRing (InfiniteAdeleRing K)` instance, e.g.
+`f i * g i =?= instCommRingInfiniteAdeleRing._aux_13 K f g i` and
+`f i + g i =?= instCommRingInfiniteAdeleRing._aux_1 K f g i`. Those auxiliaries are
+machine-generated (unstable names), so they cannot reasonably be marked `implicit_reducible`
+here; fixing this needs an upstream mathlib change to how the instance is derived. -/
 set_option backward.isDefEq.respectTransparency false in
 omit [NumberField K] in
 lemma algebraMap_completion {vi : InfinitePlace K} {x : ℝ} :
@@ -530,7 +538,6 @@ lemma algebraMap_completion {vi : InfinitePlace K} {x : ℝ} :
 
 end RealAlgebra
 
-set_option backward.isDefEq.respectTransparency false in
 omit [NumberField K] in
 lemma tensorPi_equiv_piTensor_map_mul {x y : Dinf K D} :
     tensorPiEquivPiTensor K D InfinitePlace.Completion (x * y)
@@ -538,6 +545,14 @@ lemma tensorPi_equiv_piTensor_map_mul {x y : Dinf K D} :
       * tensorPiEquivPiTensor K D InfinitePlace.Completion y := by
   -- we need that `tensorPiEquivPiTensor` is a ring hom
   -- **TODO** this is certainly true in more generality and so can go elsewhere later on
+  -- Restate everything at the `Π v, v.Completion` spelling (a definitional change), so that
+  -- the `simp` lemmas below apply without having to see through the type synonym
+  -- `InfiniteAdeleRing` at `instances` transparency.
+  suffices h : ∀ x y : D ⊗[K] ((i : InfinitePlace K) → i.Completion),
+      tensorPiEquivPiTensor K D InfinitePlace.Completion (x * y)
+      = tensorPiEquivPiTensor K D InfinitePlace.Completion x
+        * tensorPiEquivPiTensor K D InfinitePlace.Completion y from h x y
+  intro x y
   refine TensorProduct.induction_on x
     (by simp only [LinearEquiv.map_zero, zero_mul])
     (fun x₁ x₂ ↦ ?_) (fun x₁ x₂ hx₁ hx₂ ↦ by
@@ -547,9 +562,8 @@ lemma tensorPi_equiv_piTensor_map_mul {x y : Dinf K D} :
     (fun y₁ y₂ ↦ ?_) (fun y₁ y₂ hy₁ hy₂ ↦ by
       simp_all only [LinearEquiv.map_add, mul_add])
   funext vi
-  simp [Dinf, InfiniteAdeleRing, tensorPi_equiv_piTensor_apply]
+  simp [tensorPi_equiv_piTensor_apply]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- `tensorPiEquivPiTensor` applied to `Dinf`, as a `ℝ`-linear equiv. -/
 def DinfTensorPiEquivPiTensorAux :
     (Dinf K D) ≃ₗ[ℝ] Π vi : InfinitePlace K, (D ⊗[K] vi.Completion) := {
@@ -563,10 +577,12 @@ def DinfTensorPiEquivPiTensorAux :
     have h₂ :
         (algebraMap ℝ ((i : InfinitePlace K) → D ⊗[K] i.Completion)) x
         = fun (i : InfinitePlace K) ↦ 1 ⊗ₜ[K] (algebraMap ℝ i.Completion x) := rfl
-    rw [h₁, h₂, tensorPi_equiv_piTensor_apply]
-    funext vi
-    congr
-    exact algebraMap_completion _
+    rw [h₁, h₂]
+    -- cross the `K∞`/`Π v, v.Completion` spelling boundary with a term-level `exact`
+    -- (defeq at default transparency) instead of `rw`, whose pattern matching cannot see
+    -- through the type synonym `InfiniteAdeleRing` at `instances` transparency
+    exact (tensorPi_equiv_piTensor_apply K D InfinitePlace.Completion 1 _).trans
+      (by funext vi; congr 1; exact algebraMap_completion _)
 }
 
 /-- `tensorPiEquivPiTensor` applied to `Dinf`, as a continuous `ℝ`-linear equiv. -/
@@ -928,7 +944,13 @@ abbrev toQuot (a : ringHaarCharKer D_𝔸) : (_root_.Quotient (QuotientGroup.rig
 lemma toQuot_cont : Continuous (toQuot K D) where
   isOpen_preimage := fun _ a ↦ a
 
-set_option backward.isDefEq.respectTransparency false in
+/- The proof below mixes the spellings `H.subgroupOf N` and `Subgroup.comap N.subtype H` of
+the same subgroup (`Subgroup.subgroupOf` is a plain `def` of the latter), inside `Quotient`
+types of `QuotientGroup.rightRel`. Instance-implicit defeq checks between the two spellings
+must succeed at `instances` transparency (`backward.isDefEq.respectTransparency := true`, the
+default since Lean v4.29), so mark the definition `implicit_reducible`. -/
+attribute [local implicit_reducible] Subgroup.subgroupOf
+
 lemma toQuot_surjective [Algebra.IsCentral K D] : (toQuot K D) '' (M K D) = Set.univ := by
   rw [Set.eq_univ_iff_forall]
   rintro ⟨a, ha⟩

--- a/FLT/HaarMeasure/HaarChar/FiniteAdeleRing.lean
+++ b/FLT/HaarMeasure/HaarChar/FiniteAdeleRing.lean
@@ -117,7 +117,14 @@ local instance :
     Set (v.adicCompletion K))) :=
   ⟨isOpenAdicCompletionIntegers K⟩
 
-set_option backward.isDefEq.respectTransparency false in
+/- The compact open subgroups `∏ᵢ 𝓞ᵥ` used below are built through `AddSubgroup.pi` and
+`AddSubmonoid.pi`, so instance-implicit defeq checks (e.g. relating membership in
+`↑(AddSubgroup.pi …)` with the underlying `Set.pi` of the `AddSubmonoid` carriers) must be
+able to see through them. Mark them `implicit_reducible` so that these checks succeed at
+`instances` transparency (`backward.isDefEq.respectTransparency := true`, the default since
+Lean v4.29). -/
+attribute [local implicit_reducible] AddSubgroup.pi AddSubmonoid.pi
+
 local instance (v : HeightOneSpectrum (𝓞 K)) :
     CompactSpace (AddSubgroup.pi (Set.univ : Set (Module.Free.ChooseBasisIndex K B))
       fun _ ↦ (adicCompletionIntegers K v).toAddSubgroup) := by
@@ -356,7 +363,6 @@ noncomputable def φLocalKvLinear (v : HeightOneSpectrum (𝓞 K))
     | add x y _ _ => simp_all only [AlgHom.toRingHom_eq_coe, smul_add, map_add]
 }
 
-set_option backward.isDefEq.respectTransparency false in
 lemma localcomponent_matrix (v : HeightOneSpectrum (𝓞 K))
     (φ : FiniteAdeleRing (𝓞 K) K ⊗[K] B ≃L[FiniteAdeleRing (𝓞 K) K]
       FiniteAdeleRing (𝓞 K) K ⊗[K] B)
@@ -402,7 +408,9 @@ lemma localcomponent_matrix (v : HeightOneSpectrum (𝓞 K))
   have rTensor_basis (j : Module.Free.ChooseBasisIndex K B) :
       (AlgHom.rTensor B (FiniteAdeleRing.evalAlgebraMap (𝓞 K) K v)) (b j)
       = bLocal j := by
-    simp [AlgHom.rTensor, b, bLocal]
+    -- rewrite with `AlgHom.rTensor_tmul` rather than unfolding `AlgHom.rTensor`, whose
+    -- structure-literal applications fail defeq checks at `instances` transparency
+    simp only [b, bLocal, Module.Basis.baseChange_apply, AlgHom.rTensor_tmul, map_one]
   have eval_mulVec_eq (j : Module.Free.ChooseBasisIndex K B) :
       (FiniteAdeleRing.evalAlgebraMap (𝓞 K) K v)
           (((LinearMap.toMatrix b b) ↑φ.toLinearEquiv).mulVec (⇑(b.repr (1 ⊗ₜ[K] r))) j)
@@ -415,7 +423,11 @@ lemma localcomponent_matrix (v : HeightOneSpectrum (𝓞 K))
     ext i
     simp [b, bLocal, evalRingHom, evalMonoidHom, Algebra.smul_def]
     rfl
-  simp [-Matrix.toLin_toMatrix, Matrix.toLin_apply, rTensor_basis, eval_mulVec_eq]
+  -- a deterministic version of `simp [-Matrix.toLin_toMatrix, Matrix.toLin_apply,
+  -- rTensor_basis, eval_mulVec_eq]`, which relied on defeq checks that fail at
+  -- `instances` transparency
+  simp only [Matrix.toLin_apply, map_sum, AlgHom.rTensor_map_smul, rTensor_basis,
+    eval_mulVec_eq]
   /-
 
   localcomponent stuff and `single` (an annoying linear map) now gone.
@@ -518,7 +530,14 @@ lemma FiniteAdeleRing.Aux.almost_always_bijOn
   intro v h1 h2
   exact (e K B v (FiniteAdeleRing.TensorProduct.localcomponentEquiv (𝓞 K) K B v φ)).bijOn' h1 h2
 
-set_option backward.isDefEq.respectTransparency false in
+/- The proof below unfolds `FiniteAdeleRing` (a plain `def` of the restricted product
+`Πʳ [K_v, 𝓞_v]`, whose instances are inherited from it) with `simp`, so defeq checks between
+the two spellings must succeed at `instances` transparency
+(`backward.isDefEq.respectTransparency := true`, the default since Lean v4.29). Mark it and
+the underlying type synonym `RestrictedProduct` (a plain `def` of a subtype)
+`implicit_reducible`. -/
+attribute [local implicit_reducible] IsDedekindDomain.FiniteAdeleRing RestrictedProduct
+
 /-- A diagram which obviously commutes, commutes. -/
 lemma FiniteAdeleRing.Aux.f_g_local_global
     (φ : ((FiniteAdeleRing (𝓞 K) K) ⊗[K] B) ≃L[FiniteAdeleRing (𝓞 K) K]
@@ -561,8 +580,12 @@ lemma FiniteAdeleRing.Aux.f_g_local_global
       (∑ x, f x) v = ∑ x, f x v :=
     -- general lemma
     map_sum (RestrictedProduct.evalAddMonoidHom _ _) _ _
-  simp [-Matrix.toLin'_toMatrix', Matrix.mulVec, dotProduct, this, FiniteAdeleRing,
-    mul_comm (r v _) _]
+  simp only [FiniteAdeleRing, Matrix.toLin'_apply, Matrix.mulVec, dotProduct,
+    LinearMap.toMatrix'_apply, LinearEquiv.coe_coe, ContinuousLinearEquiv.coe_toLinearEquiv,
+    this, smul_eq_mul, mul_comm (r v _) _]
+  -- the summands agree by unfolding evaluation of a product/`map` in the restricted
+  -- product, which is a definitional equality (at default transparency)
+  exact Finset.sum_congr rfl fun x _ ↦ rfl
 
 lemma localcomponent_mulLeft (u : ((FiniteAdeleRing (𝓞 K) K) ⊗[K] B)ˣ)
     (v : HeightOneSpectrum (𝓞 K)) :

--- a/FLT/Mathlib/Algebra/Algebra/Pi.lean
+++ b/FLT/Mathlib/Algebra/Algebra/Pi.lean
@@ -18,7 +18,12 @@ Material destined for Mathlib.
 @[expose] public section
 
 /-- A family of semialgebra homomorphisms `g i : A →ₛₐ[φ] f i` defines a single
-semialgebra homomorphism `A →ₛₐ[φ] (i : I) → f i` to the product algebra. -/
+semialgebra homomorphism `A →ₛₐ[φ] (i : I) → f i` to the product algebra.
+
+Tagged `@[implicit_reducible]` so instance-implicit defeq checks can see through it at
+`instances` transparency: algebra structures built via `Pi.semialgHom` must unify with the
+componentwise `Pi` instances without `backward.isDefEq.respectTransparency` escape hatches. -/
+@[implicit_reducible]
 def Pi.semialgHom {I : Type*} {R S : Type*} (f : I → Type*) [CommSemiring R] [CommSemiring S]
     (φ : R →+* S) [s : (i : I) → Semiring (f i)] [(i : I) → Algebra S (f i)] {A : Type*}
     [Semiring A] [Algebra R A] (g : (i : I) → A →ₛₐ[φ] f i) :

--- a/FLT/Mathlib/LinearAlgebra/TensorProduct/Algebra.lean
+++ b/FLT/Mathlib/LinearAlgebra/TensorProduct/Algebra.lean
@@ -45,3 +45,14 @@ lemma AlgHom.rTensor_map_smul {R : Type*} [CommSemiring R] (M : Type*) {N : Type
     [Algebra R N] [Algebra R P] (f : N →ₐ[R] P) (n : N) (nm : N ⊗[R] M) :
     AlgHom.rTensor M f (n • nm) = f n • AlgHom.rTensor M f nm :=
   MulActionHom.map_smul' (AlgHom.rTensor M f).toMulActionHom n nm
+
+/- This `rfl` lemma lets proofs rewrite `AlgHom.rTensor` on pure tensors without unfolding
+the definition itself: unfolding it with `simp [AlgHom.rTensor]` produces structure-literal
+applications whose defeq checks fail at `instances` transparency
+(`backward.isDefEq.respectTransparency := true`, the default since Lean v4.29). -/
+@[simp]
+lemma AlgHom.rTensor_tmul {R : Type*} [CommSemiring R] (M : Type*) {N : Type*}
+    {P : Type*} [AddCommMonoid M] [Semiring N] [Semiring P] [Module R M]
+    [Algebra R N] [Algebra R P] (f : N →ₐ[R] P) (n : N) (m : M) :
+    AlgHom.rTensor M f (n ⊗ₜ[R] m) = f n ⊗ₜ[R] m :=
+  rfl


### PR DESCRIPTION
Removes 8 of the 9 `set_option backward.isDefEq.respectTransparency false` workarounds in the three hotspot files implicated by #889 and #891 (`DedekindDomain/Completion/BaseChange.lean`, `HaarMeasure/HaarChar/FiniteAdeleRing.lean`, `DivisionAlgebra/Finiteness.lean`), replacing each with a fix at the level the defeq check actually fails. Two supporting `FLT/Mathlib` files are touched (a new `rfl` simp lemma; a def-site attribute). Roughly 80 further sites elsewhere in the repo — including one in the supporting file `FLT/Mathlib/Algebra/Algebra/Pi.lean` itself (`Pi.algHomEquivOfIsDomain`), untouched here — are deliberately out of scope and could be attacked the same way as follow-up.

Closes #891. Towards #889.

## Why

These `set_option` lines are v4.29-migration escape hatches: they don't make the offending defeq checks cheap, they make unification stop respecting transparency for a whole declaration. #889 and #891 record the underlying disease (instance paths through type synonyms that stop being definitionally comparable at `.instances` transparency). This PR fixes the root causes for the hotspot files, in the style mathlib itself used for the same migration (mathlib4#35761: mark "pseudo-parent" definitions `@[implicit_reducible]`), so the workarounds can simply be deleted.

## What changed (per site)

| Site | Fix |
|---|---|
| `DedekindDomain/Completion/BaseChange.lean` (2 sites: `baseChangeRight_surjective`, `baseChangeContinuousAlgEquiv`) | culprit chain `semialgHomPi → Pi.semialgHom → RingHom.pi` opaque at instances transparency; `@[implicit_reducible]` on FLT-owned `semialgHomPi` and `Pi.semialgHom` at their definitions + `attribute [local implicit_reducible]` for mathlib-owned `RingHom.pi` |
| `HaarMeasure/HaarChar/FiniteAdeleRing.lean:120` (`CompactSpace` local instance) | `attribute [local implicit_reducible] AddSubgroup.pi AddSubmonoid.pi` |
| `HaarMeasure/HaarChar/FiniteAdeleRing.lean:359` (`localcomponent_matrix`) | new `@[simp] lemma AlgHom.rTensor_tmul … := rfl` (in `FLT/Mathlib/LinearAlgebra/TensorProduct/Algebra.lean`) + faithful `simp only` closes; no transparency attributes needed |
| `HaarMeasure/HaarChar/FiniteAdeleRing.lean:521` (`f_g_local_global`) | `attribute [local implicit_reducible] IsDedekindDomain.FiniteAdeleRing RestrictedProduct` + deterministic `simp only`/`Finset.sum_congr` finisher |
| `DivisionAlgebra/Finiteness.lean:533` (`tensorPi_equiv_piTensor_map_mul`) | `suffices` respelling so the statement stops mixing `K∞` with its Π-type unfolding |
| `DivisionAlgebra/Finiteness.lean:552` (`DinfTensorPiEquivPiTensorAux`) | term-level crossing (`rw [h₁, h₂]` + explicit `.trans`) instead of a transparency-dependent rewrite |
| `DivisionAlgebra/Finiteness.lean:931` (`toQuot_surjective`) | `attribute [local implicit_reducible] Subgroup.subgroupOf` |

**The one deliberate survivor in the hotspot files** — `Finiteness.lean` (`algebraMap_completion`): the failing pairs are `f i * g i =?= instCommRingInfiniteAdeleRing._aux_13 K f g i` (and the `_aux_1` addition twin) — machine-generated field auxiliaries of mathlib's `deriving CommRing` on `InfiniteAdeleRing`, with unstable names. Marking one aux just shifts the failure to the next. That needs a mathlib-side change (e.g. deriving via `inferInstanceAs (CommRing (Π v, v.Completion))`); the `set_option` stays with a comment recording exactly this, and I can file the mathlib issue as follow-up.

## Evidence

- **Each removed workaround is load-bearing on the base revision**: deleting any single one on `main` breaks its module's build (unsolved goals, rewrite-pattern misses, or type-mismatch elaboration errors, depending on the site). Verified site-by-site with a scripted audit (`lake build <module>` per site, files restored between sites).
- **HEAD is green with all 8 gone**: `lake build --iofail`, `lake test --iofail`, `lake lint`, `lake exe mk_all --check`, and the no-bare-`import Mathlib` style check all pass (`--iofail`: zero warnings).
- **#891's headline symptom is gone**: the ~10.09M-heartbeat `tryResolve` of `IsTopologicalRing ((vi : InfinitePlace K) → D ⊗[K] vi.Completion)` no longer occurs; the same resolution now costs ≈192K heartbeats (`trace.profiler` + `trace.profiler.useHeartbeats` on the formerly pathological declarations). Remaining synthesis in that region has no single pathological node.
- **Honest perf framing**: build wall/user times are parity within noise — this is defeq hygiene and tail-risk removal (correct elaboration without transparency escape hatches), not a speedup. The residual compile cost of these files is distributed TensorProduct-coercion defeq churn, which is a separate (partly mathlib-side) problem.
- Localization used `#defeq_abuse` (Mathlib.Tactic.DefEqAbuse); on the fixed declarations it now reports no abuse. Diagnostic scaffolding is fully removed from the diff.

## Test plan

```
lake exe mk_all --check
! (find FLT -name "*.lean" -type f -print0 | xargs -0 grep -E -n '^import Mathlib$')
env TEST_ARGS=--iofail lake build --iofail
lake test --iofail
lake lint
```

Review history: https://gist.github.com/anagnorisis2peripeteia/defa15335be43177b3805eb08f56c06d

---
Authored with Claude (Claude Code); every fix verified by the full local CI equivalent above.
