### PR TITLE
fix: make the pre-push scripts work on a lakefile.toml checkout without leanblueprint

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -13,7 +13,7 @@
 
 # Ensure the script is in the outermost 'FLT' folder
 echo "Checking if you are in the correct directory..."
-if [ ! -f lakefile.lean ]; then
+if [ ! -f lakefile.toml ]; then
   echo "❌ Error: This doesn't appear to be the outermost 'FLT' directory.
         Please run this script from the correct folder."
   exit 1
@@ -38,31 +38,38 @@ else
   echo "✅ Project build completed successfully."
 fi
 
-# Generate the PDF version of the blueprint
-echo "Generating PDF version of the blueprint..."
-if ! leanblueprint pdf; then
-  echo "❌ Error: Failed to generate PDF version of the blueprint."
-  exit 1
-else
-  echo "✅ PDF version of the blueprint generated successfully."
-fi
+# The blueprint toolchain is optional: most contributors don't have leanblueprint
+# installed, and the blueprint CI step is currently disabled while the blueprint
+# migrates to Verso, so only run these steps when the tool is available.
+if command -v leanblueprint >/dev/null 2>&1; then
+  # Generate the PDF version of the blueprint
+  echo "Generating PDF version of the blueprint..."
+  if ! leanblueprint pdf; then
+    echo "❌ Error: Failed to generate PDF version of the blueprint."
+    exit 1
+  else
+    echo "✅ PDF version of the blueprint generated successfully."
+  fi
 
-# Generate the web version of the blueprint
-echo "Generating web version of the blueprint..."
-if ! leanblueprint web; then
-  echo "❌ Error: Failed to generate web version of the blueprint."
-  exit 1
-else
-  echo "✅ Web version of the blueprint generated successfully."
-fi
+  # Generate the web version of the blueprint
+  echo "Generating web version of the blueprint..."
+  if ! leanblueprint web; then
+    echo "❌ Error: Failed to generate web version of the blueprint."
+    exit 1
+  else
+    echo "✅ Web version of the blueprint generated successfully."
+  fi
 
-# Check declarations
-echo "Checking if Lean declarations in the blueprint match the codebase..."
-if ! lake exe checkdecls blueprint/lean_decls; then
-  echo "❌ Error: Some declarations in the blueprint do not match Lean declarations in the codebase."
-  exit 1
+  # Check declarations
+  echo "Checking if Lean declarations in the blueprint match the codebase..."
+  if ! lake exe checkdecls blueprint/lean_decls; then
+    echo "❌ Error: Some declarations in the blueprint do not match Lean declarations in the codebase."
+    exit 1
+  else
+    echo "✅ All declarations match successfully."
+  fi
 else
-  echo "✅ All declarations match successfully."
+  echo "⏭️  leanblueprint not found — skipping blueprint PDF/web generation and declaration checks."
 fi
 
 # Final message on test completion

--- a/scripts/run_before_push.sh
+++ b/scripts/run_before_push.sh
@@ -41,37 +41,44 @@ else
   echo "✅ Project build completed successfully."
 fi
 
-# Generate the PDF version of the blueprint
-echo "Generating PDF version of the blueprint..."
-if ! leanblueprint pdf; then
-  echo "❌ Error: Failed to generate PDF version of the blueprint."
-  echo "Press any key to exit..."
-  read
-  exit 1
-else
-  echo "✅ PDF version of the blueprint generated successfully."
-fi
+# The blueprint toolchain is optional: most contributors don't have leanblueprint
+# installed, and the blueprint CI step is currently disabled while the blueprint
+# migrates to Verso, so only run these steps when the tool is available.
+if command -v leanblueprint >/dev/null 2>&1; then
+  # Generate the PDF version of the blueprint
+  echo "Generating PDF version of the blueprint..."
+  if ! leanblueprint pdf; then
+    echo "❌ Error: Failed to generate PDF version of the blueprint."
+    echo "Press any key to exit..."
+    read
+    exit 1
+  else
+    echo "✅ PDF version of the blueprint generated successfully."
+  fi
 
-# Generate the web version of the blueprint
-echo "Generating web version of the blueprint..."
-if ! leanblueprint web; then
-  echo "❌ Error: Failed to generate web version of the blueprint."
-  echo "Press any key to exit..."
-  read
-  exit 1
-else
-  echo "✅ Web version of the blueprint generated successfully."
-fi
+  # Generate the web version of the blueprint
+  echo "Generating web version of the blueprint..."
+  if ! leanblueprint web; then
+    echo "❌ Error: Failed to generate web version of the blueprint."
+    echo "Press any key to exit..."
+    read
+    exit 1
+  else
+    echo "✅ Web version of the blueprint generated successfully."
+  fi
 
-# Check declarations
-echo "Checking if Lean declarations in the blueprint match the codebase..."
-if ! lake exe checkdecls blueprint/lean_decls; then
-  echo "❌ Error: Some declarations in the blueprint do not match Lean declarations in the codebase."
-  echo "Press any key to exit..."
-  read
-  exit 1
+  # Check declarations
+  echo "Checking if Lean declarations in the blueprint match the codebase..."
+  if ! lake exe checkdecls blueprint/lean_decls; then
+    echo "❌ Error: Some declarations in the blueprint do not match Lean declarations in the codebase."
+    echo "Press any key to exit..."
+    read
+    exit 1
+  else
+    echo "✅ All declarations match successfully."
+  fi
 else
-  echo "✅ All declarations match successfully."
+  echo "⏭️  leanblueprint not found — skipping blueprint PDF/web generation and declaration checks."
 fi
 
 # Final message on test completion


### PR DESCRIPTION
Fixes the two ways the pre-push tooling that CONTRIBUTING.md points contributors at fails on a standard checkout.

Closes #1133.

## What was broken

1. `scripts/pre-push.sh` guards on `[ ! -f lakefile.lean ]`, but the project uses `lakefile.toml` — so after running `scripts/install_pre-push.sh`, the git hook aborts **every push** with "This doesn't appear to be the outermost 'FLT' directory".
2. Both `pre-push.sh` and `run_before_push.sh` then hard-fail on `leanblueprint pdf` / `leanblueprint web` / `lake exe checkdecls` for anyone without `leanblueprint` installed — even though the blueprint CI step is currently disabled during the Verso migration (#1066), so the scripts fail where CI would pass.

## The fix

- `pre-push.sh`: check for `lakefile.toml` (matching `run_before_push.sh`, which already had it right).
- Both scripts: run the three blueprint steps only when `command -v leanblueprint` succeeds, otherwise print a skip notice. Behavior is unchanged for users who do have leanblueprint installed.

## Evidence (same scenario, base vs this branch, exit codes captured)

| Script | base (`8dd8088`) | this branch |
|---|---|---|
| `bash scripts/pre-push.sh` | exit 1 — aborts at the directory check | exit 0 — cache + `lake build FLT` green, blueprint steps skipped with a notice |
| `bash scripts/run_before_push.sh` | exit 1 — `leanblueprint: command not found` after a full successful build | exit 0 — same run, blueprint steps skipped with a notice |

## Test plan

```
bash scripts/pre-push.sh          # exit 0 on a lakefile.toml checkout without leanblueprint
bash scripts/run_before_push.sh   # exit 0, blueprint steps skipped with a notice
env TEST_ARGS=--iofail lake build --iofail && lake test --iofail && lake lint && lake exe mk_all --check
```

Review history: https://gist.github.com/041c358b97ca07ff31ef49a26988b428

---
Authored with Claude (Claude Code).
