### PR TITLE
feat: prototype native RightModule/Bimodule classes

### DIFF
--- a/FLT.lean
+++ b/FLT.lean
@@ -98,6 +98,9 @@ public import FLT.Mathlib.Algebra.Group.Action.Hom
 public import FLT.Mathlib.Algebra.Homology.HomologicalComplex
 public import FLT.Mathlib.Algebra.IsDirectLimit
 public import FLT.Mathlib.Algebra.IsQuaternionAlgebra
+public import FLT.Mathlib.Algebra.Module.Bimodule.Basic
+public import FLT.Mathlib.Algebra.Module.Bimodule.Defs
+public import FLT.Mathlib.Algebra.Module.Bimodule.TensorProduct
 public import FLT.Mathlib.Algebra.Module.Submodule.Basic
 public import FLT.Mathlib.Algebra.Order.AbsoluteValue.Basic
 public import FLT.Mathlib.Algebra.Polynomial.QuadraticDiscriminant
@@ -212,6 +215,7 @@ public import FLT.Mathlib.Topology.MetricSpace.ProperSpace.InfinitePlace
 public import FLT.Mathlib.Topology.MetricSpace.Pseudo.Matrix
 public import FLT.Mathlib.Topology.Polish
 public import FLT.NumberField.AdeleRing
+public import FLT.NumberField.AdeleRing.Bimodule
 public import FLT.NumberField.Completion.Finite
 public import FLT.NumberField.Completion.Infinite
 public import FLT.NumberField.DiscriminantBounds

