### PR TITLE
ci: build API docs on demand and republish them on every deploy

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,81 @@
+# Rebuilds the Lean API documentation, on demand only.
+#
+# doc-gen4 takes about two hours, so it deliberately does not run on ordinary
+# pushes to main. To refresh the documentation, push anything to the `api-docs`
+# branch:
+#
+#     git push --force origin main:api-docs
+#
+# This workflow builds the documentation and stores it as a tarball on the
+# `api-docs-latest` release. The next push to main republishes that tarball (see
+# "Restore published API documentation" in blueprint.yml), so the documentation
+# stays live at https://imperialcollegelondon.github.io/FLT/docs/ without every
+# merge paying the two hour cost. It goes stale until the next refresh, which is
+# the intended trade.
+#
+# Two constraints shaped this design:
+#
+#   * workflow_dispatch cannot be used. docgen-action gates its API
+#     documentation step on `github.event_name == 'push'`, so a manually
+#     dispatched run would silently build nothing at all.
+#   * This workflow cannot publish to Pages itself. The github-pages environment
+#     has a branch policy allowing main only, so deploying from here would be
+#     refused. Hence the hand-off through a release asset.
+name: API documentation
+
+on:
+  push:
+    branches:
+      - api-docs
+
+permissions:
+  contents: write # to upload the documentation tarball as a release asset
+
+jobs:
+  build_api_docs:
+    runs-on: ubuntu-latest
+    name: Build API documentation
+    steps:
+      - name: Cleanup to free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: false
+          haskell: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      # Only the API documentation: the blueprint and the Jekyll homepage are
+      # built by blueprint.yml on every push to main, and are not wanted here.
+      - name: Build API documentation
+        uses: leanprover-community/docgen-action@10db47458f91456d87804787d3dfcd914b9a19e3 # 2026-06-07
+        with:
+          api-docs: true
+          blueprint: false
+          build-page: false
+          deploy: false
+          homepage: docs
+
+      - name: Archive the documentation onto the api-docs-latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Built documentation size:"
+          du -sh docs/docs
+          tar -czf api-docs.tar.gz -C docs docs
+          ls -lh api-docs.tar.gz
+          # The release is a fixed handle that blueprint.yml reads from; create
+          # it once, then overwrite the asset on every refresh.
+          gh release create api-docs-latest \
+            --title "Latest API documentation" \
+            --notes "Tarball of the generated Lean API documentation, republished by blueprint.yml on every push to main. Rebuilt by pushing to the api-docs branch." \
+            || echo "Release already exists."
+          gh release upload api-docs-latest api-docs.tar.gz --clobber

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -102,6 +102,25 @@ jobs:
           relevant-labels: FLT
           include-drafts: true
 
+      # Every Pages deploy replaces the whole site, so without this step the API
+      # documentation would vanish from https://.../FLT/docs/ at the next push
+      # to main. Building it here instead would add ~2 hours to every merge, so
+      # it is built on demand by api-docs.yml and merely republished here.
+      - name: Restore published API documentation
+        if: github.event_name == 'push' # only the deploying runs need it
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if gh release download api-docs-latest --pattern api-docs.tar.gz --clobber; then
+            mkdir -p docs
+            tar -xzf api-docs.tar.gz -C docs
+            rm api-docs.tar.gz
+            echo "Restored API documentation into docs/docs."
+          else
+            echo "No api-docs-latest release yet; publishing the site without API documentation."
+          fi
+
       # This step builds the blueprint and the Jekyll homepage, and (on pushes
       # to main only) deploys them to GitHub Pages. It is the only thing in this
       # repository that deploys Pages at all.


### PR DESCRIPTION
(this is all Claude)

Goal: never pay doc-gen4's ~2 hours on a routine merge, but stop the API documentation disappearing from the site.

## The problem

A Pages deploy replaces the **whole** site, so a run with `api-docs: false` publishes a site with no `docs/docs` and the documentation vanishes. That is exactly how the blueprint was lost in #1011. So "build the docs once, then switch them off" does not work — they survive only until the next push to main, which with daily mathlib bumps is about a day.

## The split

| | |
| --- | --- |
| **Build** (~2h, on demand) | `api-docs.yml`, triggered by pushing anything to the `api-docs` branch. Builds only the API documentation and uploads it as a tarball to the `api-docs-latest` release. Does not deploy. |
| **Publish** (~1 min, every merge) | `blueprint.yml` downloads that tarball into `docs/docs` before the docgen step, so every deploy republishes it. `api-docs` stays `false`. |

Refreshing the documentation is then:

```
git push --force origin main:api-docs
```

The documentation goes stale between refreshes. That is the intended trade.

## Why it is shaped this way

- **No `workflow_dispatch`.** docgen-action gates its API documentation step on `github.event_name == 'push'`, so a dispatched run would silently build nothing.
- **The docs workflow cannot deploy.** The `github-pages` environment has a branch policy allowing `main` only, so a deploy from `api-docs` would be refused — hence the hand-off through a release asset.
- The restore step is skipped on pull requests, which never deploy.

## Evidence

A trial run on a throwaway branch (`api-docs: true`, `deploy: false`) **succeeded** in 1h51m from a cold cache, against ~15m for a normal run. So doc-gen4's "runs for hours and then fails at the very end" from #1066 is no longer accurate — it is merely slow. That trial also populated the mathlib docs cache, which is only 0.23 GiB.

First run of `api-docs.yml` will report the real tarball size via `du -sh` and `ls -lh`, which is the one number still unmeasured.