### PR TITLE
fix: add csv to the docs bundle for Ruby 3.4

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -26,3 +26,7 @@ gem "webrick", "~> 1.8"
 
 # See https://github.com/ffi/ffi/issues/1103
 gem "ffi", "< 1.17.0"
+
+# Ruby 3.4 moved csv from a default gem to a bundled gem, so Jekyll cannot
+# require it unless it is in the bundle.
+gem "csv"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     commonmarker (0.23.10)
     concurrent-ruby (1.3.7)
     connection_pool (2.4.1)
+    csv (3.3.6)
     dnsruby (1.72.1)
       simpleidn (~> 0.2.1)
     drb (2.2.1)
@@ -268,6 +269,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  csv
   ffi (< 1.17.0)
   github-pages
   http_parser.rb (~> 0.6.0)


### PR DESCRIPTION
(this is all Claude)

Main is red after #1167. `bundle install` on Ruby 3.4 succeeded, but Jekyll failed to start:

```
bundler: failed to load command: jekyll
/opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require':
  cannot load such file -- csv (LoadError)
```

Ruby 3.4 moved `csv` from a default gem to a bundled gem, so it is not requirable under `bundle exec` unless it appears in the Gemfile. Jekyll requires it transitively. The lockfile already carries the other ex-stdlib gems (`base64`, `bigdecimal`, `logger`, `mutex_m`) because they arrive as transitive dependencies of `github-pages`; `csv` does not, so it has to be declared.

## Verification

Tested in a `ruby:3.4` container, since **pull request CI cannot exercise this path** — docgen-action gates its "Bundle dependencies" and "Build website using Jekyll" steps on `github.event_name == 'push'`, so they only ever run on main. (That gating is also why every past `docs/Gemfile.lock` bump went green on its PR and then broke main.)

- `bundle install` — exit 0
- `JEKYLL_ENV=production bundle exec jekyll build` — exit 0
- same two commands with nokogiri bumped to 1.19.4 (#1166) — both exit 0

The lockfile delta is one gem, `csv (3.3.6)`, plus its DEPENDENCIES entry. Nothing else re-resolved.