--- a/FLT/Mathlib/Algebra/Module/Bimodule/Basic.lean
+++ b/FLT/Mathlib/Algebra/Module/Bimodule/Basic.lean
@@ -1,0 +1,251 @@
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import FLT.Mathlib.Algebra.Module.Bimodule.Defs
+public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+public import Mathlib.Algebra.Ring.Opposite
+
+/-!
+# Basic API for right modules and bimodules
+
+This file continues the bimodule experiment of
+`FLT.Mathlib.Algebra.Module.Bimodule.Defs`. It contains three kinds of material, which
+should be read as three separate data points for the design discussion:
+
+1. **Cheap duplication.** Lemmas about the right action which mirror the `Module` API and
+   whose proofs are one-liners (sums, units cancellation, `compHom`-style restriction of
+   the right scalars, restriction of the left scalars along a tower). This is the part of
+   the duplication that costs essentially nothing.
+
+2. **Transport.** `restrictScalars`-style `def`s (never instances) converting between
+   `RightModule B M` and `Module Bᵐᵒᵖ M` (`RightModule.moduleOp`,
+   `RightModule.ofModuleOp`), and in the commutative case between `RightModule B M` and
+   `Module B M` (`RightModule.toModule`, `RightModule.ofModule`). These make the entire
+   op-encoded `Module` API available locally via `letI`, at the price of carrying a
+   non-instance module structure through a proof.
+
+3. **A bundled-structure probe.** A minimal theory of right-linear maps
+   `RightLinearMap B M N`, notation `M →ᵣ[B] N`, to measure what duplicating a bundled
+   structure costs. Note that the additive half (`AddMonoidHomClass`) is *reused*, not
+   duplicated: only the `rsmul`-side is new.
+-/
+
+@[expose] public section
+
+open scoped Bimodule
+
+section SumLemmas
+
+variable {ι B M : Type*} [Semiring B] [AddCommMonoid M] [RightModule B M]
+
+/-- The right action of a fixed scalar on a fixed element, as an additive monoid
+homomorphism in the scalar. See `RightModule.rsmulAddMonoidHom` for additivity in the
+module element. -/
+def RightModule.rsmulScalarAddMonoidHom (m : M) : B →+ M where
+  toFun b := m <• b
+  map_zero' := rsmul_zero m
+  map_add' := rsmul_add m
+
+@[simp]
+theorem RightModule.rsmulScalarAddMonoidHom_apply (m : M) (b : B) :
+    RightModule.rsmulScalarAddMonoidHom m b = m <• b :=
+  rfl
+
+theorem Finset.sum_rsmul (s : Finset ι) (f : ι → M) (b : B) :
+    (∑ i ∈ s, f i) <• b = ∑ i ∈ s, f i <• b :=
+  map_sum (RightModule.rsmulAddMonoidHom b) f s
+
+theorem Finset.rsmul_sum (m : M) (s : Finset ι) (f : ι → B) :
+    m <• (∑ i ∈ s, f i) = ∑ i ∈ s, m <• f i :=
+  map_sum (RightModule.rsmulScalarAddMonoidHom m) f s
+
+end SumLemmas
+
+section Units
+
+variable {B M : Type*} [Semiring B] [AddCommMonoid M] [RightModule B M]
+
+/-- Right action of a unit is injective; mirror of `smul_left_cancel`. -/
+theorem rsmul_right_cancel (u : Bˣ) {m n : M} (h : m <• (u : B) = n <• (u : B)) : m = n := by
+  have := congrArg (· <• ((u⁻¹ : Bˣ) : B)) h
+  simpa [← rsmul_mul] using this
+
+end Units
+
+section CompHom
+
+variable {B' B M : Type*} [Semiring B'] [Semiring B] [AddCommMonoid M]
+
+/-- Restriction of the right scalars along a ring homomorphism `g : B' →+* B`; the mirror
+of `Module.compHom`. Not an instance, since `g` cannot be inferred. -/
+@[instance_reducible]
+def RightModule.compHom [RightModule B M] (g : B' →+* B) : RightModule B' M where
+  rsmul m b' := m <• g b'
+  rsmul_one m := by simp
+  rsmul_mul m b c := by simp [rsmul_mul]
+  add_rsmul m n b := add_rsmul m n (g b)
+  rsmul_add m b c := by simp [rsmul_add]
+  zero_rsmul b := zero_rsmul (g b)
+  rsmul_zero m := by simp
+
+end CompHom
+
+section RestrictScalars
+
+variable {A' A M B : Type*} [Semiring A'] [Semiring A] [AddCommMonoid M] [Semiring B]
+
+/-- Restriction of the left scalars of a bimodule along a scalar tower: an
+`(A, B)`-bimodule is an `(A', B)`-bimodule for any `A'` acting on `A` and `M`
+compatibly. Not an instance, since `A` cannot be inferred from the conclusion. -/
+theorem Bimodule.restrictScalars (A : Type*) [Semiring A] [Module A' M] [Module A M]
+    [SMul A' A] [IsScalarTower A' A M] [RightModule B M] [Bimodule A M B] :
+    Bimodule A' M B :=
+  ⟨fun a' m b ↦ by rw [← smul_one_smul A a' m, smul_rsmul, smul_one_smul]⟩
+
+end RestrictScalars
+
+section Transport
+
+variable (B M : Type*) [Semiring B] [AddCommMonoid M]
+
+open MulOpposite
+
+/-- Reinterpret a right `B`-module as a left `Bᵐᵒᵖ`-module. Deliberately **not** an
+instance: this is the explicit, `restrictScalars`-style bridge to the op-encoded world,
+to be used via `letI` when a mathlib `Module` result is needed for a right action. -/
+@[instance_reducible]
+def RightModule.moduleOp [RightModule B M] : Module Bᵐᵒᵖ M where
+  smul b m := m <• b.unop
+  one_smul m := rsmul_one m
+  mul_smul b c m := by
+    change m <• (b * c).unop = (m <• c.unop) <• b.unop
+    rw [unop_mul, rsmul_mul]
+  smul_zero b := zero_rsmul b.unop
+  smul_add b m n := add_rsmul m n b.unop
+  add_smul b c m := rsmul_add m b.unop c.unop
+  zero_smul m := rsmul_zero m
+
+/-- Reinterpret a left `Bᵐᵒᵖ`-module as a right `B`-module. Deliberately **not** an
+instance; inverse to `RightModule.moduleOp`. -/
+@[instance_reducible]
+def RightModule.ofModuleOp [Module Bᵐᵒᵖ M] : RightModule B M where
+  rsmul m b := op b • m
+  rsmul_one m := by simp
+  rsmul_mul m b c := by rw [op_mul, mul_smul]
+  add_rsmul m n b := smul_add (op b) m n
+  rsmul_add m b c := by rw [op_add, add_smul]
+  zero_rsmul b := smul_zero (op b)
+  rsmul_zero m := by simp
+
+/-- A module over a commutative semiring is a right module over it. Deliberately **not**
+an instance: in the commutative world the two sides are interchangeable, but making this
+an instance would let every left module silently acquire a right action (and vice versa
+via `RightModule.toModule`), which is exactly the ambiguity the experiment avoids. -/
+@[instance_reducible]
+def RightModule.ofModule (B : Type*) [CommSemiring B] [Module B M] : RightModule B M where
+  rsmul m b := b • m
+  rsmul_one m := one_smul B m
+  rsmul_mul m b c := by rw [mul_comm, mul_smul]
+  add_rsmul m n b := smul_add b m n
+  rsmul_add m b c := add_smul b c m
+  zero_rsmul b := smul_zero b
+  rsmul_zero m := zero_smul B m
+
+/-- A right module over a commutative semiring is a module over it. Deliberately **not**
+an instance; inverse to `RightModule.ofModule`. -/
+@[instance_reducible]
+def RightModule.toModule (B : Type*) [CommSemiring B] [RightModule B M] : Module B M where
+  smul b m := m <• b
+  one_smul m := rsmul_one m
+  mul_smul b c m := by
+    change m <• (b * c) = (m <• c) <• b
+    rw [mul_comm, rsmul_mul]
+  smul_zero b := zero_rsmul b
+  smul_add b m n := add_rsmul m n b
+  add_smul b c m := rsmul_add m b c
+  zero_smul m := rsmul_zero m
+
+/-- A bimodule structure transports to an `SMulCommClass` for the op-encoded actions:
+this is the statement that the native and op-encoded notions of bimodule agree. -/
+theorem Bimodule.smulCommClass_moduleOp (A : Type*) [Semiring A] [Module A M]
+    [RightModule B M] [Bimodule A M B] :
+    letI := RightModule.moduleOp B M
+    SMulCommClass A Bᵐᵒᵖ M :=
+  letI := RightModule.moduleOp B M
+  ⟨fun a b m ↦ (smul_rsmul a m b.unop).symm⟩
+
+end Transport
+
+/-! ### Right-linear maps: the bundled-structure probe
+
+A minimal duplicate of the `LinearMap` skeleton for right modules, to price bundled
+structures. Additive structure (`AddMonoidHomClass` and everything it implies:
+`map_zero`, `map_add`, `map_sum`, `map_neg`, ...) is inherited, not duplicated. -/
+
+section RightLinearMapDef
+
+variable (B M N : Type*) [Semiring B] [AddCommMonoid M] [AddCommMonoid N]
+
+/-- A right `B`-linear map between right `B`-modules: an additive monoid homomorphism
+commuting with the right action. Notation `M →ᵣ[B] N`, scoped in the `Bimodule`
+namespace. -/
+structure RightLinearMap [RightModule B M] [RightModule B N] extends M →+ N where
+  /-- The map commutes with the right action. Use `RightLinearMap.map_rsmul` instead. -/
+  protected map_rsmul' : ∀ (m : M) (b : B), toFun (m <• b) = toFun m <• b
+
+@[inherit_doc]
+scoped[Bimodule] notation:25 M " →ᵣ[" B "] " N => RightLinearMap B M N
+
+end RightLinearMapDef
+
+namespace RightLinearMap
+
+variable {B M N P : Type*} [Semiring B] [AddCommMonoid M] [AddCommMonoid N]
+  [AddCommMonoid P] [RightModule B M] [RightModule B N] [RightModule B P]
+
+instance : FunLike (M →ᵣ[B] N) M N where
+  coe f := f.toAddMonoidHom
+  coe_injective f g h := by
+    cases f; cases g
+    congr 1
+    exact DFunLike.coe_injective h
+
+instance : AddMonoidHomClass (M →ᵣ[B] N) M N where
+  map_add f := f.toAddMonoidHom.map_add
+  map_zero f := f.toAddMonoidHom.map_zero
+
+@[ext]
+theorem ext {f g : M →ᵣ[B] N} (h : ∀ m, f m = g m) : f = g :=
+  DFunLike.ext f g h
+
+@[simp]
+theorem coe_toAddMonoidHom (f : M →ᵣ[B] N) : ⇑f.toAddMonoidHom = ⇑f :=
+  rfl
+
+@[simp]
+theorem map_rsmul (f : M →ᵣ[B] N) (m : M) (b : B) : f (m <• b) = f m <• b :=
+  f.map_rsmul' m b
+
+/-- The identity as a right-linear map. -/
+def id : M →ᵣ[B] M where
+  __ := AddMonoidHom.id M
+  map_rsmul' _ _ := rfl
+
+@[simp]
+theorem id_apply (m : M) : (id : M →ᵣ[B] M) m = m :=
+  rfl
+
+/-- Composition of right-linear maps. -/
+def comp (g : N →ᵣ[B] P) (f : M →ᵣ[B] N) : M →ᵣ[B] P where
+  __ := g.toAddMonoidHom.comp f.toAddMonoidHom
+  map_rsmul' m b := by simp
+
+@[simp]
+theorem comp_apply (g : N →ᵣ[B] P) (f : M →ᵣ[B] N) (m : M) : g.comp f m = g (f m) :=
+  rfl
+
+end RightLinearMap

--- a/FLT/Mathlib/Algebra/Module/Bimodule/Defs.lean
+++ b/FLT/Mathlib/Algebra/Module/Bimodule/Defs.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import Mathlib.Algebra.Algebra.Defs
+
+/-!
+# A native right-module class, and bimodules
+
+**This file is an experiment** (build one to throw away), to inform a design discussion:
+see the `Right actions on tensor products (again)` and `product of modules over product
+of rings` threads on Zulip.
+
+`M` is an `(A, B)`-bimodule if it is a left `A`-module and a right `B`-module and the two
+actions commute: `(a • m) <• b = a • (m <• b)`. Mathlib can already express this by
+encoding the right action as a left action of the opposite ring:
+`[Module A M] [Module Bᵐᵒᵖ M] [SMulCommClass A Bᵐᵒᵖ M]` (see
+`Mathlib/Algebra/Module/Bimodule.lean`). This file instead prototypes a *native*
+right-module class `RightModule B M`, with notation `m <• b`, together with a
+`Prop`-valued mixin `Bimodule A M B` asserting that the two actions commute.
+
+Deliberately, there is **no** instance in either direction between `RightModule B M`
+and `Module Bᵐᵒᵖ M`, nor (in the commutative case) between `RightModule B M` and
+`Module B M`. The point of the experiment is to discover how much of the `Module` API a
+native right action must then duplicate, and how much can instead be recovered through
+explicit `restrictScalars`-style transport; the transport definitions live in
+`FLT.Mathlib.Algebra.Module.Bimodule.Basic`.
+
+## Main definitions
+
+* `RightModule B M`: the semiring `B` acts on the additive monoid `M` on the right;
+  notation `m <• b`, scoped in the `Bimodule` namespace.
+* `Bimodule A M B`: `M` is an `(A, B)`-bimodule, i.e. `M` carries a left `A`-action and a
+  right `B`-action which commute. The argument order matches the mathematical
+  notation `ₐM_b`. This is a mixin in the style of `SMulCommClass`, so "`𝔸_L` is an
+  `(L, 𝔸_K)`-bimodule" is said with the pair of instances `RightModule 𝔸_K 𝔸_L` and
+  `Bimodule L 𝔸_L 𝔸_K`.
+* `RightModule.ofRingHom f`: a ring homomorphism `f : B →+* S` makes `S` a right
+  `B`-module by right multiplication, `s <• b = s * f b`.
+* `Bimodule.ofRingHom f`: if moreover `S` is a left `A`-module with
+  `IsScalarTower A S S` (e.g. if `S` is an `A`-algebra) then `RightModule.ofRingHom f`
+  makes `S` an `(A, B)`-bimodule. This is the primitive bimodule constructor: right
+  multiplication by `f b` commutes with left multiplication (associativity) and with any
+  tower action. The motivating example is `𝔸_L` as an `(L, 𝔸_K)`-bimodule, in
+  `FLT.NumberField.AdeleRing.Bimodule`.
+
+## Notation
+
+* `m <• b` for `RightModule.rsmul m b`, scoped in the `Bimodule` namespace. This is
+  deliberately the same arrow, with the same precedences, as mathlib's scoped
+  `RightActions` notation `m <• b = MulOpposite.op b • m`, so that code written in the
+  native and in the op-encoded style reads identically. Opening both scopes only causes
+  ambiguity if both a `RightModule B M` and an `SMul Bᵐᵒᵖ M` instance are present.
+
+## Naming
+
+Lemmas are named by the left-to-right order of the elements appearing in the statement,
+so `rsmul_one : m <• 1 = m` mirrors `one_smul`, `add_rsmul : (m + n) <• b = _` mirrors
+`smul_add`, and `rsmul_add : m <• (b + c) = _` mirrors `add_smul`.
+-/
+
+@[expose] public section
+
+/-- A right module structure of a semiring `B` on an additive commutative monoid `M`,
+written `m <• b` (notation scoped in the `Bimodule` namespace): an action satisfying
+`m <• (b * c) = (m <• b) <• c` which is additive in both variables.
+
+This is `Module Bᵐᵒᵖ M` in all but encoding; deliberately, there is no instance in either
+direction between the two spellings (`RightModule.moduleOp` and `RightModule.ofModuleOp`
+are the corresponding `def`s). -/
+class RightModule (B M : Type*) [Semiring B] [AddCommMonoid M] where
+  /-- `rsmul m b`, written `m <• b`, is the right action of `b : B` on `m : M`. -/
+  rsmul : M → B → M
+  /-- One acts trivially: `m <• 1 = m`. Use `rsmul_one` instead. -/
+  protected rsmul_one : ∀ (m : M), rsmul m 1 = m
+  /-- Right actions compose contravariantly: `m <• (b * c) = (m <• b) <• c`.
+  Use `rsmul_mul` instead. -/
+  protected rsmul_mul : ∀ (m : M) (b c : B), rsmul m (b * c) = rsmul (rsmul m b) c
+  /-- The action distributes over addition in `M`. Use `add_rsmul` instead. -/
+  protected add_rsmul : ∀ (m n : M) (b : B), rsmul (m + n) b = rsmul m b + rsmul n b
+  /-- The action is additive in the scalar. Use `rsmul_add` instead. -/
+  protected rsmul_add : ∀ (m : M) (b c : B), rsmul m (b + c) = rsmul m b + rsmul m c
+  /-- Zero is fixed by the action. Use `zero_rsmul` instead. -/
+  protected zero_rsmul : ∀ (b : B), rsmul 0 b = 0
+  /-- The zero scalar acts as zero. Use `rsmul_zero` instead. -/
+  protected rsmul_zero : ∀ (m : M), rsmul m 0 = 0
+
+namespace Bimodule
+
+@[inherit_doc RightModule.rsmul]
+scoped notation3:73 m:73 " <• " b:74 => RightModule.rsmul m b
+
+end Bimodule
+
+open scoped Bimodule
+
+section RightModule
+
+variable {B M : Type*} [Semiring B] [AddCommMonoid M] [RightModule B M]
+
+@[simp]
+theorem rsmul_one (m : M) : m <• (1 : B) = m :=
+  RightModule.rsmul_one m
+
+theorem rsmul_mul (m : M) (b c : B) : m <• (b * c) = (m <• b) <• c :=
+  RightModule.rsmul_mul m b c
+
+@[simp]
+theorem add_rsmul (m n : M) (b : B) : (m + n) <• b = m <• b + n <• b :=
+  RightModule.add_rsmul m n b
+
+theorem rsmul_add (m : M) (b c : B) : m <• (b + c) = m <• b + m <• c :=
+  RightModule.rsmul_add m b c
+
+@[simp]
+theorem zero_rsmul (b : B) : (0 : M) <• b = 0 :=
+  RightModule.zero_rsmul b
+
+@[simp]
+theorem rsmul_zero (m : M) : m <• (0 : B) = 0 :=
+  RightModule.rsmul_zero m
+
+/-- Right action by `b : B`, bundled as an additive monoid homomorphism `M →+ M`. -/
+@[simps]
+def RightModule.rsmulAddMonoidHom (b : B) : M →+ M where
+  toFun m := m <• b
+  map_zero' := zero_rsmul b
+  map_add' m n := add_rsmul m n b
+
+end RightModule
+
+section AddCommGroup
+
+variable {B M : Type*} [Semiring B] [AddCommGroup M] [RightModule B M]
+
+@[simp]
+theorem neg_rsmul (m : M) (b : B) : (-m) <• b = -(m <• b) :=
+  map_neg (RightModule.rsmulAddMonoidHom b) m
+
+theorem sub_rsmul (m n : M) (b : B) : (m - n) <• b = m <• b - n <• b :=
+  map_sub (RightModule.rsmulAddMonoidHom b) m n
+
+end AddCommGroup
+
+/-- `M` is an `(A, B)`-bimodule: `M` is simultaneously a left `A`-module and a right
+`B`-module, and the two actions commute. The argument order `Bimodule A M B` matches the
+mathematical notation. This is a mixin in the style of `SMulCommClass`, taking the two
+actions as instance arguments.
+
+Deliberately, a bimodule structure produces no `Module` instance for the right-hand ring:
+there is no path from `Bimodule A M B` to `Module B M` or `Module Bᵐᵒᵖ M`. -/
+class Bimodule (A : Type*) (M : Type*) (B : Type*) [Semiring A] [Semiring B]
+    [AddCommMonoid M] [Module A M] [RightModule B M] : Prop where
+  /-- The left and right actions commute. Use `smul_rsmul` instead. -/
+  protected smul_rsmul : ∀ (a : A) (m : M) (b : B), (a • m) <• b = a • (m <• b)
+
+@[simp]
+theorem smul_rsmul {A M B : Type*} [Semiring A] [Semiring B] [AddCommMonoid M]
+    [Module A M] [RightModule B M] [Bimodule A M B] (a : A) (m : M) (b : B) :
+    (a • m) <• b = a • (m <• b) :=
+  Bimodule.smul_rsmul a m b
+
+section NatInt
+
+variable {M B : Type*} [Semiring B]
+
+/-- Every right module is a `(ℕ, B)`-bimodule. -/
+instance Bimodule.nat [AddCommMonoid M] [RightModule B M] : Bimodule ℕ M B where
+  smul_rsmul n m b := map_nsmul (RightModule.rsmulAddMonoidHom b) n m
+
+/-- Every right module over an additive group is a `(ℤ, B)`-bimodule. -/
+instance Bimodule.int [AddCommGroup M] [RightModule B M] : Bimodule ℤ M B where
+  smul_rsmul n m b := map_zsmul (RightModule.rsmulAddMonoidHom b) n m
+
+end NatInt
+
+section SelfAction
+
+variable {B : Type*} [Semiring B]
+
+/-- A semiring is a right module over itself, acting by right multiplication.
+
+Note the `K = L` caveat: if some other `RightModule B B` structure arises (e.g. from
+`RightModule.ofRingHom` applied to an endomorphism of `B`) it will clash with this one. -/
+instance Semiring.toRightModule : RightModule B B where
+  rsmul := (· * ·)
+  rsmul_one := mul_one
+  rsmul_mul m b c := (mul_assoc m b c).symm
+  add_rsmul := add_mul
+  rsmul_add := mul_add
+  zero_rsmul := zero_mul
+  rsmul_zero := mul_zero
+
+@[simp]
+theorem rsmul_eq_mul (x b : B) : x <• b = x * b :=
+  rfl
+
+/-- A semiring `B` is an `(A, B)`-bimodule for any left action commuting with right
+multiplication; in particular any `A`-algebra is an `(A, B := itself)`-bimodule. -/
+instance IsScalarTower.toBimodule {A : Type*} [Semiring A] [Module A B]
+    [IsScalarTower A B B] : Bimodule A B B :=
+  ⟨fun a m b ↦ smul_mul_assoc a m b⟩
+
+end SelfAction
+
+section OfRingHom
+
+variable {A B S : Type*} [Semiring A] [Semiring B] [Semiring S]
+
+/-- A ring homomorphism `f : B →+* S` makes `S` a right `B`-module by right
+multiplication: `s <• b = s * f b`.
+
+This is a `def`, not an instance, because `f` cannot be inferred; compare
+`RingHom.toAlgebra`. Instances built from it are definitionally transparent, so a
+declaration site can (and should) restate the action as a `rfl`-lemma, e.g.
+`x <• b = x * f b`. -/
+@[instance_reducible]
+def RightModule.ofRingHom (f : B →+* S) : RightModule B S where
+  rsmul s b := s * f b
+  rsmul_one m := by simp
+  rsmul_mul m b c := by simp [mul_assoc]
+  add_rsmul m n b := add_mul m n (f b)
+  rsmul_add m b c := by simp [mul_add]
+  zero_rsmul b := zero_mul (f b)
+  rsmul_zero m := by simp
+
+/-- The primitive bimodule constructor: if `S` is a left `A`-module whose action commutes
+with right multiplication (`IsScalarTower A S S`, e.g. `S` an `A`-algebra), then any ring
+homomorphism `f : B →+* S`, acting by right multiplication, makes `S` an
+`(A, B)`-bimodule.
+
+Stated with `letI` since the `RightModule` structure is data; at a declaration site where
+`RightModule.ofRingHom f` has been registered as an instance, this proves the
+corresponding `Bimodule A S B` instance directly. -/
+theorem Bimodule.ofRingHom [Module A S] [IsScalarTower A S S] (f : B →+* S) :
+    letI := RightModule.ofRingHom f
+    Bimodule A S B :=
+  letI := RightModule.ofRingHom f
+  ⟨fun a m b ↦ smul_mul_assoc a m (f b)⟩
+
+end OfRingHom

--- a/FLT/Mathlib/Algebra/Module/Bimodule/TensorProduct.lean
+++ b/FLT/Mathlib/Algebra/Module/Bimodule/TensorProduct.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import FLT.Mathlib.Algebra.Module.Bimodule.Defs
+public import Mathlib.RingTheory.TensorProduct.Basic
+
+/-!
+# Tensor products as bimodules
+
+For `R` a commutative semiring, `M` an `R`-module and `B` an `R`-algebra, this file makes
+`M ⊗[R] B` a right `B`-module via `id_M ⊗ (· * b)`, that is
+`(m ⊗ₜ c) <• b = m ⊗ₜ (c * b)`, and shows that any compatible left action on `M` then
+makes `M ⊗[R] B` a bimodule.
+
+This is the bimodule-world answer to the question underlying mathlib PR #39699
+(`Algebra.TensorProduct.rightAlgebra`): the natural `B`-action on `M ⊗[R] B` is
+`LinearMap.lTensor M (LinearMap.mulRight R b)`, which involves no `TensorProduct.comm`
+(so no commutativity of `R` is being consumed in an essential way, and no swap to
+`B ⊗[R] M`), and no `MulOpposite`. Right multiplication by `b` is left-`R`-linear
+precisely because `B` is an `(R, B)`-bimodule — the same observation that makes
+`rightAlgebra`'s `smul` work. Unlike `rightAlgebra`, which must be a `def` because
+`Algebra B (A ⊗[R] B)` clashes with `Algebra A (A ⊗[R] B)` at `A = B`, the right-module
+structure here can be a global *instance*: `RightModule B (M ⊗[R] B)` does not compete
+with any left `Module` instance, because the two classes are unrelated by design.
+-/
+
+@[expose] public section
+
+open scoped TensorProduct Bimodule
+
+open LinearMap (lTensor mulRight)
+
+namespace TensorProduct
+
+variable {R M B : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
+  [Semiring B] [Algebra R B]
+
+/-- `M ⊗[R] B` is a right `B`-module, via `id_M ⊗ (· * b)`:
+`(m ⊗ₜ c) <• b = m ⊗ₜ (c * b)`. -/
+noncomputable instance rightModule : RightModule B (M ⊗[R] B) where
+  rsmul x b := lTensor M (mulRight R b) x
+  rsmul_one x := by rw [LinearMap.mulRight_one, LinearMap.lTensor_id, LinearMap.id_apply]
+  rsmul_mul x b c := by rw [LinearMap.mulRight_mul, LinearMap.lTensor_comp, LinearMap.comp_apply]
+  add_rsmul x y b := map_add _ x y
+  rsmul_add x b c := by
+    have : mulRight R (b + c) = mulRight R b + mulRight R c := by
+      ext x
+      simp [mul_add]
+    rw [this, LinearMap.lTensor_add, LinearMap.add_apply]
+  zero_rsmul b := map_zero _
+  rsmul_zero x := by
+    have : mulRight R (0 : B) = 0 := by
+      ext x
+      simp
+    rw [this, LinearMap.lTensor_zero, LinearMap.zero_apply]
+
+@[simp]
+theorem rsmul_tmul (m : M) (c b : B) : (m ⊗ₜ[R] c) <• b = m ⊗ₜ (c * b) :=
+  rfl
+
+/-- Any left action on `M` commuting with the `R`-action makes `M ⊗[R] B` an
+`(A, B)`-bimodule, for the left `A`-action through the `M` factor
+(`TensorProduct.leftModule`) and the right `B`-action through the `B` factor. The two
+sides act on different factors, so they commute with no hypotheses relating `A` and
+`B`. -/
+instance instBimodule {A : Type*} [Semiring A] [Module A M] [SMulCommClass R A M] :
+    Bimodule A (M ⊗[R] B) B where
+  smul_rsmul a x b := by
+    induction x with
+    | zero => simp
+    | tmul m c => simp [smul_tmul']
+    | add x y hx hy =>
+      simp only [smul_add, add_rsmul] at *
+      rw [hx, hy]
+
+/-- The `#39699` special case: for `A` an `R`-algebra, `A ⊗[R] B` is an
+`(A, B)`-bimodule — `A` acting through the left factor via `Algebra A (A ⊗[R] B)`, `B`
+acting through the right factor. No commutation, no `MulOpposite`, no diamond at
+`A = B`. -/
+example {A : Type*} [Semiring A] [Algebra R A] : Bimodule A (A ⊗[R] B) B :=
+  inferInstance
+
+/-- The left `R`-structure and right `B`-structure make `M ⊗[R] B` an
+`(R, B)`-bimodule. -/
+example : Bimodule R (M ⊗[R] B) B :=
+  inferInstance
+
+end TensorProduct

--- a/FLT/NumberField/AdeleRing/Bimodule.lean
+++ b/FLT/NumberField/AdeleRing/Bimodule.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+module
+
+public import FLT.Mathlib.Algebra.Module.Bimodule.Basic
+public import FLT.NumberField.AdeleRing
+
+/-!
+# The adele ring of `L` as an `(L, 𝔸_K)`-bimodule
+
+For `K ⊆ L` number fields, the adele ring `𝔸 L` is simultaneously an `L`-algebra and a
+right `𝔸 K`-module via the canonical (injective) ring homomorphism
+`baseChange K L : 𝔸 K → 𝔸 L` followed by multiplication, and the two actions commute:
+`𝔸 L` is an `(L, 𝔸 K)`-bimodule. This file records those two facts as *global*
+instances,
+
+* `RightModule (𝔸 K) (𝔸 L)` with `x <• b = x * baseChange K L b`, and
+* `Bimodule L (𝔸 L) (𝔸 K)`,
+
+together with basic compatibility lemmas. No scoped instances or local hacks are
+required: both conclusions determine all their arguments, so neither instance has the
+`SMul X Y → SMul (F X) (F Y)` shape that forces the `Algebra 𝔸ᶠ[K] 𝔸ᶠ[L]` instance in
+`FLT.NumberField.AdeleRing` to be scoped.
+
+## The `K = L` diamond
+
+`RightModule (𝔸 K) (𝔸 K)` is satisfied both by `Semiring.toRightModule` (right
+multiplication) and, taking `L := K`, by the instance in this file (right multiplication
+through `baseChange K K`). The two are propositionally but (presumably) not
+definitionally equal — the same `K = L` degeneracy that `FLT.NumberField.AdeleRing`
+warns about for `Algebra (𝔸 K) (𝔸 L)`-shaped instances. The clash is not hypothetical:
+it fired on the first declaration below that uses the self-action
+(`baseChangeRightLinearMap`). It is arbitrated by declaring the base-change instance at
+`priority := 900`, so that at `K = L` the self-action `Semiring.toRightModule` wins and
+`x <• b` on `𝔸 K` always means `x * b`.
+
+(For the record: the `K`-linear variant `Bimodule K (𝔸 L) (𝔸 K)` would need a
+`Module K (𝔸 L)` instance, which mathlib does not have and this design does not need;
+anyone with such an action in context can use `Bimodule.restrictScalars`.)
+-/
+
+@[expose] public section
+
+open NumberField IsDedekindDomain
+
+open scoped Adele Bimodule
+
+namespace NumberField.AdeleRing
+
+variable (K L : Type*) [Field K] [NumberField K] [Field L] [NumberField L] [Algebra K L]
+
+/-- The adele ring `𝔸 L` is a right `𝔸 K`-module: `x <• b = x * baseChange K L b`.
+
+The priority is below `Semiring.toRightModule`'s so that at `K = L` the self-action by
+right multiplication wins; see the module docstring. -/
+noncomputable instance (priority := 900) : RightModule (𝔸 K) (𝔸 L) :=
+  .ofRingHom (baseChange K L).toRingHom
+
+lemma rsmul_def (x : 𝔸 L) (b : 𝔸 K) : x <• b = x * baseChange K L b :=
+  rfl
+
+/-- The adele ring `𝔸 L` is an `(L, 𝔸 K)`-bimodule: `L` acts on the left through the
+`L`-algebra structure, `𝔸 K` acts on the right through `baseChange` and multiplication,
+and the actions commute. -/
+instance : Bimodule L (𝔸 L) (𝔸 K) :=
+  Bimodule.ofRingHom (baseChange K L).toRingHom
+
+example (l : L) (x : 𝔸 L) (b : 𝔸 K) : (l • x) <• b = l • (x <• b) :=
+  smul_rsmul l x b
+
+/-- The `(ℤ, 𝔸 K)`-bimodule structure comes for free from `Bimodule.int`. -/
+example (n : ℤ) (x : 𝔸 L) (b : 𝔸 K) : (n • x) <• b = n • (x <• b) :=
+  smul_rsmul n x b
+
+lemma one_rsmul (b : 𝔸 K) : (1 : 𝔸 L) <• b = baseChange K L b :=
+  one_mul _
+
+/-- The right `𝔸 K`-action restricted to `K ⊆ 𝔸 K` agrees with the scalar action of `K`
+through `L`. -/
+lemma rsmul_algebraMap (x : 𝔸 L) (k : K) :
+    x <• algebraMap K (𝔸 K) k = algebraMap K L k • x := by
+  rw [rsmul_def, (baseChange K L).commutes, Algebra.smul_def, mul_comm]
+
+/-- The base-change map `𝔸 K → 𝔸 L` is a morphism of right `𝔸 K`-modules, where `𝔸 K`
+acts on itself by right multiplication (`Semiring.toRightModule`, which instance search
+selects here thanks to the priorities discussed in the module docstring). -/
+noncomputable def baseChangeRightLinearMap : (𝔸 K) →ᵣ[𝔸 K] (𝔸 L) where
+  toAddMonoidHom := (baseChange K L).toRingHom.toAddMonoidHom
+  map_rsmul' x b := map_mul (baseChange K L).toRingHom x b
+
+@[simp]
+lemma baseChangeRightLinearMap_apply (x : 𝔸 K) :
+    baseChangeRightLinearMap K L x = baseChange K L x :=
+  rfl
+
+end NumberField.AdeleRing

--- a/bimodule_findings.md
+++ b/bimodule_findings.md
@@ -1,0 +1,183 @@
+# Bimodule prototype: findings
+
+*A build-one-to-throw-away experiment in FLT (`FLT/Mathlib/Algebra/Module/Bimodule/`,
+`FLT/NumberField/AdeleRing/Bimodule.lean`), prototyping a native right-module class to
+inform the recurring right-actions design discussion (Eric Wieser, Kenny Lau, Andrew
+Yang, Anatole Dedecker; threads: "#4773 base change", "Right actions on tensor products
+(again)", "product of modules over product of rings").*
+
+*Status: 689 lines across four files (Defs 244, Basic 251, TensorProduct 92, adele
+instances 102), zero diagnostics, sorry-free, every declaration axiom-checked to
+`{propext, Classical.choice, Quot.sound}`, full FLT `lake build` green.*
+
+## The design that was built
+
+Not one class but a data class and a `Prop`-mixin, mirroring the shape of mathlib's
+op-encoded `[Module A M] [Module Bᵐᵒᵖ M] [SMulCommClass A Bᵐᵒᵖ M]`:
+
+```lean
+class RightModule (B M : Type*) [Semiring B] [AddCommMonoid M] where
+  rsmul : M → B → M          -- notation `m <• b`, scoped in `Bimodule`
+  -- + 6 axioms mirroring Module's (rsmul_one, rsmul_mul, add_rsmul, rsmul_add,
+  --   zero_rsmul, rsmul_zero)
+
+class Bimodule (A M B : Type*) [Semiring A] [Semiring B] [AddCommMonoid M]
+    [Module A M] [RightModule B M] : Prop where
+  smul_rsmul : ∀ (a : A) (m : M) (b : B), (a • m) <• b = a • (m <• b)
+```
+
+Deliberately there is **no instance in either direction** between `RightModule B M` and
+`Module Bᵐᵒᵖ M` (nor `Module B M` in the commutative case); the bridges exist only as
+`@[instance_reducible] def`s for `letI`-style local transport.
+
+Two structural points that were *forced* during the experiment, not chosen up front:
+
+1. **The right action cannot live in a class parametrized by the left ring.** A
+   monolithic `class Bimodule A M B extends Module A M` (the original spec) fails twice:
+   the parent projection `Bimodule.toModule : Module A M` is an instance whose conclusion
+   doesn't mention `B` (every `Module A M` search then spawns `Bimodule A M ?B`), and if
+   `rsmul` is a field of the monolithic class then `x <• b` must synthesize
+   `Bimodule ?A M B` with `?A` a dangling metavariable — genuinely ambiguous, since e.g.
+   `𝔸_L` is at once an `(L, 𝔸_K)`- and a `(ℤ, 𝔸_K)`-bimodule *with the same right
+   action*. The action's identity belongs to `(B, M)` alone; only the compatibility
+   involves `A`. The factored design is therefore not a style choice but the load-bearing
+   part of the prototype.
+
+2. **The mixin costs one extra binder.** Generic bimodule statements read
+   `variable [Module A M] [RightModule B M] [Bimodule A M B]` — three classes where the
+   op-encoding also has three (`Module`, `Module ᵐᵒᵖ`, `SMulCommClass`), so no
+   regression, but no improvement either.
+
+Notation: `m <• b`, scoped in the `Bimodule` namespace, with the same arrow and
+precedences as mathlib's scoped `RightActions` notation for `MulOpposite.op b • m` — so
+native and op-encoded code *read identically*, and the two scopes only collide when a
+file opens both **and** both a `RightModule B M` and an `SMul Bᵐᵒᵖ M` instance exist for
+the same pair.
+
+## The headline example
+
+"`𝔸_L` is an `(L, 𝔸_K)`-bimodule" is two one-line **global** instances — no scoped
+instances, no `open`-a-hack-namespace, nothing imported that mathlib would blush at:
+
+```lean
+noncomputable instance : RightModule (𝔸 K) (𝔸 L) :=
+  .ofRingHom (baseChange K L).toRingHom
+
+instance : Bimodule L (𝔸 L) (𝔸 K) :=
+  Bimodule.ofRingHom (baseChange K L).toRingHom
+```
+
+Both conclusions determine all their arguments, so neither instance has the
+`SMul X Y → SMul (F X) (F Y)` shape that forces FLT's `Algebra 𝔸ᶠ[K] 𝔸ᶠ[L]` to be
+scoped. The constructor is the primitive one:
+
+* `RightModule.ofRingHom (f : B →+* S) : RightModule B S` — right multiplication
+  through a ring hom (`s <• b = s * f b`); the right-module analogue of
+  `RingHom.toAlgebra`.
+* `Bimodule.ofRingHom` — under `[Module A S] [IsScalarTower A S S]` (any `A`-algebra),
+  compatibility is exactly `smul_mul_assoc`, so the bimodule structure is free.
+
+This is the same observation that fixes #39699: right multiplication commutes with
+everything a left structure does, because associativity says so.
+
+## Cost accounting: what had to be duplicated
+
+**Cheap (mechanical one-liners, done in the prototype):**
+
+* The class + 6 axioms + ~10 root-level restatement lemmas with the mirrored simp set
+  (`rsmul_one`, `add_rsmul`, … following the `one_smul`, `smul_add` conventions).
+* `neg_rsmul`/`sub_rsmul` — free once `rsmulAddMonoidHom : M →+ M` exists, via
+  `map_neg`/`map_sub`.
+* `Bimodule ℕ M B` and `Bimodule ℤ M B` instances — free via `map_nsmul`/`map_zsmul`;
+  this is the "no zsmul diamond" point, confirmed in practice.
+* `Finset.sum_rsmul` / `Finset.rsmul_sum` — free via `map_sum` on the two bundled homs.
+* Units cancellation, `RightModule.compHom` (restriction of the *right* scalars along
+  `B' →+* B`), `Bimodule.restrictScalars` (restriction of the *left* scalars along a
+  tower) — a few lines each.
+
+**Reused, not duplicated:** everything additive. `RightLinearMap` extends `M →+ N` and
+gets an `AddMonoidHomClass` instance, so `map_zero`, `map_add`, `map_sum`, `map_neg`, …
+apply verbatim. The additive half of the module library never needs touching.
+
+**The real cost — bundled structures.** The `RightLinearMap B M N` probe
+(`M →ᵣ[B] N`): structure, `FunLike`, `AddMonoidHomClass`, `ext`, `map_rsmul`, `id`,
+`comp` with simp lemmas. That is the *skeleton only* — no `AddCommMonoid (M →ᵣ[B] N)`,
+no composition algebra, no kernels. Extrapolating to `RightSubmodule` (a `SetLike` with
+lattice structure, span, quotients...) and right-`Finsupp`/basis theory: this is
+thousands of lines of genuinely duplicated API. The op-encoding gets all of it today for
+free as `LinearMap Bᵐᵒᵖ`, `Submodule Bᵐᵒᵖ`.
+
+**Transport (`restrictScalars`-style) — bearable for theorems, bad for structures.**
+`RightModule.moduleOp : Module Bᵐᵒᵖ M` (a def) makes any op-encoded *theorem* available
+inside a proof at the cost of one `letI`. `Bimodule.smulCommClass_moduleOp` carries the
+mixin across. But transporting a *type* (`Submodule Bᵐᵒᵖ M` with a `letI`-instance in
+its type) recreates Andrew Yang's type-synonym objection: the instance is part of the
+type, and every consumer must carry it. Transport is a per-proof tool, not an API
+strategy.
+
+## Tensor products (the #39699 connection)
+
+`FLT/Mathlib/Algebra/Module/Bimodule/TensorProduct.lean`: for `M` an `R`-module and `B`
+an `R`-algebra,
+
+```lean
+noncomputable instance : RightModule B (M ⊗[R] B)   -- rsmul x b = lTensor M (mulRight R b) x
+instance [Module A M] [SMulCommClass R A M] : Bimodule A (M ⊗[R] B) B
+```
+
+* The action is `id_M ⊗ (· * b)` — no `TensorProduct.comm`, no `MulOpposite`, and the
+  proofs are map-level (`mulRight_mul` + `lTensor_comp` etc.), not induction.
+* Unlike `Algebra.TensorProduct.rightAlgebra` (a `def`, because `Algebra B (A ⊗[R] B)`
+  collides with `Algebra A (A ⊗[R] B)` at `A = B`), the right-module structure is a
+  global **instance**: `RightModule` never competes with `Module`, so the `A = B`
+  ambiguity that has blocked #39699-style refactors simply does not arise.
+* The `#39699` special case `Bimodule A (A ⊗[R] B) B` is found by `inferInstance`.
+
+## Warts found (the honest list)
+
+1. **The `K = L` diamond — and it fired.** `RightModule (𝔸 K) (𝔸 K)` is inhabited both
+   by `Semiring.toRightModule` (right multiplication) and by the base-change instance at
+   `L := K` (right multiplication through `baseChange K K`) — propositionally equal,
+   presumably not definitionally. This is not hypothetical: the *first* declaration
+   mixing the two (`baseChangeRightLinearMap : (𝔸 K) →ᵣ[𝔸 K] (𝔸 L)`, base change as a
+   map of right `𝔸 K`-modules) silently picked the base-change action on the domain and
+   became unprovable. Declaring the base-change instance at `priority := 900` arbitrates
+   it — the self-action wins at `K = L`, so `x <• b` on `𝔸 K` always means `x * b` —
+   and the declaration then elaborates with no pinning. Two caveats carry over to any
+   real design: priority-based arbitration is global and blunt (an `IsBaseChange`-style
+   compatibility class would be principled), and the op-encoding has the *same* problem
+   the moment anyone writes the corresponding `Module (𝔸 K)ᵐᵒᵖ (𝔸 K)` instances; it is
+   a fact about base change, not about the encoding.
+2. **`Bimodule.ofRingHom` needs `letI` in its statement**, because the `Prop` depends on
+   which `RightModule` *data* is in scope. Harmless at instance-declaration sites, but
+   it is the visible seam of the data/Prop factoring.
+3. **`rfl`-transparency discipline.** Sites registering `RightModule.ofRingHom`-built
+   instances should restate the action (`rsmul_def : x <• b = x * f b := rfl`);
+   `@[instance_reducible]` on the constructors keeps this working.
+
+## Comparison with the alternatives
+
+* **Op-encoding (status quo):** all API exists today; the cost is notational
+  (`Module Bᵐᵒᵖ`, `op b • m` — mitigated by the `RightActions` scope) and conceptual.
+  Every finding above about *diamonds* applies to it equally.
+* **Native right actions (this prototype):** the core and everything additive is cheap;
+  linear-map/submodule-level API is a large genuine duplication that someone would have
+  to write and maintain. Nothing *breaks* — the two worlds connect by explicit defs —
+  but nothing is free either.
+* **Type synonyms:** not tested here; Andrew Yang's objection (opaque synonym ⇒ carry an
+  equivalence everywhere) resurfaced in this experiment as the transport-of-structures
+  problem, which is evidence the objection is fundamental.
+* **Anatole's named actions:** still uncosted; the prototype at least sharpens what it
+  must beat — the op-encoding's zero-duplication, and the native encoding's readability.
+
+## Verdict
+
+A native right action buys exactly two things: (1) statements that read like
+mathematics (`Bimodule L (𝔸 L) (𝔸 K)` as global instances, `(l • x) <• b = l • (x <• b)`),
+and (2) an escape from `Module`-instance collisions (the tensor-product right action can
+be an instance, where `rightAlgebra` cannot). It costs a full parallel bundled-structure
+library, of which this prototype implements only the first hundred metres. If the
+bundled tier is out of budget, the op-encoding plus the `RightActions` notation scope
+remains the rational choice, and the `lTensor`-style primitive (right multiplication
+through a hom) is the piece worth extracting into it — that piece is what unblocks
+#39699 either way.


### PR DESCRIPTION
Also: ; 𝔸_L as an (L, 𝔸_K)-bimodule.

Build-one-to-throw-away experiment for the right-actions design discussion: a native right-module class `RightModule B M` (notation `m <• b`) and a Prop-valued mixin `Bimodule A M B`, deliberately with no instance in either direction to `Module Bᵐᵒᵖ M` (transport exists as defs only). Includes the primitive constructor via ring homs, a right-linear-map probe, the lTensor-based right B-module structure on M ⊗[R] B (the #39699 test case), and global instances making 𝔸_L an (L, 𝔸_K)-bimodule with no scoped hacks. Findings, including the K = L instance diamond that fired and its priority arbitration, are written up in bimodule_findings.md.