### PR TITLE
fix: install Lean in the API documentation workflow

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -52,6 +52,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # docgen-action does not install elan: it calls `~/.elan/bin/lake`
+      # directly and assumes the caller has already set Lean up (in
+      # blueprint.yml that is the "Build and lint project" step). Without this,
+      # build_docs.sh fails immediately with `lake: No such file or directory`.
+      # This also warms the Mathlib cache that the documentation build needs.
+      - name: Set Lean up and build the project
+        uses: leanprover/lean-action@v1
+        with:
+          build: true
+          test: false
+          lint: false
+
       # Only the API documentation: the blueprint and the Jekyll homepage are
       # built by blueprint.yml on every push to main, and are not wanted here.
       - name: Build API documentation


### PR DESCRIPTION
The first run of `api-docs.yml` (added in #1169) failed after a few seconds:

```
build_docs.sh: line 89: /home/runner/.elan/bin/lake: No such file or directory
##[error]Process completed with exit code 127
```

`docgen-action` does not install elan. It calls `~/.elan/bin/lake` directly and assumes the caller has already set Lean up — in `blueprint.yml` that is the `Build and lint project` step (`leanprover/lean-action@v1`), which the new standalone workflow did not have.

Adds `leanprover/lean-action` before the docgen step, with `test: false` and `lint: false` since `blueprint.yml` already runs those on every push to main. It also warms the Mathlib cache the documentation build depends on.

Main was never affected: the failure was confined to the `api-docs` branch, which by design cannot deploy.