### PR TITLE
refactor: replace private summation lemmas with Mathlib's API

### DIFF
--- a/FLT/KnownIn1980s/EllipticCurves/TateCurveConstruction.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/TateCurveConstruction.lean
@@ -251,7 +251,8 @@ differentiation; for exponents `k ≥ 2` and `w` in the upper half plane this is
 `EisensteinSeries.qExpansion_identity` in Mathlib. We state the two special cases we
 need, with the Lambert-type sums on the right-hand side in closed form
 (`∑_{d ≥ 1} d vᵈ = v/(1-v)²` and `∑_{d ≥ 1} d² vᵈ = v(1+v)/(1-v)³` for `‖v‖ < 1`,
-by differentiating the geometric series). -/
+Mathlib's `tsum_coe_mul_geometric_of_norm_lt_one` and
+`tsum_sq_mul_geometric_of_norm_lt_one`). -/
 
 /-- The Lambert-type sum `∑_{n ≥ 0} (n choose 2)rⁿ = r²/(1 - r)³` for `‖r‖ < 1`, by
 shifting the index in `∑' n, ((n + 2).choose 2) * rⁿ = 1/(1 - r)³`. -/
@@ -264,28 +265,6 @@ private lemma hasSum_choose_two_mul_geometric {r : ℂ} (hr : ‖r‖ < 1) :
     ring
   rw [heq] at h
   simpa [Finset.sum_range_succ] using (hasSum_nat_add_iff (f := fun n ↦ n.choose 2 * r ^ n) 2).mp h
-
-/-- The Lambert-type sum `∑_{n ≥ 0} n²rⁿ = r(1 + r)/(1 - r)³` for `‖r‖ < 1`, from the
-`n(n-1)/2`- and `n`-sums (`hasSum_choose_two_mul_geometric`,
-`hasSum_coe_mul_geometric_of_norm_lt_one`). -/
-private lemma tsum_sq_mul_geometric_of_norm_lt_one {r : ℂ} (hr : ‖r‖ < 1) :
-    ∑' n : ℕ, (n : ℂ) ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3 := by
-  have hr1 : (1 : ℂ) - r ≠ 0 := by
-    intro hr1
-    rw [sub_eq_zero] at hr1
-    simp [← hr1] at hr
-  -- combine via `n² = 2(n choose 2) + n`
-  have h3 := ((hasSum_choose_two_mul_geometric hr).mul_left 2).add
-    (hasSum_coe_mul_geometric_of_norm_lt_one hr)
-  have heq : (fun n : ℕ ↦ 2 * (((n.choose 2 : ℕ) : ℂ) * r ^ n) + (n : ℂ) * r ^ n) =
-      fun n : ℕ ↦ (n : ℂ) ^ 2 * r ^ n := by
-    funext n
-    rw [Nat.cast_choose_two]
-    ring
-  rw [heq] at h3
-  rw [h3.tsum_eq]
-  field_simp
-  ring
 
 /-- Row sum, exponent `k + 1 ≥ 2`, with the Lambert sum in series form: for `w` in the
 upper half plane, `∑_{m : ℤ} (w + m)⁻⁽ᵏ⁺¹⁾ = ((-2πi)ᵏ⁺¹/k!) ∑_{d ≥ 0} dᵏ e(w)ᵈ`.

--- a/FLT/KnownIn1980s/EllipticCurves/TateCurveConstruction.lean
+++ b/FLT/KnownIn1980s/EllipticCurves/TateCurveConstruction.lean
@@ -254,17 +254,17 @@ need, with the Lambert-type sums on the right-hand side in closed form
 Mathlib's `tsum_coe_mul_geometric_of_norm_lt_one` and
 `tsum_sq_mul_geometric_of_norm_lt_one`). -/
 
-/-- The Lambert-type sum `∑_{n ≥ 0} (n choose 2)rⁿ = r²/(1 - r)³` for `‖r‖ < 1`, by
-shifting the index in `∑' n, ((n + 2).choose 2) * rⁿ = 1/(1 - r)³`. -/
+/-- The Lambert-type sum `∑_{n ≥ 0} (n choose 2)rⁿ = r²/(1 - r)³` for `‖r‖ < 1`,
+halving the descending-factorial sum `∑' n, n(n-1)rⁿ = 2r²/(1 - r)³`
+(`hasSum_descFactorial_mul_geometric_of_norm_lt_one`), using `n(n-1) = 2(n choose 2)`. -/
 private lemma hasSum_choose_two_mul_geometric {r : ℂ} (hr : ‖r‖ < 1) :
     HasSum (fun n : ℕ ↦ ((n.choose 2 : ℕ) : ℂ) * r ^ n) (r ^ 2 * ((1 - r) ^ 3)⁻¹) := by
-  have h := (hasSum_choose_mul_geometric_of_norm_lt_one 2 hr).mul_left (r ^ 2)
-  have heq : (fun n ↦ r ^ 2 * ((n + 2).choose 2 * r ^ n)) =
-      fun n ↦ (n + 2).choose 2 * r ^ (n + 2) := by
-    funext n
+  have h := (hasSum_descFactorial_mul_geometric_of_norm_lt_one 2 hr).div_const 2
+  rw [show r ^ 2 * ((1 - r) ^ 3)⁻¹ = (2 : ℕ).factorial * r ^ 2 / (1 - r) ^ 3 / 2 by
+    push_cast [Nat.factorial_two]; ring]
+  exact h.congr_fun fun n ↦ by
+    push_cast [Nat.descFactorial_eq_factorial_mul_choose, Nat.factorial_two]
     ring
-  rw [heq] at h
-  simpa [Finset.sum_range_succ] using (hasSum_nat_add_iff (f := fun n ↦ n.choose 2 * r ^ n) 2).mp h
 
 /-- Row sum, exponent `k + 1 ≥ 2`, with the Lambert sum in series form: for `w` in the
 upper half plane, `∑_{m : ℤ} (w + m)⁻⁽ᵏ⁺¹⁾ = ((-2πi)ᵏ⁺¹/k!) ∑_{d ≥ 0} dᵏ e(w)ᵈ`.


### PR DESCRIPTION
This PR removes the private lemma `tsum_sq_mul_geometric_of_norm_lt_one` from `KnownIn1980s/EllipticCurves/TateCurveConstruction.lean`, since it has been merged into Mathlib ([#41498](https://github.com/leanprover-community/mathlib4/pull/41498)).
It also refactors the proof of `hasSum_choose_two_mul_geometric` using lemmas from Mathlib [#41498](https://github.com/leanprover-community/mathlib4/pull/41498).

Co-authored-by: Pepa Montero Jimena pepamonterojimena@gmail.com