### PR TITLE
Discharge GL₀ constant-form and elliptic-curve action sorries

### DIFF
--- a/FLT/EllipticCurve/Torsion.lean
+++ b/FLT/EllipticCurve/Torsion.lean
@@ -106,10 +106,17 @@ noncomputable instance WeierstrassCurve.galoisRepresentationSmul
 noncomputable instance WeierstrassCurve.galoisRepresentation
     (K : Type u) [Field K] [DecidableEq K] [Algebra k K] :
     DistribMulAction (K ≃ₐ[k] K) (E⁄K).Point where
-      one_smul := sorry -- these should all be easy
-      mul_smul := sorry
-      smul_zero := sorry
-      smul_add := sorry
+      one_smul P := by
+        change WeierstrassCurve.Affine.Point.map (AlgHom.id k K) P = P
+        exact DFunLike.congr_fun (WeierstrassCurve.Points.map_id E K) P
+      mul_smul g h P := by
+        change WeierstrassCurve.Affine.Point.map (g * h).toAlgHom P =
+          WeierstrassCurve.Affine.Point.map g.toAlgHom
+            (WeierstrassCurve.Affine.Point.map h.toAlgHom P)
+        rw [WeierstrassCurve.Affine.Point.map_map]
+        rfl
+      smul_zero g := map_zero (WeierstrassCurve.Affine.Point.map g.toAlgHom)
+      smul_add g P Q := map_add (WeierstrassCurve.Affine.Point.map g.toAlgHom) P Q
 
 -- the next `sorry` is data but the only thing which should be missing is
 -- the continuity argument, which follows from the finiteness asserted above.

--- a/FLT/GlobalLanglandsConjectures/GLzero.lean
+++ b/FLT/GlobalLanglandsConjectures/GLzero.lean
@@ -64,9 +64,9 @@ def ofComplex (c : ℂ) : AutomorphicFormForGLnOverQ 0 ρ := {
     is_smooth := {
       continuous := by continuity
       loc_cst := by
-        rw [IsLocallyConstant]
-        sorry
-        -- aesop -- used to work
+        intro _
+        exact IsLocallyConstant.const
+          (X := GL (Fin 0) (IsDedekindDomain.FiniteAdeleRing ℤ ℚ)) c
       smooth := by simp [contMDiff_const]
     }
     is_periodic := by simp
@@ -83,7 +83,12 @@ def ofComplex (c : ℂ) : AutomorphicFormForGLnOverQ 0 ρ := {
       }
       apply Exists.intro U
       exact {
-          is_open := by sorry -- used to be simp but there's a timeout
+          is_open := by
+            change IsOpen ({1} : Set (GL (Fin 0) (IsDedekindDomain.FiniteAdeleRing ℤ ℚ)))
+            rw [show ({1} : Set (GL (Fin 0)
+              (IsDedekindDomain.FiniteAdeleRing ℤ ℚ))) = Set.univ from
+                Set.eq_univ_of_forall fun x ↦ Subsingleton.elim x 1]
+            exact isOpen_univ
           is_compact := by aesop
           finite_level := by simp
       }


### PR DESCRIPTION
I needed this exact bridge during some Fermats last theorem experiments (I am formalizing the historical proofs and some new potential proofs in Lean here: https://github.com/isomorphic-ai/fermat).

I am sharing this as the work was done and the tokens used, but I can understand if this is not up to the quality of the repository, yet.

I carefully checked the code and would have written it like this myself now.

As I understand it now, I am marking this as ready for review.

---

> [!IMPORTANT]
> **LLM disclosure.** This fork PR was prepared with substantial assistance from OpenAI Codex and
> should be labeled `LLM-generated` (“PRs with substantial input from LLMs — review accordingly”).
> Before submission, the human proposer should review every mathematical statement and Lean proof
> line by line, confirm that they can explain each step, and take responsibility for the contribution.

# Suggested title

Discharge GL₀ constant-form and elliptic-curve action sorries

## Summary

This PR fills six `sorry` tokens in two existing declarations without changing their statements:

- `AutomorphicForm.GL0.ofComplex`: proves local constancy of the constant function and openness of
  its level subgroup. The latter uses that `GL (Fin 0)` is a subsingleton, so `{1}` is the whole
  group.
- `WeierstrassCurve.galoisRepresentation`: proves the four `DistribMulAction` laws from the existing
  identity/composition lemmas for point maps and their additive-homomorphism structure.

No axiom was added. The other unresolved declarations are deliberately outside this PR; in
particular, it does not change theorem statements or route a short proof through another sorried
result.

## Verification

Only the two touched targets were built, using the repository's pinned Lean `v4.33.0-rc1`
toolchain and cached dependencies:

```text
lake build FLT.GlobalLanglandsConjectures.GLzero FLT.EllipticCurve.Torsion
Build completed successfully (3633 jobs).
```

Exact dependency checks:

```text
'AutomorphicForm.GL0.ofComplex' depends on axioms: [propext, Classical.choice, Quot.sound]
'WeierstrassCurve.galoisRepresentation' depends on axioms: [propext, Classical.choice, Quot.sound]
```

Neither filled declaration depends on `sorryAx` or `knownin1980s`.

## Suggested issue notes

No dedicated open issue was found for either exact proof hole. The paragraphs below are ready to
post if maintainers identify an issue thread where the cleanup belongs; the scope qualifications
should be retained.

### `AutomorphicForm.GL0.ofComplex`

I filled the two proof obligations in `AutomorphicForm.GL0.ofComplex`: local constancy now follows
from the constant-function lemma, and the singleton level subgroup is open because `GL (Fin 0)` is
a subsingleton and hence `{1} = Set.univ`. The targeted `GLzero` build passes, and `#print axioms`
reports only `propext`, `Classical.choice`, and `Quot.sound`. This is finite-adele-adjacent cleanup,
but it does **not** establish the `QHat`/`ZHat` equivalences requested in
[FLT issue #737](https://github.com/ImperialCollegeLondon/FLT/issues/737).

### `WeierstrassCurve.galoisRepresentation`

I filled all four action-law obligations in `WeierstrassCurve.galoisRepresentation`: identity and
composition use the existing point-map API, while preservation of zero and addition comes from the
map's additive-homomorphism structure. The targeted torsion build passes, and `#print axioms`
reports only `propext`, `Classical.choice`, and `Quot.sound`. This is adjacent infrastructure only:
it does **not** prove the `n`-torsion cardinality theorem tracked in
[FLT issue #1064](https://github.com/ImperialCollegeLondon/FLT/issues/1064), which points to the
separate `FLT/KnownIn1980s/EllipticCurves/Torsion.lean` development.